### PR TITLE
fix resources links being correctly indexed when linking eachother as part of a single transaction bundle

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -1415,6 +1415,8 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> implements IDao {
 			for (ResourceLink next : links) {
 				myEntityManager.persist(next);
 			}
+			// make sure links are indexed
+			theEntity.setResourceLinks(links);
 
 		} // if thePerformIndexing
 


### PR DESCRIPTION
When creating a Patient with Id and an Observation with a reference to that patient in a single Bundle (transaction). The logic seems to persist/merge the entities multiple times which causes their Links to be reset (due to LAZY loading of the relation). This does not actually trigger a missing link, but it does fail to actually index that link using lucene.
