### PR TITLE
Exposing parameters for HTTP client request pool max connections in RestfulClientFactory

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/IRestfulClientFactory.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/IRestfulClientFactory.java
@@ -48,6 +48,16 @@ public interface IRestfulClientFactory {
 	public static final int DEFAULT_SOCKET_TIMEOUT = 10000;
 	
 	/**
+	 * Default value for {@link #getPoolMaxTotal() ()}
+	 */
+	public static final int DEFAULT_POOL_MAX = 20;
+	
+	/**
+	 * Default value for {@link #getPoolMaxPerRoute() }
+	 */
+	public static final int DEFAULT_POOL_MAX_PER_ROUTE = DEFAULT_POOL_MAX;
+	
+	/**
 	 * Gets the connection request timeout, in milliseconds. This is the amount of time that the HTTPClient connection
 	 * pool may wait for an available connection before failing. This setting typically does not need to be adjusted.
 	 * <p>
@@ -99,6 +109,22 @@ public interface IRestfulClientFactory {
 	 */
 	int getSocketTimeout();
 
+	/**
+	 * Gets the maximum number of connections allowed in the pool.
+	 * <p>
+	 * The default value for this setting is defined by {@link #DEFAULT_POOL_MAX}
+	 * </p>
+	 */
+	int getPoolMaxTotal();
+
+	/**
+	 * Gets the maximum number of connections per route allowed in the pool.
+	 * <p>
+	 * The default value for this setting is defined by {@link #DEFAULT_POOL_MAX_PER_ROUTE}
+	 * </p>
+	 */
+	int getPoolMaxPerRoute();
+	
 	/**
 	 * Instantiates a new client instance
 	 * 
@@ -193,4 +219,19 @@ public interface IRestfulClientFactory {
 	 */
 	void setSocketTimeout(int theSocketTimeout);
 
+	/**
+	 * Sets the maximum number of connections allowed in the pool.
+	 * <p>
+	 * The default value for this setting is defined by {@link #DEFAULT_POOL_MAX}
+	 * </p>
+	 */
+	void setPoolMaxTotal(int thePoolMaxTotal);
+
+	/**
+	 * Sets the maximum number of connections per route allowed in the pool.
+	 * <p>
+	 * The default value for this setting is defined by {@link #DEFAULT_POOL_MAX_PER_ROUTE}
+	 * </p>
+	 */
+	void setPoolMaxPerRoute(int thePoolMaxPerRoute);
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/RestfulClientFactory.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/RestfulClientFactory.java
@@ -68,7 +68,9 @@ public class RestfulClientFactory implements IRestfulClientFactory {
 	private ServerValidationModeEnum myServerValidationMode = DEFAULT_SERVER_VALIDATION_MODE;
 	private int mySocketTimeout = DEFAULT_SOCKET_TIMEOUT;
 	private Set<String> myValidatedServerBaseUrls = Collections.synchronizedSet(new HashSet<String>());
-
+	private int myPoolMaxTotal = DEFAULT_POOL_MAX;
+	private int myPoolMaxPerRoute = DEFAULT_POOL_MAX_PER_ROUTE;
+	
 	/**
 	 * Constructor
 	 */
@@ -100,7 +102,9 @@ public class RestfulClientFactory implements IRestfulClientFactory {
 		if (myHttpClient == null) {
 
 			PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager(5000, TimeUnit.MILLISECONDS);
-
+			connectionManager.setMaxTotal(myPoolMaxTotal);
+			connectionManager.setDefaultMaxPerRoute(myPoolMaxPerRoute);
+			
 			//@formatter:off
 			RequestConfig defaultRequestConfig = RequestConfig.custom()
 				    .setSocketTimeout(mySocketTimeout)
@@ -147,6 +151,16 @@ public class RestfulClientFactory implements IRestfulClientFactory {
 	@Override
 	public int getSocketTimeout() {
 		return mySocketTimeout;
+	}
+
+	@Override
+	public int getPoolMaxTotal() {
+		return myPoolMaxTotal;
+	}
+
+	@Override
+	public int getPoolMaxPerRoute() {
+		return myPoolMaxPerRoute;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -273,6 +287,18 @@ public class RestfulClientFactory implements IRestfulClientFactory {
 	@Override
 	public synchronized void setSocketTimeout(int theSocketTimeout) {
 		mySocketTimeout = theSocketTimeout;
+		myHttpClient = null;
+	}
+
+	@Override
+	public synchronized void setPoolMaxTotal(int thePoolMaxTotal) {
+		myPoolMaxTotal = thePoolMaxTotal;
+		myHttpClient = null;
+	}
+
+	@Override
+	public synchronized void setPoolMaxPerRoute(int thePoolMaxPerRoute) {
+		myPoolMaxPerRoute = thePoolMaxPerRoute;
 		myHttpClient = null;
 	}
 


### PR DESCRIPTION
The current RestfulClientFactory uses the default HTTP client PoolingHttpClientConnectionManager settings for max number of connections.
The defaults for these are 20 max total connections and 2 max per route.

These changes expose parameters on RestfulClientFactory to allow overriding these defaults.

The default for max connections per route is also changed here from 2 to 20 (using the same value as max total connections).

Other possible approaches:
* Expose HttpClientBuilder in RestfulClientFactory, allow subclasses to override settings
  * Expose a setter for IRestfulClientFactory in FhirContext to allow subclassing