### PR TITLE
FHIR Tester application use configured client factory

### DIFF
--- a/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/Controller.java
+++ b/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/Controller.java
@@ -1112,7 +1112,8 @@ public class Controller {
 	}
 
 	private Conformance loadAndAddConfDstu1(HttpServletRequest theServletRequest, final HomeRequest theRequest, final ModelMap theModel) {
-		IGenericClient client = getContext(theRequest).newRestfulGenericClient(theRequest.getServerBase(theServletRequest, myConfig));
+		CaptureInterceptor interceptor = new CaptureInterceptor();
+		GenericClient client = theRequest.newClient(theServletRequest, getContext(theRequest), myConfig, interceptor);
 
 		Conformance conformance;
 		try {
@@ -1171,7 +1172,8 @@ public class Controller {
 	}
 
 	private IResource loadAndAddConfDstu2(HttpServletRequest theServletRequest, final HomeRequest theRequest, final ModelMap theModel) {
-		IGenericClient client = getContext(theRequest).newRestfulGenericClient(theRequest.getServerBase(theServletRequest, myConfig));
+		CaptureInterceptor interceptor = new CaptureInterceptor();
+		GenericClient client = theRequest.newClient(theServletRequest, getContext(theRequest), myConfig, interceptor);
 
 		ca.uhn.fhir.model.dstu2.resource.Conformance conformance;
 		try {

--- a/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/model/HomeRequest.java
+++ b/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/model/HomeRequest.java
@@ -19,6 +19,7 @@ import ca.uhn.fhir.rest.server.EncodingEnum;
 import ca.uhn.fhir.rest.server.IncomingRequestAddressStrategy;
 import ca.uhn.fhir.to.Controller;
 import ca.uhn.fhir.to.TesterConfig;
+import ca.uhn.fhir.util.ITestingUiClientFactory;
 
 public class HomeRequest {
 
@@ -123,8 +124,18 @@ public class HomeRequest {
 
 	public GenericClient newClient(HttpServletRequest theRequest, FhirContext theContext, TesterConfig theConfig, Controller.CaptureInterceptor theInterceptor) {
 		theContext.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
-		
-		GenericClient retVal = (GenericClient) theContext.newRestfulGenericClient(getServerBase(theRequest, theConfig));
+
+		GenericClient retVal;
+		ITestingUiClientFactory clientFactory = theConfig.getClientFactory();
+		if (clientFactory != null) {
+			retVal = (GenericClient) clientFactory.newClient(
+					theContext,
+					theRequest,
+					getServerBase(theRequest, theConfig));
+		} else {
+			retVal = (GenericClient) theContext.newRestfulGenericClient(getServerBase(theRequest, theConfig));
+		}
+
 		retVal.setKeepResponses(true);
 
 		if ("true".equals(getPretty())) {

--- a/src/site/xdoc/doc_server_tester.xml.vm
+++ b/src/site/xdoc/doc_server_tester.xml.vm
@@ -70,8 +70,8 @@
 				</overlays>
 			</configuration>
 		</plugin>
-	</build>
-</plugins>]]></source>
+	</plugins>
+</build>]]></source>
 				</p>
 
 				<p>


### PR DESCRIPTION
I want the FHIR Tester application to connect to a FHIR server that requires HTTP Basic authentication. I followed the instructions at http://jamesagnew.github.io/hapi-fhir/doc_server_tester.html but setting the `clientFactory` property to my custom `ITestingUiClientFactory` implementation had no effect. The FHIR Tester application displayed the error message:

    Failed to load conformance statement, error was: ca.uhn.fhir.rest.server.exceptions.AuthenticationException: HTTP 401 Unauthorized

This pull request changes the FHIR Tester application to actually use the configured client factory as documented.
