### PR TITLE
revise maven-dependency-plugin configuration to reference version 1.5-SNAPSHOT of hapi-fhir-cli-jpaserver

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -208,7 +208,7 @@
 								<artifactItem>
 									<groupId>ca.uhn.hapi.fhir</groupId>
 									<artifactId>hapi-fhir-cli-jpaserver</artifactId>
-									<version>1.4-SNAPSHOT</version>
+									<version>1.5-SNAPSHOT</version>
 									<type>war</type>
 									<overWrite>true</overWrite>
 									<outputDirectory>target/classes</outputDirectory>


### PR DESCRIPTION
In hapi-fhir-cli-app pom.xml's maven-dependency-plugin configuration, change hapi-fhir-cli-jpaserver version to 1.5-SNAPSHOT.  Closes #300