### PR TITLE
Update Javadocs to reference Github docs

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirContext.java
@@ -340,7 +340,7 @@ public class FhirContext {
 	 * cases to contain methods for each of the RESTful operations you wish to implement (e.g. "read ImagingStudy",
 	 * "search Patient by identifier", etc.). This interface must extend {@link IRestfulClient} (or commonly its
 	 * sub-interface {@link IBasicClient}). See the <a
-	 * href="http://hl7api.sourceforge.net/hapi-fhir/doc_rest_client.html">RESTful Client</a> documentation for more
+	 * href="http://jamesagnew.github.io/hapi-fhir/doc_rest_client.html">RESTful Client</a> documentation for more
 	 * information on how to define this interface.
 	 * 
 	 * <p>

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/AddTags.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/AddTags.java
@@ -46,7 +46,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * Note that for a
  * server implementation, the {@link #type()} annotation is optional if the
  * method is defined in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#resource_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#resource_providers"
  * >resource provider</a>, since the type is implied.</li>
  * <li>
  * To add tag(s) on the server <b>to the given version of the
@@ -61,7 +61,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * operation.
  * Note that for a server implementation, the
  * {@link #type()} annotation is optional if the method is defined in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#resource_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#resource_providers"
  * >resource provider</a>, since the type is implied.</li>
  * </ul>
  */

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/DeleteTags.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/DeleteTags.java
@@ -44,7 +44,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * Note that for a
  * server implementation, the {@link #type()} annotation is optional if the
  * method is defined in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#resource_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#resource_providers"
  * >resource provider</a>, since the type is implied.</li>
  * <li>
  * To delete tag(s) on the server <b>to the given version of the
@@ -57,7 +57,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * to be deleted.
  * Note that for a server implementation, the
  * {@link #type()} annotation is optional if the method is defined in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#resource_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#resource_providers"
  * >resource provider</a>, since the type is implied.</li>
  * </ul>
  */

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/GetTags.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/annotation/GetTags.java
@@ -38,7 +38,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * contain a {@link #type()} attribute, and the method should not have an ID or
  * Version ID parameter. On server implementations, the method must be defined
  * in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#plain_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#plain_providers"
  * >plain provider</a>.</li>
  * <li>
  * To return a list of all tags on the server <b>for the given resource
@@ -46,7 +46,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * specifying the resource type, and the method should not have an ID or Version
  * ID parameter. Note that for a server implementation, the {@link #type()}
  * annotation is optional if the method is defined in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#resource_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#resource_providers"
  * >resource provider</a>, since the type is implied.</li>
  * <li>
  * To return a list of all tags on the server <b>for the given resource
@@ -55,7 +55,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * {@link IdDt} annotated with the {@link IdParam} annotation. Note that for a
  * server implementation, the {@link #type()} annotation is optional if the
  * method is defined in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#resource_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#resource_providers"
  * >resource provider</a>, since the type is implied.</li>
  * <li>
  * To return a list of all tags on the server <b>for the given version of the
@@ -65,7 +65,7 @@ import ca.uhn.fhir.model.primitive.IdDt;
  * annotation, <b>and</b> a parameter of type {@link IdDt} annotated with the
  * {@link IdParam} annotation. Note that for a server implementation, the
  * {@link #type()} annotation is optional if the method is defined in a <a href=
- * "http://hl7api.sourceforge.net/hapi-fhir/doc_rest_server.html#resource_providers"
+ * "http://jamesagnew.github.io/hapi-fhir/doc_rest_server.html#resource_providers"
  * >resource provider</a>, since the type is implied.</li>
  * </ul>
  */

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/interceptor/BasicAuthInterceptor.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/interceptor/BasicAuthInterceptor.java
@@ -36,7 +36,7 @@ import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
  * HTTP interceptor to be used for adding HTTP basic auth username/password tokens
  * to requests
  * <p>
- * See the <a href="http://hl7api.sourceforge.net/hapi-fhir/doc_rest_client.html#HTTP_Basic_Authorization">HAPI Documentation</a>
+ * See the <a href="http://jamesagnew.github.io/hapi-fhir/doc_rest_client_interceptor.html#Security_HTTP_Basic_Authorization">HAPI Documentation</a>
  * for information on how to use this class.
  * </p>
  */
@@ -44,7 +44,7 @@ public class BasicAuthInterceptor implements IClientInterceptor {
 
 	private String myUsername;
 	private String myPassword;
-	
+
     public BasicAuthInterceptor(String theUsername, String thePassword) {
 		super();
 		myUsername = theUsername;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/interceptor/BearerTokenAuthInterceptor.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/interceptor/BearerTokenAuthInterceptor.java
@@ -37,7 +37,7 @@ import net.sourceforge.cobertura.CoverageIgnore;
  * where the token portion (at the end of the header) is supplied by the invoking code.
  * </p>
  * <p>
- * See the <a href="http://hl7api.sourceforge.net/hapi-fhir/doc_rest_client.html#HTTP_Basic_Authorization">HAPI Documentation</a> for information on how to use this class.
+ * See the <a href="http://jamesagnew.github.io/hapi-fhir/doc_rest_client_interceptor.html#Security_HTTP_Bearer_Token_Authorization">HAPI Documentation</a> for information on how to use this class.
  * </p>
  */
 public class BearerTokenAuthInterceptor implements IClientInterceptor {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/interceptor/UserInfoInterceptor.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/interceptor/UserInfoInterceptor.java
@@ -29,10 +29,6 @@ import ca.uhn.fhir.rest.client.IClientInterceptor;
 
 /**
  * HTTP interceptor to be used for adding HTTP headers containing user identifying info for auditing purposes to the request
- * <p>
- * See the <a href="http://hl7api.sourceforge.net/hapi-fhir/doc_rest_client.html#User_Info">HAPI Documentation</a>
- * for information on how to use this class.
- * </p>
  */
 public class UserInfoInterceptor implements IClientInterceptor {
 	

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,10 @@
 			<id>pukkaone</id>
 			<name>Chin Huang</name>
 		</developer>
+		<developer>
+			<id>SingingTree</id>
+			<name>Bryce Van Dyk</name>
+		</developer>	
 	</developers>
 
 	<licenses>


### PR DESCRIPTION
Several Javadoc comments still reference the old Sourceforge based
documentation. These have been updated to point to the Github based
documentation where relevant, or removed in one case where the Github docs
do not appear to have such a section.