### PR TITLE
Fixed issue with adding profile information to an unmodifiable list

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
@@ -25,6 +25,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1870,13 +1871,17 @@ class ParserState<T> {
 			} else if (theLocalPart.equals("profile")) {
 				@SuppressWarnings("unchecked")
 				List<IdDt> profiles = (List<IdDt>) myMap.get(ResourceMetadataKeyEnum.PROFILES);
-				if (profiles == null) {
-					profiles = new ArrayList<IdDt>();
-					myMap.put(ResourceMetadataKeyEnum.PROFILES, profiles);
+				List<IdDt> newProfiles;
+				if (profiles != null) {
+					newProfiles = new ArrayList<IdDt>(profiles.size() + 1);
+					newProfiles.addAll(profiles);
+				} else {
+					newProfiles = new ArrayList<IdDt>(1);
 				}
 				IdDt profile = new IdDt();
 				push(new PrimitiveState(getPreResourceState(), profile));
-				profiles.add(profile);
+				newProfiles.add(profile);
+				myMap.put(ResourceMetadataKeyEnum.PROFILES, Collections.unmodifiableList(newProfiles));
 			} else if (theLocalPart.equals("tag")) {
 				TagList tagList = (TagList) myMap.get(ResourceMetadataKeyEnum.TAG_LIST);
 				if (tagList == null) {


### PR DESCRIPTION
This pull request fixes the issue outlined here: https://github.com/jamesagnew/hapi-fhir/issues/447
In short, an UnsupportedOperationException occured when parsing profile information. This was due to an attempt to add to an unmodifiable list. 

The change proposed here makes a new list instead, populates it with elements of the previous list and adds the new profile. An unmodifiable view on this new list is put back into the map to be consistent with the documentation of the ResourceMetadataKeyEnum.PROFILES constant. 

This approach has a squared time complexity to the number of profile declaration in the received resource. However, assuming the number of profile declarations per resource is low, this should not be a problem. 

If deemed too inefficient, either the profiles list should be modifiable or another approach should be used. Perhaps a builder pattern would be adequate. 