### PR TITLE
Added net.sf.saxon:saxon-he

### DIFF
--- a/hapi-fhir-structures-hl7org-dstu2/pom.xml
+++ b/hapi-fhir-structures-hl7org-dstu2/pom.xml
@@ -33,6 +33,11 @@
 		<artifactId>xpp3_min</artifactId>
 		<version>1.1.4c</version>
 	</dependency>
+	<dependency>
+		<groupId>net.sf.saxon</groupId>
+		<artifactId>Saxon-HE</artifactId>
+		<version>9.6.0-4</version>
+	</dependency>
 
 		<!-- Testing -->
 		<dependency>


### PR DESCRIPTION
Not sure if you are interested in this fix, but hapi-fhir-structures-hl7org-dstu2 was not compiling because saxon dependency was missing.