### PR TITLE
Adjust the checkstyle location to play nice on Win

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -190,7 +190,7 @@
 						</reportSets>
 						<configuration>
 							<linkXRef>false</linkXRef>
-							<configLocation>file://${project.basedir}/../src/checkstyle/checkstyle.xml</configLocation>
+							<configLocation>${project.basedir}/../src/checkstyle/checkstyle.xml</configLocation>
 							<!--<sourceDirectories> <sourceDirectory> ${project.basedir}/../hapi-fhir-base/src/main/java 
 								</sourceDirectory> </sourceDirectories> -->
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -787,7 +787,7 @@
 						</dependency>
 					</dependencies>
 					<configuration>
-						<configLocation>file://${project.basedir}/src/checkstyle/checkstyle.xml</configLocation>
+						<configLocation>${project.basedir}/src/checkstyle/checkstyle.xml</configLocation>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
Removed the file:// prefix on the checkstyle config location. This appeared to be breaking the site build on Windows. I've also tested this on Linux (OpenSuse 13.2) and believe that change has not broken anything. However it would be good if someone else could make sure the site still builds with this change on Linux.

If there are reasons not to remove the file:// prefix, or issues with doing so, please let me know, and I'll attempt to remedy the build issues on Windows via other means.