### PR TITLE
Add serializability for BoundCodeableConceptDt

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/IBoundCodeableConcept.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/IBoundCodeableConcept.java
@@ -20,6 +20,8 @@ package ca.uhn.fhir.model.api;
  * #L%
  */
 
-public interface IBoundCodeableConcept {
+import java.io.Serializable;
+
+public interface IBoundCodeableConcept extends Serializable {
 
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/IValueSetEnumBinder.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/api/IValueSetEnumBinder.java
@@ -21,8 +21,9 @@ package ca.uhn.fhir.model.api;
  */
 
 
+import java.io.Serializable;
 
-public interface IValueSetEnumBinder<T extends Enum<?>> {
+public interface IValueSetEnumBinder<T extends Enum<?>> extends Serializable {
 
 	T fromCodeString(String theCodeString);
 	

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/model/dstu2/ModelSerializationTest.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/model/dstu2/ModelSerializationTest.java
@@ -17,6 +17,7 @@ import ca.uhn.fhir.model.dstu2.composite.AddressDt;
 import ca.uhn.fhir.model.dstu2.composite.HumanNameDt;
 import ca.uhn.fhir.model.dstu2.resource.Bundle;
 import ca.uhn.fhir.model.dstu2.resource.Patient;
+import ca.uhn.fhir.model.dstu2.valueset.MaritalStatusCodesEnum;
 import ca.uhn.fhir.parser.IParser;
 
 public class ModelSerializationTest {
@@ -53,6 +54,21 @@ public class ModelSerializationTest {
 		IParser p = ourCtx.newXmlParser().setPrettyPrint(true);
 		assertEquals(p.encodeResourceToString(theObject), p.encodeResourceToString(obj));
 
+	}
+
+	/**
+	 * Verify that MaritalStatusCodeEnum (and, by extension, BoundCodeableConcepts in general) are serializable.
+	 * Author: Nick Peterson (nrpeterson@gmail.com)
+	 */
+	@Test
+	public void testBoundCodeableConceptSerialization() {
+		MaritalStatusCodesEnum maritalStatus = MaritalStatusCodesEnum.M;
+		byte[] bytes = SerializationUtils.serialize(maritalStatus);
+		assertTrue(bytes.length > 0);
+
+		MaritalStatusCodesEnum deserialized = SerializationUtils.deserialize(bytes);
+		assertEquals(maritalStatus.getCode(), deserialized.getCode());
+		assertEquals(maritalStatus.getSystem(), deserialized.getSystem());
 	}
 
 }


### PR DESCRIPTION
Makes IBoundCodeableConcept and IValueSetEnumBinder extend java.io.Serializable, so that value sets (such as MaritalStatusCodesEnum) can be serialized.  Adds a test to ensure that DSTU2 MaritalStatusCodesEnum serializes.

Closes #258 