### PR TITLE
Updated ServerConformanceProvider and test

### DIFF
--- a/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/hapi/rest/server/ServerConformanceProvider.java
+++ b/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/hapi/rest/server/ServerConformanceProvider.java
@@ -57,6 +57,7 @@ import org.hl7.fhir.dstu3.model.Conformance.UnknownContentCode;
 import org.hl7.fhir.dstu3.model.Enumerations.ConformanceResourceStatus;
 import org.hl7.fhir.dstu3.model.OperationDefinition.OperationDefinitionParameterComponent;
 import org.hl7.fhir.dstu3.model.OperationDefinition.OperationParameterUse;
+import org.hl7.fhir.dstu3.model.Reference;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
@@ -281,7 +282,7 @@ public class ServerConformanceProvider implements IServerConformanceProvider<Con
 						String opName = myOperationBindingToName.get(methodBinding);
 						if (operationNames.add(opName)) {
 							// Only add each operation (by name) once
-							rest.addOperation().setName(methodBinding.getName()).getDefinition().setReference("OperationDefinition/" + opName);
+							rest.addOperation().setName(methodBinding.getName()).setDefinition(new Reference(readOperationDefinition(new IdType(opName))));
 						}
 					}
 
@@ -315,7 +316,7 @@ public class ServerConformanceProvider implements IServerConformanceProvider<Con
 						OperationMethodBinding methodBinding = (OperationMethodBinding) nextMethodBinding;
 						String opName = myOperationBindingToName.get(methodBinding);
 						if (operationNames.add(opName)) {
-							rest.addOperation().setName(methodBinding.getName()).getDefinition().setReference("OperationDefinition/" + opName);
+							rest.addOperation().setName(methodBinding.getName()).setDefinition(new Reference(readOperationDefinition(new IdType(opName))));
 						}
 					}
 				}

--- a/hapi-fhir-structures-dstu3/src/test/java/org/hl7/fhir/dstu3/hapi/rest/server/ServerConformanceProviderDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/org/hl7/fhir/dstu3/hapi/rest/server/ServerConformanceProviderDstu3Test.java
@@ -132,7 +132,10 @@ public class ServerConformanceProviderDstu3Test {
 
 		assertEquals(1, conformance.getRest().get(0).getOperation().size());
 		assertEquals("$everything", conformance.getRest().get(0).getOperation().get(0).getName());
-		assertEquals("OperationDefinition/everything", conformance.getRest().get(0).getOperation().get(0).getDefinition().getReferenceElement().getValue());
+		assertEquals("$everything", ((OperationDefinition)conformance.getRest().get(0).getOperation().get(0).getDefinition().getResource()).getCode());
+
+		OperationDefinition opDef = sc.readOperationDefinition(new IdType("OperationDefinition/everything"));
+		assertEquals("$everything", opDef.getCode());
 	}
 
 	@Test
@@ -267,7 +270,7 @@ public class ServerConformanceProviderDstu3Test {
 		rs.init(createServletConfig());
 
 		Conformance sconf = sc.getServerConformance(createHttpServletRequest());
-		assertEquals("OperationDefinition/plain", sconf.getRest().get(0).getOperation().get(0).getDefinition().getReferenceElement().getValue());
+		assertEquals("$plain", ((OperationDefinition)sconf.getRest().get(0).getOperation().get(0).getDefinition().getResource()).getCode());
 
 		OperationDefinition opDef = sc.readOperationDefinition(new IdType("OperationDefinition/plain"));
 


### PR DESCRIPTION
ServerConformanceProvider only placed a string reference to
OperationDefinitions, which were nowhere to be found in the Conformance
statement.  With this change, SCP assigns a reference containing the
OperationDefinition for each operation.  The OperationDefinitions are, per the
spec, located in the 'contained' portion of the Conformance statement.