### PR TITLE
Configure maven-enforcer-plugin to require JDK 1.8 or higher.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -951,6 +951,28 @@
 		</pluginManagement>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-java</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireJavaVersion>
+									<version>[1.8,)</version>
+									<message>
+										The hapi-fhir Maven build requires JDK version 1.8 or higher.
+									</message>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>license-maven-plugin</artifactId>
 				<inherited>false</inherited>


### PR DESCRIPTION
Add maven-enforcer-plugin configuration to require use of JDK 1.8 or higher.  Closes #263.