### PR TITLE
Added the ability to wire the JPA conformance providers

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaConformanceProviderDstu1.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaConformanceProviderDstu1.java
@@ -56,6 +56,11 @@ public class JpaConformanceProviderDstu1 extends ServerConformanceProvider {
 		super.setCache(false);
 	}
 
+	public JpaConformanceProviderDstu1(){
+		super();
+		super.setCache(false);
+	}
+
 	@Override
 	public Conformance getServerConformance(HttpServletRequest theRequest) {
 		Conformance retVal = myCachedValue;
@@ -93,6 +98,16 @@ public class JpaConformanceProviderDstu1 extends ServerConformanceProvider {
 		retVal.getImplementation().setDescription(myImplementationDescription);
 		myCachedValue = retVal;
 		return retVal;
+	}
+
+	@Override
+	public void setRestfulServer(RestfulServer theRestfulServer) {
+		this.myRestfulServer = theRestfulServer;
+		super.setRestfulServer(theRestfulServer);
+	}
+
+	public void setMySystemDao(IFhirSystemDao<List<IResource>> mySystemDao) {
+		this.mySystemDao = mySystemDao;
 	}
 
 	public void setImplementationDescription(String theImplDesc) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaConformanceProviderDstu2.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/JpaConformanceProviderDstu2.java
@@ -60,6 +60,11 @@ public class JpaConformanceProviderDstu2 extends ServerConformanceProvider {
 		super.setCache(false);
 	}
 
+	public JpaConformanceProviderDstu2(){
+		super();
+		super.setCache(false);
+	}
+
 	@Override
 	public Conformance getServerConformance(HttpServletRequest theRequest) {
 		Conformance retVal = myCachedValue;
@@ -105,8 +110,21 @@ public class JpaConformanceProviderDstu2 extends ServerConformanceProvider {
 		return retVal;
 	}
 
+	@Override
+	public void setRestfulServer(RestfulServer theRestfulServer) {
+		this.myRestfulServer = theRestfulServer;
+		super.setRestfulServer(theRestfulServer);
+	}
+
+	public void setMyDaoConfig(DaoConfig myDaoConfig) {
+		this.myDaoConfig = myDaoConfig;
+	}
+
+	public void setMySystemDao(IFhirSystemDao<Bundle> mySystemDao) {
+		this.mySystemDao = mySystemDao;
+	}
+
 	public void setImplementationDescription(String theImplDesc) {
 		myImplementationDescription = theImplDesc;
 	}
-
 }


### PR DESCRIPTION
We came across a scenario where we needed to Spring autowire the ServerConformanceProvider while configuring the RestfulServer class.  These changes add that ability to the JpaConformanceProviderDstu1 & JpaConformanceProviderDstu2 classes, as accommodated by [RestfulServer.java](https://github.com/jamesagnew/hapi-fhir/blob/d3685e72bac36e2bcaf422d7d9203bbe0d1c7759/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java#L1313).