### PR TITLE
Change android build to work without having to "hack" the jar

### DIFF
--- a/hapi-fhir-android/.classpath
+++ b/hapi-fhir-android/.classpath
@@ -23,6 +23,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="lib" path="target/hapi-fhir-android-1.2-SNAPSHOT.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/hapi-fhir-android/pom.xml
+++ b/hapi-fhir-android/pom.xml
@@ -207,7 +207,6 @@
 								<filter>
 									<artifact>ca.uhn.hapi.fhir:hapi-fhir-base</artifact>
 									<excludes>
-										<exclude>ca/uhn/fhir/model/dstu/valueset/**</exclude>
 										<exclude>**/*.java</exclude>
 									</excludes>
 								</filter>

--- a/hapi-fhir-dist/src/assembly/hapi-fhir-android-distribution.xml
+++ b/hapi-fhir-dist/src/assembly/hapi-fhir-android-distribution.xml
@@ -15,7 +15,7 @@
 			<directory>${project.basedir}/../hapi-fhir-android/target/</directory>
 			<outputDirectory>/</outputDirectory>
 			<includes>
-				<include>hapi-fhir-android-${project.version}.jar</include>
+				<include>hapi-fhir-android-${project.version}*.jar</include>
 			</includes>
 		</fileSet>
 	</fileSets>


### PR DESCRIPTION
Made changes to include files in the android jar, also added the standalone android dstu, dstu2 and shaded jar to distribution, instead having an almost empty distribution in 1.2 release