### PR TITLE
Support JSON-like resource structures

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/IJsonLikeParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/IJsonLikeParser.java
@@ -1,0 +1,101 @@
+package ca.uhn.fhir.parser;
+
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+
+import org.hl7.fhir.instance.model.api.IAnyResource;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+import ca.uhn.fhir.model.api.Bundle;
+import ca.uhn.fhir.model.api.IResource;
+import ca.uhn.fhir.model.api.TagList;
+import ca.uhn.fhir.parser.json.JsonLikeStructure;
+import ca.uhn.fhir.parser.json.JsonLikeWriter;
+
+/**
+ * An extension to the parser interface that is implemented by parsers that understand a generalized form of
+ * JSON data. This generalized form uses Map-like, List-like, and scalar elements to construct resources.
+ * <p>
+ * Thread safety: <b>Parsers are not guaranteed to be thread safe</b>. Create a new parser instance for every thread or
+ * every message being parsed/encoded.
+ * </p>
+ */
+public interface IJsonLikeParser extends IParser {
+
+	void encodeBundleToJsonLikeWriter(Bundle theBundle, JsonLikeWriter theJsonLikeWriter) throws IOException, DataFormatException;
+
+	void encodeResourceToJsonLikeWriter(IBaseResource theResource, JsonLikeWriter theJsonLikeWriter) throws IOException, DataFormatException;
+
+	void encodeTagListToJsonLikeWriter(TagList theTagList, JsonLikeWriter theJsonLikeWriter) throws IOException;
+
+
+	/**
+	 * Parse a DSTU1 style Atom Bundle. Note that as of DSTU2, Bundle is a resource so you should use
+	 * {@link #parseResource(Class, JsonLikeStructure)} with the Bundle class found in the
+	 * <code>ca.uhn.hapi.fhir.model.[version].resource</code> package instead.
+	 */
+	<T extends IBaseResource> Bundle parseBundle(Class<T> theResourceType, JsonLikeStructure theJsonLikeStructure);
+
+	/**
+	 * Parse a DSTU1 style Atom Bundle. Note that as of DSTU2, Bundle is a resource so you should use
+	 * {@link #parseResource(Class, JsonLikeStructure)} with the Bundle class found in the
+	 * <code>ca.uhn.hapi.fhir.model.[version].resource</code> package instead.
+	 */
+	Bundle parseBundle(JsonLikeStructure theJsonLikeStructure) throws DataFormatException;
+
+	/**
+	 * Parses a resource from a JSON-like data structure
+	 * 
+	 * @param theResourceType
+	 *           The resource type to use. This can be used to explicitly specify a class which extends a built-in type
+	 *           (e.g. a custom type extending the default Patient class)
+	 * @param theJsonLikeStructure
+	 *           The JSON-like structure to parse
+	 * @return A parsed resource
+	 * @throws DataFormatException
+	 *            If the resource can not be parsed because the data is not recognized or invalid for any reason
+	 */
+	<T extends IBaseResource> T parseResource(Class<T> theResourceType, JsonLikeStructure theJsonLikeStructure) throws DataFormatException;
+
+
+	/**
+	 * Parses a resource from a JSON-like data structure
+	 * 
+	 * @param theJsonLikeStructure
+	 *           The JSON-like structure to parse
+	 * @return A parsed resource. Note that the returned object will be an instance of {@link IResource} or
+	 *         {@link IAnyResource} depending on the specific FhirContext which created this parser.
+	 * @throws DataFormatException
+	 *            If the resource can not be parsed because the data is not recognized or invalid for any reason
+	 */
+	IBaseResource parseResource(JsonLikeStructure theJsonLikeStructure) throws DataFormatException;
+
+	/**
+	 * Parses a tag list from a JSON-like data structure
+	 * 
+	 * @param theJsonLikeStructure
+	 *           The JSON-like structure to parse
+	 * @return A parsed tag list
+	 */
+	TagList parseTagList(JsonLikeStructure theJsonLikeStructure);
+
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -33,11 +33,12 @@ import java.util.*;
 import java.util.Map.Entry;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.text.WordUtils;
 import org.hl7.fhir.instance.model.api.*;
 
-import com.google.gson.*;
-import com.google.gson.stream.JsonWriter;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import ca.uhn.fhir.context.*;
 import ca.uhn.fhir.context.BaseRuntimeElementDefinition.ChildTypeEnum;
@@ -47,6 +48,12 @@ import ca.uhn.fhir.model.base.composite.BaseCodingDt;
 import ca.uhn.fhir.model.base.composite.BaseContainedDt;
 import ca.uhn.fhir.model.primitive.*;
 import ca.uhn.fhir.narrative.INarrativeGenerator;
+import ca.uhn.fhir.parser.json.GsonStructure;
+import ca.uhn.fhir.parser.json.JsonLikeArray;
+import ca.uhn.fhir.parser.json.JsonLikeObject;
+import ca.uhn.fhir.parser.json.JsonLikeStructure;
+import ca.uhn.fhir.parser.json.JsonLikeValue;
+import ca.uhn.fhir.parser.json.JsonLikeWriter;
 import ca.uhn.fhir.rest.server.EncodingEnum;
 import ca.uhn.fhir.util.ElementUtil;
 
@@ -54,7 +61,7 @@ import ca.uhn.fhir.util.ElementUtil;
  * This class is the FHIR JSON parser/encoder. Users should not interact with this class directly, but should use
  * {@link FhirContext#newJsonParser()} to get an instance.
  */
-public class JsonParser extends BaseParser implements IParser {
+public class JsonParser extends BaseParser implements IJsonLikeParser {
 
 	private static final Set<String> BUNDLE_TEXTNODE_CHILDREN_DSTU1;
 	private static final Set<String> BUNDLE_TEXTNODE_CHILDREN_DSTU2;
@@ -134,7 +141,7 @@ public class JsonParser extends BaseParser implements IParser {
 		}
 	}
 
-	private void assertObjectOfType(JsonElement theResourceTypeObj, Object theValueType, String thePosition) {
+	private void assertObjectOfType(JsonLikeValue theResourceTypeObj, Object theValueType, String thePosition) {
 //		if (theResourceTypeObj == null) {
 //			throw new DataFormatException("Invalid JSON content detected, missing required element: '" + thePosition + "'");
 //		}
@@ -144,51 +151,72 @@ public class JsonParser extends BaseParser implements IParser {
 //		}
 	}
 
-	private void beginArray(JsonWriter theEventWriter, String arrayName) throws IOException {
-		theEventWriter.name(arrayName);
-		theEventWriter.beginArray();
+	private void beginArray(JsonLikeWriter theEventWriter, String arrayName) throws IOException {
+		theEventWriter.beginArray(arrayName);
 	}
 
-	private void beginObject(JsonWriter theEventWriter, String arrayName) throws IOException {
-		theEventWriter.name(arrayName);
-		theEventWriter.beginObject();
+	private void beginObject(JsonLikeWriter theEventWriter, String arrayName) throws IOException {
+		theEventWriter.beginObject(arrayName);
 	}
 
-	private JsonWriter createJsonWriter(Writer theWriter) {
-		JsonWriter retVal = new JsonWriter(theWriter);
-		retVal.setSerializeNulls(true);
-		if (myPrettyPrint) {
-			retVal.setIndent("  ");
-		}
+	private JsonLikeWriter createJsonWriter(Writer theWriter) {
+		JsonLikeStructure jsonStructure = new GsonStructure();
+		JsonLikeWriter retVal = jsonStructure.getJsonLikeWriter(theWriter);
 		return retVal;
 	}
 
 	@Override
 	public void doEncodeBundleToWriter(Bundle theBundle, Writer theWriter) throws IOException {
-		JsonWriter eventWriter = createJsonWriter(theWriter);
-		if (myContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU1)) {
-			encodeBundleToWriterInDstu2Format(theBundle, eventWriter);
-		} else {
-			encodeBundleToWriterInDstu1Format(theBundle, eventWriter);
+		JsonLikeWriter eventWriter = createJsonWriter(theWriter);
+		doEncodeBundleToJsonLikeWriter(theBundle, eventWriter);
+	}
+	
+	public void doEncodeBundleToJsonLikeWriter(Bundle theBundle, JsonLikeWriter theEventWriter) throws IOException { 
+		if (myPrettyPrint) {
+			theEventWriter.setPrettyPrint(myPrettyPrint);
 		}
-		eventWriter.flush();
+		theEventWriter.init();
+
+		if (myContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU1)) {
+			encodeBundleToWriterInDstu2Format(theBundle, theEventWriter);
+		} else {
+			encodeBundleToWriterInDstu1Format(theBundle, theEventWriter);
+		}
+		theEventWriter.flush();
 	}
 
 	@Override
 	protected void doEncodeResourceToWriter(IBaseResource theResource, Writer theWriter) throws IOException {
-		JsonWriter eventWriter = createJsonWriter(theWriter);
+		JsonLikeWriter eventWriter = createJsonWriter(theWriter);
+		doEncodeResourceToJsonLikeWriter(theResource, eventWriter);
+	}
+	
+	public void doEncodeResourceToJsonLikeWriter(IBaseResource theResource, JsonLikeWriter theEventWriter) throws IOException { 
+		if (myPrettyPrint) {
+			theEventWriter.setPrettyPrint(myPrettyPrint);
+		}
+		theEventWriter.init();
 
 		RuntimeResourceDefinition resDef = myContext.getResourceDefinition(theResource);
-		encodeResourceToJsonStreamWriter(resDef, theResource, eventWriter, null, false, false);
-		eventWriter.flush();
+		encodeResourceToJsonStreamWriter(resDef, theResource, theEventWriter, null, false, false);
+		theEventWriter.flush();
 	}
 
 	@Override
 	public <T extends IBaseResource> T doParseResource(Class<T> theResourceType, Reader theReader) {
-			JsonObject object = parse(theReader);
+		JsonLikeStructure jsonStructure = new GsonStructure();
+		jsonStructure.load(theReader);
+		
+		T retVal = doParseResource(theResourceType, jsonStructure);
+		
+		return retVal;
+	}
 
-			JsonPrimitive resourceTypeObj = object.getAsJsonPrimitive("resourceType");
-			if (resourceTypeObj == null || isBlank(resourceTypeObj.getAsString())) {
+	public <T extends IBaseResource> T doParseResource(Class<T> theResourceType, JsonLikeStructure theJsonStructure) {
+			JsonLikeObject object = theJsonStructure.getRootObject();
+		
+			JsonLikeValue resourceTypeObj = object.get("resourceType");
+			if (resourceTypeObj == null || !resourceTypeObj.isString() || isBlank(resourceTypeObj.getAsString())) {
 				throw new DataFormatException("Invalid JSON content detected, missing required element: 'resourceType'");
 			}
 			
@@ -208,7 +236,15 @@ public class JsonParser extends BaseParser implements IParser {
 			return retVal;
 	}
 
-	private void encodeBundleToWriterInDstu1Format(Bundle theBundle, JsonWriter theEventWriter) throws IOException {
+	@Override
+	public void encodeBundleToJsonLikeWriter(Bundle theBundle, JsonLikeWriter theJsonLikeWriter) throws IOException, DataFormatException {
+		Validate.notNull(theBundle, "theBundle must not be null");
+		Validate.notNull(theJsonLikeWriter, "theJsonLikeWriter must not be null");
+
+		doEncodeBundleToJsonLikeWriter(theBundle, theJsonLikeWriter);
+	}
+
+	private void encodeBundleToWriterInDstu1Format(Bundle theBundle, JsonLikeWriter theEventWriter) throws IOException {
 		theEventWriter.beginObject();
 
 		write(theEventWriter, "resourceType", "Bundle");
@@ -277,7 +313,7 @@ public class JsonParser extends BaseParser implements IParser {
 		theEventWriter.endObject(); // resource object
 	}
 
-	private void encodeBundleToWriterInDstu2Format(Bundle theBundle, JsonWriter theEventWriter) throws IOException {
+	private void encodeBundleToWriterInDstu2Format(Bundle theBundle, JsonLikeWriter theEventWriter) throws IOException {
 		theEventWriter.beginObject();
 
 		write(theEventWriter, "resourceType", "Bundle");
@@ -374,7 +410,7 @@ public class JsonParser extends BaseParser implements IParser {
 		theEventWriter.endObject(); // resource object
 	}
 
-	private void encodeChildElementToStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonWriter theEventWriter, IBase theNextValue, BaseRuntimeElementDefinition<?> theChildDef, String theChildName, boolean theContainedResource, CompositeChildElement theChildElem,
+	private void encodeChildElementToStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonLikeWriter theEventWriter, IBase theNextValue, BaseRuntimeElementDefinition<?> theChildDef, String theChildName, boolean theContainedResource, CompositeChildElement theChildElem,
 			boolean theForceEmpty) throws IOException {
 
 		switch (theChildDef.getChildType()) {
@@ -387,7 +423,7 @@ public class JsonParser extends BaseParser implements IParser {
 			if (theChildName != null) {
 				write(theEventWriter, theChildName, encodedValue);
 			} else {
-				theEventWriter.value(encodedValue);
+				theEventWriter.write(encodedValue);
 			}
 			break;
 		}
@@ -395,7 +431,7 @@ public class JsonParser extends BaseParser implements IParser {
 			final IPrimitiveType<?> value = (IPrimitiveType<?>) theNextValue;
 			if (isBlank(value.getValueAsString())) {
 				if (theForceEmpty) {
-					theEventWriter.nullValue();
+					theEventWriter.writeNull();
 				}
 				break;
 			}
@@ -404,7 +440,7 @@ public class JsonParser extends BaseParser implements IParser {
 				if (theChildName != null) {
 					write(theEventWriter, theChildName, ((IBaseIntegerDatatype) value).getValue());
 				} else {
-					theEventWriter.value(((IBaseIntegerDatatype) value).getValue());
+					theEventWriter.write(((IBaseIntegerDatatype) value).getValue());
 				}
 			} else if (value instanceof IBaseDecimalDatatype) {
 				BigDecimal decimalValue = ((IBaseDecimalDatatype) value).getValue();
@@ -419,7 +455,7 @@ public class JsonParser extends BaseParser implements IParser {
 				if (theChildName != null) {
 					write(theEventWriter, theChildName, decimalValue);
 				} else {
-					theEventWriter.value(decimalValue);
+					theEventWriter.write(decimalValue);
 				}
 			} else if (value instanceof IBaseBooleanDatatype) {
 				if (theChildName != null) {
@@ -427,7 +463,7 @@ public class JsonParser extends BaseParser implements IParser {
 				} else {
 					Boolean booleanValue = ((IBaseBooleanDatatype) value).getValue();
 					if (booleanValue != null) {
-						theEventWriter.value(booleanValue.booleanValue());
+						theEventWriter.write(booleanValue.booleanValue());
 					}
 				}
 			} else {
@@ -435,7 +471,7 @@ public class JsonParser extends BaseParser implements IParser {
 				if (theChildName != null) {
 					write(theEventWriter, theChildName, valueStr);
 				} else {
-					theEventWriter.value(valueStr);
+					theEventWriter.write(valueStr);
 				}
 			}
 			break;
@@ -443,8 +479,7 @@ public class JsonParser extends BaseParser implements IParser {
 		case RESOURCE_BLOCK:
 		case COMPOSITE_DATATYPE: {
 			if (theChildName != null) {
-				theEventWriter.name(theChildName);
-				theEventWriter.beginObject();
+				theEventWriter.beginObject(theChildName);
 			} else {
 				theEventWriter.beginObject();
 			}
@@ -480,13 +515,13 @@ public class JsonParser extends BaseParser implements IParser {
 				if (theChildName != null) {
 					write(theEventWriter, theChildName, dt.getValueAsString());
 				} else {
-					theEventWriter.value(dt.getValueAsString());
+					theEventWriter.write(dt.getValueAsString());
 				}
 			} else {
 				if (theChildName != null) {
 					// do nothing
 				} else {
-					theEventWriter.nullValue();
+					theEventWriter.writeNull();
 				}
 			}
 			break;
@@ -503,7 +538,7 @@ public class JsonParser extends BaseParser implements IParser {
 
 	}
 
-	private void encodeCompositeElementChildrenToStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, IBase theElement, JsonWriter theEventWriter, boolean theContainedResource, CompositeChildElement theParent) throws IOException {
+	private void encodeCompositeElementChildrenToStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, IBase theElement, JsonLikeWriter theEventWriter, boolean theContainedResource, CompositeChildElement theParent) throws IOException {
 
 		{
 			String elementId = getCompositeElementId(theElement);
@@ -691,7 +726,7 @@ public class JsonParser extends BaseParser implements IParser {
 					}
 
 					if (!haveContent) {
-						theEventWriter.nullValue();
+						theEventWriter.writeNull();
 					} else {
 						if (inArray) {
 							theEventWriter.beginObject();
@@ -702,7 +737,7 @@ public class JsonParser extends BaseParser implements IParser {
 						if (nextComments != null && !nextComments.isEmpty()) {
 							beginArray(theEventWriter, "fhir_comments");
 							for (String next : nextComments) {
-								theEventWriter.value(next);
+								theEventWriter.write(next);
 							}
 							theEventWriter.endArray();
 						}
@@ -722,13 +757,25 @@ public class JsonParser extends BaseParser implements IParser {
 		}
 	}
 
-	private void encodeCompositeElementToStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, IBase theNextValue, JsonWriter theEventWriter, boolean theContainedResource, CompositeChildElement theParent) throws IOException, DataFormatException {
+	private void encodeCompositeElementToStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, IBase theNextValue, JsonLikeWriter theEventWriter, boolean theContainedResource, CompositeChildElement theParent) throws IOException, DataFormatException {
 
 		writeCommentsPreAndPost(theNextValue, theEventWriter);
 		encodeCompositeElementChildrenToStreamWriter(theResDef, theResource, theNextValue, theEventWriter, theContainedResource, theParent);
 	}
 
-	private void encodeResourceToJsonStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonWriter theEventWriter, String theObjectNameOrNull, boolean theContainedResource, boolean theSubResource) throws IOException {
+	@Override
+	public void encodeResourceToJsonLikeWriter(IBaseResource theResource, JsonLikeWriter theJsonLikeWriter) throws IOException, DataFormatException {
+		Validate.notNull(theResource, "theResource can not be null");
+		Validate.notNull(theJsonLikeWriter, "theJsonLikeWriter can not be null");
+
+		if (theResource.getStructureFhirVersionEnum() != myContext.getVersion().getVersion()) {
+			throw new IllegalArgumentException("This parser is for FHIR version " + myContext.getVersion().getVersion() + " - Can not encode a structure for version " + theResource.getStructureFhirVersionEnum());
+		}
+
+		doEncodeResourceToJsonLikeWriter(theResource, theJsonLikeWriter);
+	}
+
+	private void encodeResourceToJsonStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonLikeWriter theEventWriter, String theObjectNameOrNull, boolean theContainedResource, boolean theSubResource) throws IOException {
 		IIdType resourceId = null;
 		//		if (theResource instanceof IResource) {
 		//			IResource res = (IResource) theResource;
@@ -767,7 +814,7 @@ public class JsonParser extends BaseParser implements IParser {
 		encodeResourceToJsonStreamWriter(theResDef, theResource, theEventWriter, theObjectNameOrNull, theContainedResource, resourceId);
 	}
 
-	private void encodeResourceToJsonStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonWriter theEventWriter, String theObjectNameOrNull, boolean theContainedResource, IIdType theResourceId) throws IOException {
+	private void encodeResourceToJsonStreamWriter(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonLikeWriter theEventWriter, String theObjectNameOrNull, boolean theContainedResource, IIdType theResourceId) throws IOException {
 		if (!theContainedResource) {
 			super.containResourcesForEncoding(theResource);
 		}
@@ -815,7 +862,7 @@ public class JsonParser extends BaseParser implements IParser {
 					beginArray(theEventWriter, "profile");
 					for (IIdType profile : profiles) {
 						if (profile != null && isNotBlank(profile.getValue())) {
-							theEventWriter.value(profile.getValue());
+							theEventWriter.write(profile.getValue());
 						}
 					}
 					theEventWriter.endArray();
@@ -869,7 +916,16 @@ public class JsonParser extends BaseParser implements IParser {
 
 	@Override
 	public void encodeTagListToWriter(TagList theTagList, Writer theWriter) throws IOException {
-		JsonWriter theEventWriter = createJsonWriter(theWriter);
+		JsonLikeWriter theEventWriter = createJsonWriter(theWriter);
+		encodeTagListToJsonLikeWriter(theTagList, theEventWriter);
+	}
+
+	@Override
+	public void encodeTagListToJsonLikeWriter(TagList theTagList, JsonLikeWriter theEventWriter) throws IOException {
+		if (myPrettyPrint) {
+			theEventWriter.setPrettyPrint(myPrettyPrint);
+		}
+		theEventWriter.init();
 
 		theEventWriter.beginObject();
 
@@ -902,7 +958,7 @@ public class JsonParser extends BaseParser implements IParser {
 	 * called _name): resource extensions, and extension extensions
 	 * @param theChildElem 
 	 */
-	private void extractAndWriteExtensionsAsDirectChild(IBase theElement, JsonWriter theEventWriter, BaseRuntimeElementDefinition<?> theElementDef, RuntimeResourceDefinition theResDef, IBaseResource theResource, CompositeChildElement theChildElem) throws IOException {
+	private void extractAndWriteExtensionsAsDirectChild(IBase theElement, JsonLikeWriter theEventWriter, BaseRuntimeElementDefinition<?> theElementDef, RuntimeResourceDefinition theResDef, IBaseResource theResource, CompositeChildElement theChildElem) throws IOException {
 		List<HeldExtension> extensions = new ArrayList<HeldExtension>(0);
 		List<HeldExtension> modifierExtensions = new ArrayList<HeldExtension>(0);
 
@@ -988,55 +1044,55 @@ public class JsonParser extends BaseParser implements IParser {
 		return EncodingEnum.JSON;
 	}
 
-	private JsonArray grabJsonArray(JsonObject theObject, String nextName, String thePosition) {
-		JsonElement object = theObject.get(nextName);
-		if (object == null || object instanceof JsonNull) {
+	private JsonLikeArray grabJsonArray(JsonLikeObject theObject, String nextName, String thePosition) {
+		JsonLikeValue object = theObject.get(nextName);
+		if (object == null || object.isNull()) {
 			return null;
 		}
-		if (!(object instanceof JsonArray)) {
-			throw new DataFormatException("Syntax error parsing JSON FHIR structure: Expected ARRAY at element '" + thePosition + "', found '" + object.getClass().getSimpleName() + "'");
+		if (!object.isArray()) {
+			throw new DataFormatException("Syntax error parsing JSON FHIR structure: Expected ARRAY at element '" + thePosition + "', found '" + object.getJsonType() + "'");
 		}
-		return (JsonArray) object;
+		return object.getAsArray();
 	}
 
-	private JsonObject parse(Reader theReader) {
+//	private JsonObject parse(Reader theReader) {
+//
+//		PushbackReader pbr = new PushbackReader(theReader);
+//		JsonObject object;
+//		try {
+//			while(true) {
+//				int nextInt;
+//					nextInt = pbr.read();
+//				if (nextInt == -1) {
+//					throw new DataFormatException("Did not find any content to parse");
+//				}
+//				if (nextInt == '{') {
+//					pbr.unread('{');
+//					break;
+//				}
+//				if (Character.isWhitespace(nextInt)) {
+//					continue;
+//				}
+//				throw new DataFormatException("Content does not appear to be FHIR JSON, first non-whitespace character was: '" + (char)nextInt + "' (must be '{')");
+//			}
+//		
+//			Gson gson = newGson();
+//		
+//			object = gson.fromJson(pbr, JsonObject.class);
+//		} catch (Exception e) {
+//			throw new DataFormatException("Failed to parse JSON content, error was: " + e.getMessage(), e);
+//		}
+//		
+//		return object;
+//	}
 
-		PushbackReader pbr = new PushbackReader(theReader);
-		JsonObject object;
-		try {
-			while(true) {
-				int nextInt;
-					nextInt = pbr.read();
-				if (nextInt == -1) {
-					throw new DataFormatException("Did not find any content to parse");
-				}
-				if (nextInt == '{') {
-					pbr.unread('{');
-					break;
-				}
-				if (Character.isWhitespace(nextInt)) {
-					continue;
-				}
-				throw new DataFormatException("Content does not appear to be FHIR JSON, first non-whitespace character was: '" + (char)nextInt + "' (must be '{')");
-			}
-		
-			Gson gson = newGson();
-		
-			object = gson.fromJson(pbr, JsonObject.class);
-		} catch (Exception e) {
-			throw new DataFormatException("Failed to parse JSON content, error was: " + e.getMessage(), e);
-		}
-		
-		return object;
-	}
-
-	private void parseAlternates(JsonElement theAlternateVal, ParserState<?> theState, String theElementName) {
-		if (theAlternateVal == null || theAlternateVal instanceof JsonNull) {
+	private void parseAlternates(JsonLikeValue theAlternateVal, ParserState<?> theState, String theElementName) {
+		if (theAlternateVal == null || theAlternateVal.isNull()) {
 			return;
 		}
 
-		if (theAlternateVal instanceof JsonArray) {
-			JsonArray array = (JsonArray) theAlternateVal;
+		if (theAlternateVal.isArray()) {
+			JsonLikeArray array = theAlternateVal.getAsArray();
 			if (array.size() > 1) {
 				throw new DataFormatException("Unexpected array of length " + array.size() + " (expected 0 or 1) for element: " + theElementName);
 			}
@@ -1047,43 +1103,51 @@ public class JsonParser extends BaseParser implements IParser {
 			return;
 		}
 
-		JsonObject alternate = (JsonObject) theAlternateVal;
-		for (Entry<String, JsonElement> nextEntry : alternate.entrySet()) {
-			String nextKey = nextEntry.getKey();
-			JsonElement nextVal = nextEntry.getValue();
+		JsonLikeObject alternate = theAlternateVal.getAsObject();
+		for (String nextKey : alternate.keySet()) {
+			JsonLikeValue nextVal = alternate.get(nextKey);
 			if ("extension".equals(nextKey)) {
 				boolean isModifier = false;
-				JsonArray array = (JsonArray) nextEntry.getValue();
+				JsonLikeArray array = nextVal.getAsArray();
 				parseExtension(theState, array, isModifier);
 			} else if ("modifierExtension".equals(nextKey)) {
 				boolean isModifier = true;
-				JsonArray array = (JsonArray) nextEntry.getValue();
+				JsonLikeArray array = nextVal.getAsArray();
 				parseExtension(theState, array, isModifier);
 			} else if ("id".equals(nextKey)) {
-				if (nextVal instanceof JsonPrimitive) {
-					theState.attributeValue("id", ((JsonPrimitive) nextVal).getAsString());
+				if (nextVal.isString() || nextVal.isNumber()) {
+					theState.attributeValue("id", nextVal.getAsString());
 				}
 			} else if ("fhir_comments".equals(nextKey)) {
-				parseFhirComments(nextEntry.getValue(), theState);
+				parseFhirComments(nextVal, theState);
 			}
 		}
 	}
 
 	@Override
 	public <T extends IBaseResource> Bundle parseBundle(Class<T> theResourceType, Reader theReader) {
-		JsonObject object;
+		JsonLikeStructure jsonStructure = new GsonStructure();
+		jsonStructure.load(theReader);
+		
+		Bundle retVal = parseBundle(theResourceType, jsonStructure);
+		
+		return retVal;
+	}
 
-		try {
-			object = parse(theReader);
-		} catch (JsonSyntaxException e) {
-			if (e.getMessage().startsWith("Unexpected char 39")) {
-				throw new DataFormatException("Failed to parse JSON encoded FHIR content: " + e.getMessage() + " - This may indicate that single quotes are being used as JSON escapes where double quotes are required", e);
-			}
-			throw new DataFormatException("Failed to parse JSON encoded FHIR content: " + e.getMessage(), e);
+	@Override
+	public Bundle parseBundle(JsonLikeStructure theJsonLikeStructure) throws DataFormatException {
+		return parseBundle(null, theJsonLikeStructure);
+	}
+
+	@Override
+	public <T extends IBaseResource> Bundle parseBundle(Class<T> theResourceType, JsonLikeStructure theJsonStructure) {
+		JsonLikeObject object = theJsonStructure.getRootObject();
+		
+		JsonLikeValue resourceTypeObj = object.get("resourceType");
+		if (resourceTypeObj == null || !resourceTypeObj.isString()) {
+			throw new DataFormatException("Invalid JSON content detected, missing required element: 'resourceType'");
 		}
-		JsonElement resourceTypeObj = object.get("resourceType");
-		assertObjectOfType(resourceTypeObj, JsonPrimitive.class, "resourceType");
-		String resourceType = ((JsonPrimitive) resourceTypeObj).getAsString();
+		String resourceType = resourceTypeObj.getAsString();
 		if (!"Bundle".equals(resourceType)) {
 			throw new DataFormatException("Trying to parse bundle but found resourceType other than 'Bundle'. Found: '" + resourceType + "'");
 		}
@@ -1105,27 +1169,28 @@ public class JsonParser extends BaseParser implements IParser {
 		return retVal;
 	}
 
-	private void parseBundleChildren(JsonObject theObject, ParserState<?> theState) {
-		for (Entry<String, JsonElement> nextEntry : theObject.entrySet()) {
-			String nextName = nextEntry.getKey();
+	private void parseBundleChildren(JsonLikeObject theObject, ParserState<?> theState) {
+		for (String nextName : theObject.keySet()) {
 			if ("resourceType".equals(nextName)) {
 				continue;
 			} else if ("entry".equals(nextName)) {
-				JsonArray entries = grabJsonArray(theObject, nextName, "entry");
-				for (JsonElement JsonElement : entries) {
+				JsonLikeArray entries = grabJsonArray(theObject, nextName, "entry");
+				for (int i = 0; i < entries.size(); i++) {
+					JsonLikeValue jsonValue = entries.get(i);
 					theState.enteringNewElement(null, "entry");
-					parseBundleChildren((JsonObject) JsonElement, theState);
+					parseBundleChildren(jsonValue.getAsObject(), theState);
 					theState.endingElement();
 				}
 				continue;
 			} else if (myContext.getVersion().getVersion() == FhirVersionEnum.DSTU1) {
 				if ("link".equals(nextName)) {
-					JsonArray entries = grabJsonArray(theObject, nextName, "link");
-					for (JsonElement JsonElement : entries) {
+					JsonLikeArray entries = grabJsonArray(theObject, nextName, "link");
+					for (int i = 0; i < entries.size(); i++) {
+						JsonLikeValue jsonValue = entries.get(i);
 						theState.enteringNewElement(null, "link");
-						JsonObject linkObj = (JsonObject) JsonElement;
-						String rel = linkObj.get("rel").getAsString();
-						String href = linkObj.get("href").getAsString();
+						JsonLikeObject linkObj = jsonValue.getAsObject();
+						String rel = linkObj.getString("rel", null);
+						String href = linkObj.getString("href", null);
 						theState.attributeValue("rel", rel);
 						theState.attributeValue("href", href);
 						theState.endingElement();
@@ -1133,8 +1198,8 @@ public class JsonParser extends BaseParser implements IParser {
 					continue;
 				} else if (BUNDLE_TEXTNODE_CHILDREN_DSTU1.contains(nextName)) {
 					theState.enteringNewElement(null, nextName);
-					JsonElement jsonElement = theObject.get(nextName);
-					if (jsonElement instanceof JsonPrimitive) {
+					JsonLikeValue jsonElement = theObject.get(nextName);
+					if (jsonElement.isScalar()) {
 						theState.string(jsonElement.getAsString());
 					}
 					theState.endingElement();
@@ -1142,12 +1207,13 @@ public class JsonParser extends BaseParser implements IParser {
 				}
 			} else {
 				if ("link".equals(nextName)) {
-					JsonArray entries = grabJsonArray(theObject, nextName, "link");
-					for (JsonElement JsonElement : entries) {
+					JsonLikeArray entries = grabJsonArray(theObject, nextName, "link");
+					for (int i = 0; i < entries.size(); i++) {
+						JsonLikeValue jsonValue = entries.get(i);
 						theState.enteringNewElement(null, "link");
-						JsonObject linkObj = (JsonObject) JsonElement;
-						String rel = linkObj.get("relation").getAsString();
-						String href = linkObj.get("url").getAsString();
+						JsonLikeObject linkObj = jsonValue.getAsObject();
+						String rel = linkObj.getString("relation", null);
+						String href = linkObj.getString("url", null);
 						theState.enteringNewElement(null, "relation");
 						theState.attributeValue("value", rel);
 						theState.endingElement();
@@ -1161,10 +1227,10 @@ public class JsonParser extends BaseParser implements IParser {
 					theState.enteringNewElement(null, nextName);
 					// String obj = theObject.getString(nextName, null);
 
-					JsonElement obj = theObject.get(nextName);
-					if (obj == null) {
+					JsonLikeValue obj = theObject.get(nextName);
+					if (obj == null || obj.isNull()) {
 						theState.attributeValue("value", null);
-					} else if (obj instanceof JsonPrimitive) {
+					} else if (obj.isScalar()) {
 						theState.attributeValue("value", obj.getAsString());
 					} else {
 						throw new DataFormatException("Unexpected JSON object for entry '" + nextName + "'");
@@ -1175,29 +1241,27 @@ public class JsonParser extends BaseParser implements IParser {
 				}
 			}
 
-			JsonElement nextVal = theObject.get(nextName);
+			JsonLikeValue nextVal = theObject.get(nextName);
 			parseChildren(theState, nextName, nextVal, null, null);
 
 		}
 	}
 
-	private void parseChildren(JsonObject theObject, ParserState<?> theState) {
-		Set<Entry<String, JsonElement>> entrySet = theObject.entrySet();
+	private void parseChildren(JsonLikeObject theObject, ParserState<?> theState) {
+		Set<String> keySet = theObject.keySet();
 
 		int allUnderscoreNames = 0;
 		int handledUnderscoreNames = 0;
 
-		for (Entry<String, JsonElement> nextEntry : entrySet) {
-			String nextName = nextEntry.getKey();
-			JsonElement nextObject = nextEntry.getValue();
+		for (String nextName : keySet) {
 			if ("resourceType".equals(nextName)) {
 				continue;
 			} else if ("extension".equals(nextName)) {
-				JsonArray array = grabJsonArray(theObject, nextName, "extension");
+				JsonLikeArray array = grabJsonArray(theObject, nextName, "extension");
 				parseExtension(theState, array, false);
 				continue;
 			} else if ("modifierExtension".equals(nextName)) {
-				JsonArray array = grabJsonArray(theObject, nextName, "modifierExtension");
+				JsonLikeArray array = grabJsonArray(theObject, nextName, "modifierExtension");
 				parseExtension(theState, array, true);
 				continue;
 			} else if (nextName.equals("fhir_comments")) {
@@ -1208,9 +1272,9 @@ public class JsonParser extends BaseParser implements IParser {
 				continue;
 			}
 
-			JsonElement nextVal = theObject.get(nextName);
+			JsonLikeValue nextVal = theObject.get(nextName);
 			String alternateName = '_' + nextName;
-			JsonElement alternateVal = theObject.get(alternateName);
+			JsonLikeValue alternateVal = theObject.get(alternateName);
 			if (alternateVal != null) {
 				handledUnderscoreNames++;
 			}
@@ -1235,11 +1299,10 @@ public class JsonParser extends BaseParser implements IParser {
 		 * for example.
 		 */
 		if (allUnderscoreNames > handledUnderscoreNames) {
-			for (Entry<String, JsonElement> nextEntry : entrySet) {
-				String alternateName = nextEntry.getKey();
+			for (String alternateName : keySet) {
 				if (alternateName.startsWith("_") && alternateName.length() > 1) {
-					JsonElement nextValue = theObject.get(alternateName);
-					if (nextValue instanceof JsonObject) {
+					JsonLikeValue nextValue = theObject.get(alternateName);
+					if (nextValue != null && nextValue.isObject()) {
 						String nextName = alternateName.substring(1);
 						if (theObject.get(nextName) == null) {
 							theState.enteringNewElement(null, nextName);
@@ -1253,26 +1316,26 @@ public class JsonParser extends BaseParser implements IParser {
 
 	}
 
-	private void parseChildren(ParserState<?> theState, String theName, JsonElement theJsonVal, JsonElement theAlternateVal, String theAlternateName) {
-		if (theJsonVal instanceof JsonArray) {
-			JsonArray nextArray = (JsonArray) theJsonVal;
-			JsonArray nextAlternateArray = (JsonArray) theAlternateVal;
+	private void parseChildren(ParserState<?> theState, String theName, JsonLikeValue theJsonVal, JsonLikeValue theAlternateVal, String theAlternateName) {
+		if (theJsonVal.isArray()) {
+			JsonLikeArray nextArray = theJsonVal.getAsArray();
+			JsonLikeArray nextAlternateArray = JsonLikeValue.asArray(theAlternateVal); // could be null
 			for (int i = 0; i < nextArray.size(); i++) {
-				JsonElement nextObject = nextArray.get(i);
-				JsonElement nextAlternate = null;
+				JsonLikeValue nextObject = nextArray.get(i);
+				JsonLikeValue nextAlternate = null;
 				if (nextAlternateArray != null) {
 					nextAlternate = nextAlternateArray.get(i);
 				}
 				parseChildren(theState, theName, nextObject, nextAlternate, theAlternateName);
 			}
-		} else if (theJsonVal instanceof JsonObject) {
+		} else if (theJsonVal.isObject()) {
 			theState.enteringNewElement(null, theName);
 			parseAlternates(theAlternateVal, theState, theAlternateName);
-			JsonObject nextObject = (JsonObject) theJsonVal;
+			JsonLikeObject nextObject = theJsonVal.getAsObject();
 			boolean preResource = false;
 			if (theState.isPreResource()) {
-				JsonPrimitive resType = nextObject.getAsJsonPrimitive("resourceType");
-				if (resType == null || isBlank(resType.getAsString())) {
+				JsonLikeValue resType = nextObject.get("resourceType");
+				if (resType == null || !resType.isString()) {
 					throw new DataFormatException("Missing required element 'resourceType' from JSON resource object, unable to parse");
 				}
 				theState.enteringNewElement(null, resType.getAsString());
@@ -1283,25 +1346,25 @@ public class JsonParser extends BaseParser implements IParser {
 				theState.endingElement();
 			}
 			theState.endingElement();
-		} else if (theJsonVal instanceof JsonNull) {
+		} else if (theJsonVal.isNull()) {
 			theState.enteringNewElement(null, theName);
 			parseAlternates(theAlternateVal, theState, theAlternateName);
 			theState.endingElement();
 		} else {
-			JsonPrimitive nextValStr = (JsonPrimitive)theJsonVal;
+			// must be a SCALAR
 			theState.enteringNewElement(null, theName);
-			theState.attributeValue("value", nextValStr.getAsString());
+			theState.attributeValue("value", theJsonVal.getAsString());
 			parseAlternates(theAlternateVal, theState, theAlternateName);
 			theState.endingElement();
 		}
 	}
 
-	private void parseExtension(ParserState<?> theState, JsonArray theValues, boolean theIsModifier) {
+	private void parseExtension(ParserState<?> theState, JsonLikeArray theValues, boolean theIsModifier) {
 		for (int i = 0; i < theValues.size(); i++) {
-			JsonObject nextExtObj = (JsonObject) theValues.get(i);
-			JsonElement jsonElement = nextExtObj.get("url");
+			JsonLikeObject nextExtObj = JsonLikeValue.asObject(theValues.get(i));
+			JsonLikeValue jsonElement = nextExtObj.get("url");
 			String url;
-			if (!(jsonElement instanceof JsonPrimitive)) {
+			if (null == jsonElement || !(jsonElement.isScalar())) {
 				String parentElementName;
 				if (theIsModifier) {
 					parentElementName = "modifierExtension";
@@ -1314,18 +1377,17 @@ public class JsonParser extends BaseParser implements IParser {
 				url = jsonElement.getAsString();
 			}
 			theState.enteringNewElementExtension(null, url, theIsModifier);
-			for (Iterator<Entry<String, JsonElement>> iter = nextExtObj.entrySet().iterator(); iter.hasNext();) {
-				String next = iter.next().getKey();
+			for (String next : nextExtObj.keySet()) {
 				if ("url".equals(next)) {
 					continue;
 				} else if ("extension".equals(next)) {
-					JsonArray jsonVal = (JsonArray) nextExtObj.get(next);
+					JsonLikeArray jsonVal = JsonLikeValue.asArray(nextExtObj.get(next));
 					parseExtension(theState, jsonVal, false);
 				} else if ("modifierExtension".equals(next)) {
-					JsonArray jsonVal = (JsonArray) nextExtObj.get(next);
+					JsonLikeArray jsonVal = JsonLikeValue.asArray(nextExtObj.get(next));
 					parseExtension(theState, jsonVal, true);
 				} else {
-					JsonElement jsonVal = nextExtObj.get(next);
+					JsonLikeValue jsonVal = nextExtObj.get(next);
 					parseChildren(theState, next, jsonVal, null, null);
 				}
 			}
@@ -1333,11 +1395,13 @@ public class JsonParser extends BaseParser implements IParser {
 		}
 	}
 
-	private void parseFhirComments(JsonElement theObject, ParserState<?> theState) {
-		if (theObject instanceof JsonArray) {
-			for (JsonElement nextComment : ((JsonArray) theObject)) {
-				if (nextComment instanceof JsonPrimitive) {
-					String commentText = ((JsonPrimitive) nextComment).getAsString();
+	private void parseFhirComments(JsonLikeValue theObject, ParserState<?> theState) {
+		if (theObject.isArray()) {
+			JsonLikeArray comments = theObject.getAsArray();
+			for (int i = 0; i < comments.size(); i++) {
+				JsonLikeValue nextComment = comments.get(i);
+				if (nextComment.isString()) {
+					String commentText = nextComment.getAsString();
 					if (commentText != null) {
 						theState.commentPre(commentText);
 					}
@@ -1347,10 +1411,91 @@ public class JsonParser extends BaseParser implements IParser {
 	}
 
 	@Override
-	public TagList parseTagList(Reader theReader) {
-		JsonObject object = parse(theReader);
+	public <T extends IBaseResource> T parseResource(Class<T> theResourceType, JsonLikeStructure theJsonLikeStructure) throws DataFormatException {
+		
+		/*****************************************************
+		 * ************************************************* *
+		 * ** NOTE: this duplicates most of the code in   ** *
+		 * ** BaseParser.parseResource(Class<T>, Reader). ** *
+		 * ** Unfortunately, there is no way to avoid     ** *   
+		 * ** this without doing some refactoring of the  ** *
+		 * ** BaseParser class.                           ** *
+		 * ************************************************* *
+		 *****************************************************/
+		
+		/*
+		 * We do this so that the context can verify that the structure is for
+		 * the correct FHIR version
+		 */
+		if (theResourceType != null) {
+			myContext.getResourceDefinition(theResourceType);
+		}
 
-		JsonPrimitive resourceTypeObj = object.getAsJsonPrimitive("resourceType");
+		// Actually do the parse
+		T retVal = doParseResource(theResourceType, theJsonLikeStructure);
+
+		RuntimeResourceDefinition def = myContext.getResourceDefinition(retVal);
+		if ("Bundle".equals(def.getName())) {
+
+			BaseRuntimeChildDefinition entryChild = def.getChildByName("entry");
+			BaseRuntimeElementCompositeDefinition<?> entryDef = (BaseRuntimeElementCompositeDefinition<?>) entryChild.getChildByName("entry");
+			List<IBase> entries = entryChild.getAccessor().getValues(retVal);
+			if (entries != null) {
+				for (IBase nextEntry : entries) {
+
+					/**
+					 * If Bundle.entry.fullUrl is populated, set the resource ID to that
+					 */
+					// TODO: should emit a warning and maybe notify the error handler if the resource ID doesn't match the
+					// fullUrl idPart
+					BaseRuntimeChildDefinition fullUrlChild = entryDef.getChildByName("fullUrl");
+					if (fullUrlChild == null) {
+						continue; // TODO: remove this once the data model in tinder plugin catches up to 1.2
+					}
+					List<IBase> fullUrl = fullUrlChild.getAccessor().getValues(nextEntry);
+					if (fullUrl != null && !fullUrl.isEmpty()) {
+						IPrimitiveType<?> value = (IPrimitiveType<?>) fullUrl.get(0);
+						if (value.isEmpty() == false) {
+							List<IBase> entryResources = entryDef.getChildByName("resource").getAccessor().getValues(nextEntry);
+							if (entryResources != null && entryResources.size() > 0) {
+								IBaseResource res = (IBaseResource) entryResources.get(0);
+								String versionId = res.getIdElement().getVersionIdPart();
+								res.setId(value.getValueAsString());
+								if (isNotBlank(versionId) && res.getIdElement().hasVersionIdPart() == false) {
+									res.setId(res.getIdElement().withVersion(versionId));
+								}
+							}
+						}
+					}
+
+				}
+			}
+
+		}
+
+		return retVal;
+	}
+
+	@Override
+	public IBaseResource parseResource(JsonLikeStructure theJsonLikeStructure) throws DataFormatException {
+		return parseResource(null, theJsonLikeStructure);
+	}
+
+	@Override
+	public TagList parseTagList(Reader theReader) {
+		JsonLikeStructure jsonStructure = new GsonStructure();
+		jsonStructure.load(theReader);
+		
+		TagList retVal = parseTagList(jsonStructure);
+		
+		return retVal;
+	}
+	
+	@Override
+	public TagList parseTagList(JsonLikeStructure theJsonStructure) {
+		JsonLikeObject object = theJsonStructure.getRootObject();
+
+		JsonLikeValue resourceTypeObj = object.get("resourceType");
 		String resourceType = resourceTypeObj.getAsString();
 
 		ParserState<TagList> state = ParserState.getPreTagListInstance(this, myContext, true, getErrorHandler());
@@ -1370,9 +1515,10 @@ public class JsonParser extends BaseParser implements IParser {
 		return this;
 	}
 
-	private void write(JsonWriter theEventWriter, String theChildName, BigDecimal theDecimalValue) throws IOException {
-		theEventWriter.name(theChildName);
-		theEventWriter.value(theDecimalValue);
+	private void write(JsonLikeWriter theEventWriter, String theChildName, Boolean theValue) throws IOException {
+		if (theValue != null) {
+			theEventWriter.write(theChildName, theValue.booleanValue());
+		}
 	}
 
 	// private void parseExtensionInDstu2Style(boolean theModifier, ParserState<?> theState, String
@@ -1401,24 +1547,19 @@ public class JsonParser extends BaseParser implements IParser {
 	// theState.endingElement();
 	// }
 
-	private void write(JsonWriter theEventWriter, String theChildName, Boolean theValue) throws IOException {
-		if (theValue != null) {
-			theEventWriter.name(theChildName);
-			theEventWriter.value(theValue.booleanValue());
-		}
+	private void write(JsonLikeWriter theEventWriter, String theChildName, BigDecimal theDecimalValue) throws IOException {
+		theEventWriter.write(theChildName, theDecimalValue);
 	}
 
-	private void write(JsonWriter theEventWriter, String theChildName, Integer theValue) throws IOException {
-		theEventWriter.name(theChildName);
-		theEventWriter.value(theValue);
+	private void write(JsonLikeWriter theEventWriter, String theChildName, Integer theValue) throws IOException {
+		theEventWriter.write(theChildName, theValue);
 	}
 
-	private boolean writeAtomLinkInDstu1Format(JsonWriter theEventWriter, String theRel, StringDt theLink, boolean theStarted) throws IOException {
+	private boolean writeAtomLinkInDstu1Format(JsonLikeWriter theEventWriter, String theRel, StringDt theLink, boolean theStarted) throws IOException {
 		boolean retVal = theStarted;
 		if (isNotBlank(theLink.getValue())) {
 			if (theStarted == false) {
-				theEventWriter.name("link");
-				theEventWriter.beginArray();
+				theEventWriter.beginArray("link");
 				retVal = true;
 			}
 
@@ -1430,12 +1571,11 @@ public class JsonParser extends BaseParser implements IParser {
 		return retVal;
 	}
 
-	private boolean writeAtomLinkInDstu2Format(JsonWriter theEventWriter, String theRel, StringDt theLink, boolean theStarted) throws IOException {
+	private boolean writeAtomLinkInDstu2Format(JsonLikeWriter theEventWriter, String theRel, StringDt theLink, boolean theStarted) throws IOException {
 		boolean retVal = theStarted;
 		if (isNotBlank(theLink.getValue())) {
 			if (theStarted == false) {
-				theEventWriter.name("link");
-				theEventWriter.beginArray();
+				theEventWriter.beginArray("link");
 				retVal = true;
 			}
 
@@ -1447,7 +1587,7 @@ public class JsonParser extends BaseParser implements IParser {
 		return retVal;
 	}
 
-	private void writeAuthor(BaseBundle theBundle, JsonWriter theEventWriter) throws IOException {
+	private void writeAuthor(BaseBundle theBundle, JsonLikeWriter theEventWriter) throws IOException {
 		if (StringUtils.isNotBlank(theBundle.getAuthorName().getValue())) {
 			beginArray(theEventWriter, "author");
 			theEventWriter.beginObject();
@@ -1458,10 +1598,9 @@ public class JsonParser extends BaseParser implements IParser {
 		}
 	}
 
-	private void writeCategories(JsonWriter theEventWriter, TagList categories) throws IOException {
+	private void writeCategories(JsonLikeWriter theEventWriter, TagList categories) throws IOException {
 		if (categories != null && categories.size() > 0) {
-			theEventWriter.name("category");
-			theEventWriter.beginArray();
+			theEventWriter.beginArray("category");
 			for (Tag next : categories) {
 				theEventWriter.beginObject();
 				write(theEventWriter, "term", defaultString(next.getTerm()));
@@ -1473,26 +1612,26 @@ public class JsonParser extends BaseParser implements IParser {
 		}
 	}
 
-	private void writeCommentsPreAndPost(IBase theNextValue, JsonWriter theEventWriter) throws IOException {
+	private void writeCommentsPreAndPost(IBase theNextValue, JsonLikeWriter theEventWriter) throws IOException {
 		if (theNextValue.hasFormatComment()) {
 			beginArray(theEventWriter, "fhir_comments");
 			List<String> pre = theNextValue.getFormatCommentsPre();
 			if (pre.isEmpty() == false) {
 				for (String next : pre) {
-					theEventWriter.value(next);
+					theEventWriter.write(next);
 				}
 			}
 			List<String> post = theNextValue.getFormatCommentsPost();
 			if (post.isEmpty() == false) {
 				for (String next : post) {
-					theEventWriter.value(next);
+					theEventWriter.write(next);
 				}
 			}
 			theEventWriter.endArray();
 		}
 	}
 
-	private void writeExtensionsAsDirectChild(IBaseResource theResource, JsonWriter theEventWriter, RuntimeResourceDefinition resDef, List<HeldExtension> extensions, List<HeldExtension> modifierExtensions) throws IOException {
+	private void writeExtensionsAsDirectChild(IBaseResource theResource, JsonLikeWriter theEventWriter, RuntimeResourceDefinition resDef, List<HeldExtension> extensions, List<HeldExtension> modifierExtensions) throws IOException {
 		if (extensions.isEmpty() == false) {
 			beginArray(theEventWriter, "extension");
 			for (HeldExtension next : extensions) {
@@ -1509,19 +1648,19 @@ public class JsonParser extends BaseParser implements IParser {
 		}
 	}
 
-	private void writeOptionalTagWithDecimalNode(JsonWriter theEventWriter, String theElementName, DecimalDt theValue) throws IOException {
+	private void writeOptionalTagWithDecimalNode(JsonLikeWriter theEventWriter, String theElementName, DecimalDt theValue) throws IOException {
 		if (theValue != null && theValue.isEmpty() == false) {
 			write(theEventWriter, theElementName, theValue.getValue());
 		}
 	}
 
-	private void writeOptionalTagWithNumberNode(JsonWriter theEventWriter, String theElementName, IntegerDt theValue) throws IOException {
+	private void writeOptionalTagWithNumberNode(JsonLikeWriter theEventWriter, String theElementName, IntegerDt theValue) throws IOException {
 		if (theValue != null && theValue.isEmpty() == false) {
 			write(theEventWriter, theElementName, theValue.getValue().intValue());
 		}
 	}
 
-	private void writeOptionalTagWithTextNode(JsonWriter theEventWriter, String theElementName, IPrimitiveDatatype<?> thePrimitive) throws IOException {
+	private void writeOptionalTagWithTextNode(JsonLikeWriter theEventWriter, String theElementName, IPrimitiveDatatype<?> thePrimitive) throws IOException {
 		if (thePrimitive == null) {
 			return;
 		}
@@ -1529,22 +1668,21 @@ public class JsonParser extends BaseParser implements IParser {
 		writeOptionalTagWithTextNode(theEventWriter, theElementName, str);
 	}
 
-	private void writeOptionalTagWithTextNode(JsonWriter theEventWriter, String theElementName, String theValue) throws IOException {
+	private void writeOptionalTagWithTextNode(JsonLikeWriter theEventWriter, String theElementName, String theValue) throws IOException {
 		if (StringUtils.isNotBlank(theValue)) {
 			write(theEventWriter, theElementName, theValue);
 		}
 	}
 
-	private void writeTagWithTextNode(JsonWriter theEventWriter, String theElementName, IPrimitiveDatatype<?> theIdDt) throws IOException {
+	private void writeTagWithTextNode(JsonLikeWriter theEventWriter, String theElementName, IPrimitiveDatatype<?> theIdDt) throws IOException {
 		if (theIdDt != null && !theIdDt.isEmpty()) {
 			write(theEventWriter, theElementName, theIdDt.getValueAsString());
 		} else {
-			theEventWriter.name(theElementName);
-			theEventWriter.nullValue();
+			theEventWriter.writeNull(theElementName);
 		}
 	}
 
-	private void writeTagWithTextNode(JsonWriter theEventWriter, String theElementName, StringDt theStringDt) throws IOException {
+	private void writeTagWithTextNode(JsonLikeWriter theEventWriter, String theElementName, StringDt theStringDt) throws IOException {
 		if (StringUtils.isNotBlank(theStringDt.getValue())) {
 			write(theEventWriter, theElementName, theStringDt.getValue());
 		}
@@ -1557,10 +1695,9 @@ public class JsonParser extends BaseParser implements IParser {
 		Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 		return gson;
 	}
-
-	private static void write(JsonWriter theWriter, String theName, String theValue) throws IOException {
-		theWriter.name(theName);
-		theWriter.value(theValue);
+	
+	private static void write(JsonLikeWriter theWriter, String theName, String theValue) throws IOException {
+		theWriter.write(theName, theValue);
 	}
 	
 	private class HeldExtension implements Comparable<HeldExtension> {
@@ -1595,7 +1732,7 @@ public class JsonParser extends BaseParser implements IParser {
 			return url1.compareTo(url2);
 		}
 
-		public void write(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonWriter theEventWriter) throws IOException {
+		public void write(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonLikeWriter theEventWriter) throws IOException {
 			if (myUndeclaredExtension != null) {
 				writeUndeclaredExtension(theResDef, theResource, theEventWriter, myUndeclaredExtension);
 			} else {
@@ -1627,7 +1764,7 @@ public class JsonParser extends BaseParser implements IParser {
 		}
 
 		
-		private void writeUndeclaredExtension(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonWriter theEventWriter, IBaseExtension<?, ?> ext) throws IOException {
+		private void writeUndeclaredExtension(RuntimeResourceDefinition theResDef, IBaseResource theResource, JsonLikeWriter theEventWriter, IBaseExtension<?, ?> ext) throws IOException {
 			IBase value = ext.getValue();
 			String extensionUrl = ext.getUrl();
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/GsonStructure.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/GsonStructure.java
@@ -1,0 +1,389 @@
+package ca.uhn.fhir.parser.json;
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.PushbackReader;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import ca.uhn.fhir.parser.DataFormatException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
+
+public class GsonStructure implements JsonLikeStructure {
+
+	private enum ROOT_TYPE {OBJECT, ARRAY};
+	private ROOT_TYPE rootType = null;
+	private JsonElement nativeRoot = null;
+	private JsonLikeValue jsonLikeRoot = null;
+	private GsonWriter jsonLikeWriter = null;
+	
+	public GsonStructure() {
+		super();
+	}
+	
+	public GsonStructure (JsonObject json) {
+		super();
+		setNativeObject(json);
+	}
+	public GsonStructure (JsonArray json) {
+		super();
+		setNativeArray(json);
+	}
+	
+	public void setNativeObject (JsonObject json) {
+		this.rootType = ROOT_TYPE.OBJECT;
+		this.nativeRoot = json;
+	}
+	public void setNativeArray (JsonArray json) {
+		this.rootType = ROOT_TYPE.ARRAY;
+		this.nativeRoot = json;
+	}
+
+	@Override
+	public JsonLikeStructure getInstance() {
+		return new GsonStructure();
+	}
+
+	@Override
+	public void load(Reader theReader) throws DataFormatException {
+		this.load(theReader, false);		
+	}
+
+	@Override
+	public void load(Reader theReader, boolean allowArray) throws DataFormatException {
+		PushbackReader pbr = new PushbackReader(theReader);
+		int nextInt;
+		try {
+			while(true) {
+					nextInt = pbr.read();
+				if (nextInt == -1) {
+					throw new DataFormatException("Did not find any content to parse");
+				}
+				if (nextInt == '{') {
+					pbr.unread(nextInt);
+					break;
+				}
+				if (Character.isWhitespace(nextInt)) {
+					continue;
+				}
+				if (allowArray) {
+					if (nextInt == '[') {
+						pbr.unread(nextInt);
+						break;
+					}
+					throw new DataFormatException("Content does not appear to be FHIR JSON, first non-whitespace character was: '" + (char)nextInt + "' (must be '{' or '[')");
+				}
+				throw new DataFormatException("Content does not appear to be FHIR JSON, first non-whitespace character was: '" + (char)nextInt + "' (must be '{')");
+			}
+		
+			Gson gson = new GsonBuilder().disableHtmlEscaping().create();
+			if (nextInt == '{') {
+				JsonObject root = gson.fromJson(pbr, JsonObject.class);
+				setNativeObject(root);
+			} else
+			if (nextInt == '[') {
+				JsonArray root = gson.fromJson(pbr, JsonArray.class);
+				setNativeArray(root);
+			}
+		} catch (JsonSyntaxException e) {
+			if (e.getMessage().startsWith("Unexpected char 39")) {
+				throw new DataFormatException("Failed to parse JSON encoded FHIR content: " + e.getMessage() + " - This may indicate that single quotes are being used as JSON escapes where double quotes are required", e);
+			}
+			throw new DataFormatException("Failed to parse JSON encoded FHIR content: " + e.getMessage(), e);
+		} catch (Exception e) {
+			throw new DataFormatException("Failed to parse JSON content, error was: " + e.getMessage(), e);
+		}
+	}
+
+	@Override
+	public JsonLikeWriter getJsonLikeWriter (Writer writer) {
+		if (null == jsonLikeWriter) {
+			jsonLikeWriter = new GsonWriter(writer);
+		}
+		return jsonLikeWriter;
+	}
+
+	@Override
+	public JsonLikeWriter getJsonLikeWriter () {
+		if (null == jsonLikeWriter) {
+			jsonLikeWriter = new GsonWriter();
+		}
+		return jsonLikeWriter;
+	}
+
+	@Override
+	public JsonLikeObject getRootObject() throws DataFormatException {
+		if (rootType == ROOT_TYPE.OBJECT) {
+			if (null == jsonLikeRoot) {
+				jsonLikeRoot = new GsonJsonObject((JsonObject)nativeRoot);
+			}
+			return jsonLikeRoot.getAsObject();
+		}
+		throw new DataFormatException("Content must be a valid JSON Object. It must start with '{'.");
+	}
+
+	@Override
+	public JsonLikeArray getRootArray() throws DataFormatException {
+		if (rootType == ROOT_TYPE.ARRAY) {
+			if (null == jsonLikeRoot) {
+				jsonLikeRoot = new GsonJsonArray((JsonArray)nativeRoot);
+			}
+			return jsonLikeRoot.getAsArray();
+		}
+		throw new DataFormatException("Content must be a valid JSON Array. It must start with '['.");
+	}
+
+	private static class GsonJsonObject extends JsonLikeObject {
+		private JsonObject nativeObject;
+		private Set<String> keySet = null;
+		private Map<String,JsonLikeValue> jsonLikeMap = new LinkedHashMap<String,JsonLikeValue>();
+		
+		public GsonJsonObject (JsonObject json) {
+			this.nativeObject = json;
+		}
+
+		@Override
+		public Object getValue() {
+			return null;
+		}
+
+		@Override
+		public Set<String> keySet() {
+			if (null == keySet) {
+				Set<Entry<String, JsonElement>> entrySet = nativeObject.entrySet();
+				keySet = new EntryOrderedSet<String>(entrySet.size());
+				for (Entry<String,?> entry : entrySet) {
+					keySet.add(entry.getKey());
+				}
+			}
+			return keySet;
+		}
+
+		@Override
+		public JsonLikeValue get(String key) {
+			JsonLikeValue result = null;
+			if (jsonLikeMap.containsKey(key)) {
+				result = jsonLikeMap.get(key); 
+			} else {
+				JsonElement child = nativeObject.get(key);
+				if (child != null) {
+					result = new GsonJsonValue(child);
+				}
+				jsonLikeMap.put(key, result);
+			}
+			return result;
+		}
+	}
+	
+	private static class GsonJsonArray extends JsonLikeArray {
+		private JsonArray nativeArray;
+		private Map<Integer,JsonLikeValue> jsonLikeMap = new LinkedHashMap<Integer,JsonLikeValue>();
+		
+		public GsonJsonArray (JsonArray json) {
+			this.nativeArray = json;
+		}
+
+		@Override
+		public Object getValue() {
+			return null;
+		}
+
+		@Override
+		public int size() {
+			return nativeArray.size();
+		}
+
+		@Override
+		public JsonLikeValue get(int index) {
+			Integer key = Integer.valueOf(index);
+			JsonLikeValue result = null;
+			if (jsonLikeMap.containsKey(key)) {
+				result = jsonLikeMap.get(key); 
+			} else {
+				JsonElement child = nativeArray.get(index);
+				if (child != null) {
+					result = new GsonJsonValue(child);
+				}
+				jsonLikeMap.put(key, result);
+			}
+			return result;
+		}
+	}
+	
+	private static class GsonJsonValue extends JsonLikeValue {
+		private JsonElement nativeValue;
+		private JsonLikeObject jsonLikeObject = null;
+		private JsonLikeArray jsonLikeArray = null;
+		
+		public GsonJsonValue (JsonElement json) {
+			this.nativeValue = json;
+		}
+
+		@Override
+		public Object getValue() {
+			if (nativeValue != null && nativeValue.isJsonPrimitive()) {
+				if (((JsonPrimitive)nativeValue).isNumber()) {
+					return nativeValue.getAsNumber();
+				}
+				if (((JsonPrimitive)nativeValue).isBoolean()) {
+					return Boolean.valueOf(nativeValue.getAsBoolean());
+				}
+				return nativeValue.getAsString();
+			}
+			return null;
+		}
+		
+		@Override
+		public ValueType getJsonType() {
+			if (null == nativeValue || nativeValue.isJsonNull()) {
+				return ValueType.NULL;
+			}
+			if (nativeValue.isJsonObject()) {
+				return ValueType.OBJECT;
+			}
+			if (nativeValue.isJsonArray()) {
+				return ValueType.ARRAY;
+			}
+			if (nativeValue.isJsonPrimitive()) {
+				return ValueType.SCALAR;
+			}
+			return null;
+		}
+		
+		@Override
+		public ScalarType getDataType() {
+			if (nativeValue != null && nativeValue.isJsonPrimitive()) {
+				if (((JsonPrimitive)nativeValue).isNumber()) {
+					return ScalarType.NUMBER;
+				}
+				if (((JsonPrimitive)nativeValue).isString()) {
+					return ScalarType.STRING;
+				}
+				if (((JsonPrimitive)nativeValue).isBoolean()) {
+					return ScalarType.BOOLEAN;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public JsonLikeArray getAsArray() {
+			if (nativeValue != null && nativeValue.isJsonArray()) {
+				if (null == jsonLikeArray) {
+					jsonLikeArray = new GsonJsonArray((JsonArray)nativeValue);
+				}
+			}
+			return jsonLikeArray;
+		}
+
+		@Override
+		public JsonLikeObject getAsObject() {
+			if (nativeValue != null && nativeValue.isJsonObject()) {
+				if (null == jsonLikeObject) {
+					jsonLikeObject = new GsonJsonObject((JsonObject)nativeValue);
+				}
+			}
+			return jsonLikeObject;
+		}
+
+		@Override
+		public Number getAsNumber() {
+			return nativeValue != null ? nativeValue.getAsNumber() : null;
+		}
+
+		@Override
+		public String getAsString() {
+			return nativeValue != null ? nativeValue.getAsString() : null;
+		}
+
+		@Override
+		public boolean getAsBoolean() {
+			if (nativeValue != null && nativeValue.isJsonPrimitive() && ((JsonPrimitive)nativeValue).isBoolean()) {
+				return nativeValue.getAsBoolean();
+			}
+			return super.getAsBoolean();
+		}
+	}
+	
+	private static class EntryOrderedSet<T> extends AbstractSet<T> {
+		private transient ArrayList<T> data = null;
+		
+		public EntryOrderedSet (int initialCapacity) {
+			data = new ArrayList<T>(initialCapacity);
+		}
+		@SuppressWarnings("unused")
+		public EntryOrderedSet () {
+			data = new ArrayList<T>();
+		}
+		
+		@Override
+		public int size() {
+			return data.size();
+		}
+
+		@Override
+		public boolean contains(Object o) {
+			return data.contains(o);
+		}
+
+		@SuppressWarnings("unused")  // not really.. just not here
+		public T get(int index) {
+			return data.get(index);
+		}
+		
+		@Override
+		public boolean add(T element) {
+			if (data.contains(element)) {
+				return false;
+			}
+			return data.add(element);
+		}
+		
+		@Override
+		public boolean remove(Object o) {
+			return data.remove(o);
+		}
+
+		@Override
+		public void clear() {
+			data.clear();
+		}
+		
+		@Override
+		public Iterator<T> iterator() {
+			return data.iterator();
+		}
+		
+	}
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/GsonWriter.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/GsonWriter.java
@@ -1,0 +1,263 @@
+package ca.uhn.fhir.parser.json;
+
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+import java.io.Writer;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Stack;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.stream.JsonWriter;
+
+public class GsonWriter extends JsonLikeWriter {
+	private static final Logger log = LoggerFactory.getLogger(GsonWriter.class);
+
+	private JsonWriter eventWriter;
+	private enum BlockType {
+		NONE, OBJECT, ARRAY
+	}
+	private BlockType blockType = BlockType.NONE;
+	private Stack<BlockType> blockStack = new Stack<BlockType>(); 
+
+	public GsonWriter () {
+		super();
+	}
+	public GsonWriter (Writer writer) {
+		setWriter(writer);
+	}
+
+	@Override
+	public JsonLikeWriter init() throws IOException {
+		eventWriter = new JsonWriter(getWriter());
+		eventWriter.setSerializeNulls(true);
+		if (isPrettyPrint()) {
+			eventWriter.setIndent("  ");
+		}
+		blockType = BlockType.NONE;
+		blockStack.clear();
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter flush() throws IOException {
+		if (blockType != BlockType.NONE) {
+			log.error("JsonLikeStreamWriter.flush() called but JSON document is not finished");
+		}
+		eventWriter.flush();
+		getWriter().flush();
+		return this;
+	}
+
+	@Override
+	public void close() throws IOException {
+		eventWriter.close();
+		getWriter().close();
+	}
+
+	@Override
+	public JsonLikeWriter beginObject() throws IOException {
+		blockStack.push(blockType);
+		blockType = BlockType.OBJECT;
+		eventWriter.beginObject();
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter beginArray() throws IOException {
+		blockStack.push(blockType);
+		blockType = BlockType.ARRAY;
+		eventWriter.beginArray();
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter beginObject(String name) throws IOException {
+		blockStack.push(blockType);
+		blockType = BlockType.OBJECT;
+		eventWriter.name(name);
+		eventWriter.beginObject();
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter beginArray(String name) throws IOException {
+		blockStack.push(blockType);
+		blockType = BlockType.ARRAY;
+		eventWriter.name(name);
+		eventWriter.beginArray();
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(String value) throws IOException {
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(BigInteger value) throws IOException {
+		eventWriter.value(value);
+		return this;
+	}
+	
+	@Override
+	public JsonLikeWriter write(BigDecimal value) throws IOException {
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(long value) throws IOException {
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(double value) throws IOException {
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(Boolean value) throws IOException {
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(boolean value) throws IOException {
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter writeNull() throws IOException {
+		eventWriter.nullValue();
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(String name, String value) throws IOException {
+		eventWriter.name(name);
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(String name, BigInteger value) throws IOException {
+		eventWriter.name(name);
+		eventWriter.value(value);
+		return this;
+	}
+	@Override
+	public JsonLikeWriter write(String name, BigDecimal value) throws IOException {
+		eventWriter.name(name);
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(String name, long value) throws IOException {
+		eventWriter.name(name);
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(String name, double value) throws IOException {
+		eventWriter.name(name);
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(String name, Boolean value) throws IOException {
+		eventWriter.name(name);
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter write(String name, boolean value) throws IOException {
+		eventWriter.name(name);
+		eventWriter.value(value);
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter writeNull(String name) throws IOException {
+		eventWriter.name(name);
+		eventWriter.nullValue();
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter endObject() throws IOException {
+		if (blockType == BlockType.NONE) {
+			log.error("JsonLikeStreamWriter.endObject(); called with no active JSON document");
+		} else {
+			if (blockType != BlockType.OBJECT) {
+				log.error("JsonLikeStreamWriter.endObject(); called outside a JSON object. (Use endArray() instead?)");
+				eventWriter.endArray();
+			} else {
+				eventWriter.endObject();
+			}
+			blockType = blockStack.pop();
+		}
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter endArray() throws IOException {
+		if (blockType == BlockType.NONE) {
+			log.error("JsonLikeStreamWriter.endArray(); called with no active JSON document");
+		} else {
+			if (blockType != BlockType.ARRAY) {
+				log.error("JsonLikeStreamWriter.endArray(); called outside a JSON array. (Use endObject() instead?)");
+				eventWriter.endObject();
+			} else {
+				eventWriter.endArray();
+			}
+			blockType = blockStack.pop();
+		}
+		return this;
+	}
+
+	@Override
+	public JsonLikeWriter endBlock() throws IOException {
+		if (blockType == BlockType.NONE) {
+			log.error("JsonLikeStreamWriter.endBlock(); called with no active JSON document");
+		} else {
+			if (blockType == BlockType.ARRAY) {
+				eventWriter.endArray();
+			} else {
+				eventWriter.endObject();
+			}
+			blockType = blockStack.pop();
+		}
+		return this;
+	}
+
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeArray.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeArray.java
@@ -1,0 +1,53 @@
+package ca.uhn.fhir.parser.json;
+
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public abstract class JsonLikeArray extends JsonLikeValue {
+
+	@Override
+	public ValueType getJsonType() {
+		return ValueType.ARRAY;
+	}
+	
+	@Override
+	public ScalarType getDataType() {
+		return null;
+	}
+
+	@Override
+	public boolean isArray() {
+		return true;
+	}
+
+	@Override
+	public JsonLikeArray getAsArray() {
+		return this;
+	}
+
+	@Override
+	public String getAsString() {
+		return null;
+	}
+
+	public abstract int size ();
+	
+	public abstract JsonLikeValue get (int index);
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeObject.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeObject.java
@@ -1,0 +1,72 @@
+package ca.uhn.fhir.parser.json;
+
+import java.util.Set;
+
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public abstract class JsonLikeObject extends JsonLikeValue {
+
+	@Override
+	public ValueType getJsonType() {
+		return ValueType.OBJECT;
+	}
+	
+	@Override
+	public ScalarType getDataType() {
+		return null;
+	}
+
+	@Override
+	public boolean isObject() {
+		return true;
+	}
+
+	@Override
+	public JsonLikeObject getAsObject() {
+		return this;
+	}
+
+	@Override
+	public String getAsString() {
+		return null;
+	}
+
+	public abstract Set<String> keySet ();
+	
+	public abstract JsonLikeValue get (String key);
+	
+	public String getString (String key) {
+		JsonLikeValue value = this.get(key);
+		if (null == value) {
+			throw new NullPointerException("Json object missing element named \""+key+"\"");
+		}
+		return value.getAsString();
+	}
+	
+	public String getString (String key, String defaultValue) {
+		String result = defaultValue;
+		JsonLikeValue value = this.get(key);
+		if (value != null) {
+			result = value.getAsString();
+		}
+		return result;
+	}
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeStructure.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeStructure.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.parser.json;
+
+import java.io.Reader;
+import java.io.Writer;
+
+import ca.uhn.fhir.parser.DataFormatException;
+
+/**
+ * This interface is the generic representation of any sort of data 
+ * structure that looks and smells like JSON. These data structures
+ * can be abstractly viewed as a <code.Map</code> or <code>List</code>
+ * whose members are other Maps, Lists, or scalars (Strings, Numbers, Boolean)
+ * 
+ * @author Bill.Denton
+ */
+public interface JsonLikeStructure {
+	public JsonLikeStructure getInstance();
+	
+	/**
+	 * Parse the JSON document into the Json-like structure
+	 * so that it can be navigated.
+	 * 
+	 * @param theReader a <code>Reader</code> that will
+	 * 			process the JSON input stream
+	 * @throws DataFormatException when invalid JSON is received
+	 */
+	public void load (Reader theReader) throws DataFormatException;
+	public void load (Reader theReader, boolean allowArray) throws DataFormatException;
+	public JsonLikeObject getRootObject () throws DataFormatException;
+	public JsonLikeArray getRootArray () throws DataFormatException;
+	public JsonLikeWriter getJsonLikeWriter ();
+	public JsonLikeWriter getJsonLikeWriter (Writer writer);
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeValue.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeValue.java
@@ -1,0 +1,228 @@
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package ca.uhn.fhir.parser.json;
+
+/**
+ * This is the generalization of anything that is a "value"
+ * element in a JSON structure. This could be a JSON object,
+ * a JSON array, a scalar value (number, string, boolean),
+ * or a null.
+ * 
+ */
+public abstract class JsonLikeValue {
+	
+	public enum ValueType {
+		ARRAY, OBJECT, SCALAR, NULL
+	};
+	
+	public enum ScalarType {
+		NUMBER, STRING, BOOLEAN
+	}
+	
+	public abstract ValueType getJsonType ();
+	
+	public abstract ScalarType getDataType ();
+	
+	public abstract Object getValue ();
+	
+	public boolean isArray () {
+		return this.getJsonType() == ValueType.ARRAY;
+	}
+	
+	public boolean isObject () {
+		return this.getJsonType() == ValueType.OBJECT;
+	}
+	
+	public boolean isScalar () {
+		return this.getJsonType() == ValueType.SCALAR;
+	}
+	
+	public boolean isString () {
+		return this.getJsonType() == ValueType.SCALAR && this.getDataType() == ScalarType.STRING;
+	}
+	
+	public boolean isNumber () {
+		return this.getJsonType() == ValueType.SCALAR && this.getDataType() == ScalarType.NUMBER;
+	}
+	
+	public boolean isNull () {
+		return this.getJsonType() == ValueType.NULL;
+	}
+	
+	public JsonLikeArray getAsArray () {
+		return null;
+	}
+	public JsonLikeObject getAsObject () {
+		return null;
+	}
+	public String getAsString () {
+		return this.toString();
+	}
+	public Number getAsNumber () {
+		return this.isNumber() ? (Number)this.getValue() : null;
+	}
+	public boolean getAsBoolean () {
+		return !isNull();
+	}
+	
+	public static JsonLikeArray asArray (JsonLikeValue element) {
+		if (element != null) {
+			return element.getAsArray();
+		}
+		return null;
+	}
+	public static JsonLikeObject asObject (JsonLikeValue element) {
+		if (element != null) {
+			return element.getAsObject();
+		}
+		return null;
+	}
+	public static String asString (JsonLikeValue element) {
+		if (element != null) {
+			return element.getAsString();
+		}
+		return null;
+	}
+	public static boolean asBoolean (JsonLikeValue element) {
+		if (element != null) {
+			return element.getAsBoolean();
+		}
+		return false;
+	}
+	
+
+    public static final JsonLikeValue NULL = new JsonLikeValue() {
+        @Override
+        public ValueType getJsonType() {
+            return ValueType.NULL;
+        }
+
+        @Override
+		public ScalarType getDataType() {
+			return null;
+		}
+
+		@Override
+		public Object getValue() {
+			 return null;
+		}
+
+		@Override
+        public boolean equals (Object obj) {
+            if (this == obj){
+                return true;
+            }
+            if (obj instanceof JsonLikeValue) {
+                return getJsonType().equals(((JsonLikeValue)obj).getJsonType());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return "null".hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "null";
+        }
+    };
+
+    public static final JsonLikeValue TRUE = new JsonLikeValue() {
+        @Override
+        public ValueType getJsonType() {
+        	return ValueType.SCALAR;
+        }
+        
+        @Override
+        public ScalarType getDataType() {
+            return ScalarType.BOOLEAN;
+        }
+
+		  @Override
+		  public Object getValue() {
+			   return Boolean.TRUE;
+		  }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj){
+                return true;
+            }
+            if (obj instanceof JsonLikeValue) {
+                return getJsonType().equals(((JsonLikeValue)obj).getJsonType())
+                	&& getDataType().equals(((JsonLikeValue)obj).getDataType())
+                	&& toString().equals(((JsonLikeValue)obj).toString());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return "true".hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "true";
+        }
+    };
+
+    public static final JsonLikeValue FALSE = new JsonLikeValue() {
+        @Override
+        public ValueType getJsonType() {
+        	return ValueType.SCALAR;
+        }
+        
+        @Override
+        public ScalarType getDataType() {
+            return ScalarType.BOOLEAN;
+        }
+
+		  @Override
+		  public Object getValue() {
+			   return Boolean.FALSE;
+		  }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj){
+                return true;
+            }
+            if (obj instanceof JsonLikeValue) {
+                return getJsonType().equals(((JsonLikeValue)obj).getJsonType())
+                    	&& getDataType().equals(((JsonLikeValue)obj).getDataType())
+                    	&& toString().equals(((JsonLikeValue)obj).toString());
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return "false".hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "false";
+        }
+    };
+}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeWriter.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/json/JsonLikeWriter.java
@@ -1,0 +1,83 @@
+package ca.uhn.fhir.parser.json;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/*
+ * #%L
+ * HAPI FHIR - Core Library
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public abstract class JsonLikeWriter {
+
+	private boolean prettyPrint;
+	private Writer writer;
+	
+	public void setPrettyPrint (boolean tf) {
+		prettyPrint = tf; 
+	}
+	public boolean isPrettyPrint () {
+		return prettyPrint;
+	}
+	
+	public void setWriter (Writer writer) {
+		this.writer = writer;
+	}
+	public Writer getWriter () {
+		return writer;
+	}
+	
+	public abstract JsonLikeWriter init () throws IOException;
+	public abstract JsonLikeWriter flush () throws IOException;
+	public abstract void close () throws IOException;
+	
+	public abstract JsonLikeWriter beginObject () throws IOException;
+	public abstract JsonLikeWriter beginArray () throws IOException;
+
+	public abstract JsonLikeWriter beginObject (String name) throws IOException;
+	public abstract JsonLikeWriter beginArray (String name) throws IOException;
+	
+	public abstract JsonLikeWriter write (String value) throws IOException;
+	public abstract JsonLikeWriter write (BigInteger value) throws IOException;
+	public abstract JsonLikeWriter write (BigDecimal value) throws IOException;
+	public abstract JsonLikeWriter write (long value) throws IOException;
+	public abstract JsonLikeWriter write (double value) throws IOException;
+	public abstract JsonLikeWriter write (Boolean value) throws IOException;
+	public abstract JsonLikeWriter write (boolean value) throws IOException;
+	public abstract JsonLikeWriter writeNull () throws IOException;
+	
+	public abstract JsonLikeWriter write (String name, String value) throws IOException;
+	public abstract JsonLikeWriter write (String name, BigInteger value) throws IOException;
+	public abstract JsonLikeWriter write (String name, BigDecimal value) throws IOException;
+	public abstract JsonLikeWriter write (String name, long value) throws IOException;
+	public abstract JsonLikeWriter write (String name, double value) throws IOException;
+	public abstract JsonLikeWriter write (String name, Boolean value) throws IOException;
+	public abstract JsonLikeWriter write (String name, boolean value) throws IOException;
+	public abstract JsonLikeWriter writeNull (String name) throws IOException;
+
+	public abstract JsonLikeWriter endObject () throws IOException;
+	public abstract JsonLikeWriter endArray () throws IOException;
+	public abstract JsonLikeWriter endBlock () throws IOException;
+	
+	public JsonLikeWriter() {
+		super();
+	}
+
+}

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/parser/json/JsonLikeStructureTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/parser/json/JsonLikeStructureTest.java
@@ -1,0 +1,145 @@
+package ca.uhn.fhir.parser.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.StringReader;
+
+import org.junit.Test;
+
+import ca.uhn.fhir.context.FhirContext;
+
+public class JsonLikeStructureTest {
+	private static FhirContext ourCtx;
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(JsonLikeStructureTest.class);
+
+	private static final String TEST_STRUCTURELOADING_DATA = 
+		"{" +
+		"    \"resourceType\":\"Organization\"," +
+		"    \"id\":\"11111\"," +
+		"    \"meta\":{" +
+		"        \"lastUpdated\":\"3900-09-20T10:10:10.000-07:00\"" +
+		"    }," +
+		"    \"identifier\":[" +
+		"        {" +
+		"            \"value\":\"15250\"" +
+		"        }" +
+		"    ]," +
+		"    \"type\":{" +
+		"        \"coding\":[" +
+		"            {" +
+		"                \"system\":\"http://test\"," +
+		"                \"code\":\"ins\"," +
+		"                \"display\":\"General Ledger System\"," +
+		"                \"userSelected\":false" +
+		"            }" +
+		"        ]" +
+		"    }," +
+		"    \"name\":\"Acme Investments\"" +
+		"}";
+
+	@Test
+	public void testStructureLoading() {
+		StringReader reader = new StringReader(TEST_STRUCTURELOADING_DATA);
+		JsonLikeStructure jsonStructure = new GsonStructure();
+		jsonStructure.load(reader);
+		
+		JsonLikeObject rootObject = jsonStructure.getRootObject();
+		
+		assertNotNull(rootObject);
+		assertEquals(JsonLikeValue.ValueType.OBJECT, rootObject.getJsonType());
+	}
+
+	private static final String TEST_JSONTYPES_DATA = 
+			"{" +
+			"    \"scalar-string\":\"A scalar string\"," +
+			"    \"scalar-number\":11111," +
+			"    \"scalar-boolean\":true," +
+			"    \"null-value\":null," +
+			"    \"object-value\":{" +
+			"        \"lastUpdated\":\"3900-09-20T10:10:10.000-07:00\"," +
+			"        \"deleted\":\"3909-09-20T10:10:10.000-07:00\"" +
+			"    }," +
+			"    \"array-value\":[" +
+			"        12345," +
+			"        {" +
+			"            \"value\":\"15250\"" +
+			"        }" +
+			"    ]" +
+			"}";
+
+
+	@Test
+	public void testJsonAndDataTypes() {
+		StringReader reader = new StringReader(TEST_JSONTYPES_DATA);
+		JsonLikeStructure jsonStructure = new GsonStructure();
+		jsonStructure.load(reader);
+		
+		JsonLikeObject rootObject = jsonStructure.getRootObject();
+		
+		assertNotNull(rootObject);
+		
+		JsonLikeValue value = rootObject.get("object-value");
+		assertNotNull(value);
+		assertEquals(JsonLikeValue.ValueType.OBJECT, value.getJsonType());
+		assertEquals(true, value.isObject());
+		assertEquals(false, value.isArray());
+		assertEquals(false, value.isScalar());
+		assertEquals(false, value.isNull());
+
+		JsonLikeObject obj = value.getAsObject();
+		assertNotNull(obj);
+		assertEquals(JsonLikeValue.ValueType.OBJECT, obj.getJsonType());
+		assertEquals(true, obj.isObject());
+		assertEquals(false, obj.isArray());
+		assertEquals(false, obj.isScalar());
+		assertEquals(false, obj.isNull());
+		
+		value = rootObject.get("array-value");
+		assertNotNull(value);
+		assertEquals(JsonLikeValue.ValueType.ARRAY, value.getJsonType());
+		assertEquals(false, value.isObject());
+		assertEquals(true, value.isArray());
+		assertEquals(false, value.isScalar());
+		assertEquals(false, value.isNull());
+
+		JsonLikeArray array = value.getAsArray();
+		assertNotNull(array);
+		assertEquals(JsonLikeValue.ValueType.ARRAY, array.getJsonType());
+		assertEquals(false, array.isObject());
+		assertEquals(true, array.isArray());
+		assertEquals(false, array.isScalar());
+		assertEquals(false, array.isNull());
+
+		value = rootObject.get("null-value");
+		assertNotNull(value);
+		assertEquals(JsonLikeValue.ValueType.NULL, value.getJsonType());
+		assertEquals(false, value.isObject());
+		assertEquals(false, value.isArray());
+		assertEquals(false, value.isScalar());
+		assertEquals(true, value.isNull());
+
+		value = rootObject.get("scalar-string");
+		assertNotNull(value);
+		assertEquals(JsonLikeValue.ValueType.SCALAR, value.getJsonType());
+		assertEquals(false, value.isObject());
+		assertEquals(false, value.isArray());
+		assertEquals(true, value.isScalar());
+		assertEquals(false, value.isNull());
+		assertEquals(JsonLikeValue.ScalarType.STRING, value.getDataType());
+		assertEquals(value.getAsString(), "A scalar string");
+
+		value = rootObject.get("scalar-number");
+		assertNotNull(value);
+		assertEquals(JsonLikeValue.ValueType.SCALAR, value.getJsonType());
+		assertEquals(JsonLikeValue.ScalarType.NUMBER, value.getDataType());
+		assertEquals(value.getAsString(), "11111");
+
+		value = rootObject.get("scalar-boolean");
+		assertNotNull(value);
+		assertEquals(JsonLikeValue.ValueType.SCALAR, value.getJsonType());
+		assertEquals(JsonLikeValue.ScalarType.BOOLEAN, value.getDataType());
+		assertEquals(value.getAsString(), "true");
+	}
+
+}

--- a/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/parser/jsonlike/JsonLikeParserTest.java
+++ b/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/parser/jsonlike/JsonLikeParserTest.java
@@ -1,0 +1,226 @@
+package ca.uhn.fhir.parser.jsonlike;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.Bundle;
+import ca.uhn.fhir.model.api.BundleEntry;
+import ca.uhn.fhir.model.api.TagList;
+import ca.uhn.fhir.model.dstu.resource.DiagnosticReport;
+import ca.uhn.fhir.model.dstu.resource.Patient;
+import ca.uhn.fhir.parser.DataFormatException;
+import ca.uhn.fhir.parser.IJsonLikeParser;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.parser.JsonParser;
+import ca.uhn.fhir.parser.StrictErrorHandler;
+import ca.uhn.fhir.parser.XmlParser;
+import ca.uhn.fhir.parser.json.GsonStructure;
+import ca.uhn.fhir.parser.json.JsonLikeStructure;
+import ca.uhn.fhir.parser.json.JsonLikeWriter;
+import ca.uhn.fhir.util.TestUtil;
+import net.sf.json.JSON;
+import net.sf.json.JSONSerializer;
+
+public class JsonLikeParserTest {
+	private static FhirContext ourCtx;
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(JsonLikeParserTest.class);
+
+	@Test
+	public void testJsonLikeSimpleBundleEncode() throws InterruptedException, IOException {
+		String xmlString = IOUtils.toString(JsonParser.class.getResourceAsStream("/atom-document-large.xml"), Charset.forName("UTF-8"));
+		Bundle obs = ourCtx.newXmlParser().parseBundle(xmlString);
+
+		IJsonLikeParser jsonLikeParser = (IJsonLikeParser)ourCtx.newJsonParser().setPrettyPrint(true);
+		StringWriter stringWriter = new StringWriter();
+		JsonLikeStructure jsonLikeStructure = new GsonStructure();
+		JsonLikeWriter jsonLikeWriter = jsonLikeStructure.getJsonLikeWriter(stringWriter);
+		jsonLikeParser.encodeBundleToJsonLikeWriter(obs, jsonLikeWriter);
+		String encoded = stringWriter.toString();
+		ourLog.info(encoded);
+	}
+
+	@Test
+	public void testJsonLikeSimpleResourceEncode() throws IOException {
+
+		String xmlString = IOUtils.toString(JsonParser.class.getResourceAsStream("/example-patient-general.xml"), Charset.forName("UTF-8"));
+		IParser parser = ourCtx.newXmlParser();
+		parser.setParserErrorHandler(new StrictErrorHandler());
+		Patient obs = parser.parseResource(Patient.class, xmlString);
+
+		IJsonLikeParser jsonLikeParser = (IJsonLikeParser)ourCtx.newJsonParser();
+		StringWriter stringWriter = new StringWriter();
+		JsonLikeStructure jsonLikeStructure = new GsonStructure();
+		JsonLikeWriter jsonLikeWriter = jsonLikeStructure.getJsonLikeWriter(stringWriter);
+		jsonLikeParser.encodeResourceToJsonLikeWriter(obs, jsonLikeWriter);
+		String encoded = stringWriter.toString();
+		ourLog.info(encoded);
+
+		String jsonString = IOUtils.toString(JsonParser.class.getResourceAsStream("/example-patient-general.json"), Charset.forName("UTF-8"));
+
+		JSON expected = JSONSerializer.toJSON(jsonString);
+		JSON actual = JSONSerializer.toJSON(encoded.trim());
+
+		// The encoded escapes quote marks using XML escaping instead of JSON escaping, which is probably nicer anyhow...
+		String exp = expected.toString().replace("\\\"Jim\\\"", "&quot;Jim&quot;");
+		String act = actual.toString();
+
+		ourLog.info("Expected: {}", exp);
+		ourLog.info("Actual  : {}", act);
+		assertEquals("\nExpected: " + exp + "\nActual  : " + act, exp, act);
+
+	}
+	
+	@Test
+	public void testJsonLikeSimpleResourceParse() throws DataFormatException, IOException {
+
+		String msg = IOUtils.toString(XmlParser.class.getResourceAsStream("/example-patient-general.json"));
+
+		IJsonLikeParser jsonLikeParser = (IJsonLikeParser)ourCtx.newJsonParser().setPrettyPrint(true);
+		StringReader reader = new StringReader(msg);
+		JsonLikeStructure jsonLikeStructure = new GsonStructure();
+		jsonLikeStructure.load(reader);
+		
+		Patient res = jsonLikeParser.parseResource(Patient.class, jsonLikeStructure);
+
+		assertEquals(2, res.getUndeclaredExtensions().size());
+		assertEquals(1, res.getUndeclaredModifierExtensions().size());
+
+	}
+	
+	@Test
+	public void testJsonLikeParseBundle() throws DataFormatException, IOException {
+
+		String msg = IOUtils.toString(XmlParser.class.getResourceAsStream("/atom-document-large.json"));
+
+		IJsonLikeParser jsonLikeParser = (IJsonLikeParser)ourCtx.newJsonParser().setPrettyPrint(true);
+		StringReader reader = new StringReader(msg);
+		JsonLikeStructure jsonLikeStructure = new GsonStructure();
+		jsonLikeStructure.load(reader);
+		
+		Bundle bundle = jsonLikeParser.parseBundle(jsonLikeStructure);
+		
+		assertEquals(1, bundle.getCategories().size());
+		assertEquals("http://scheme", bundle.getCategories().get(0).getScheme());
+		assertEquals("http://term", bundle.getCategories().get(0).getTerm());
+		assertEquals("label", bundle.getCategories().get(0).getLabel());
+
+		String encoded = ourCtx.newXmlParser().setPrettyPrint(true).encodeBundleToString(bundle);
+		ourLog.info(encoded);
+
+		assertEquals("http://fhir.healthintersections.com.au/open/DiagnosticReport/_search?_format=application/json+fhir&search-id=46d5f0e7-9240-4d4f-9f51-f8ac975c65&search-sort=_id",
+				bundle.getLinkSelf().getValue());
+		assertEquals("urn:uuid:0b754ff9-03cf-4322-a119-15019af8a3", bundle.getBundleId().getValue());
+
+		BundleEntry entry = bundle.getEntries().get(0);
+		assertEquals("http://fhir.healthintersections.com.au/open/DiagnosticReport/101", entry.getId().getValue());
+		assertEquals("http://fhir.healthintersections.com.au/open/DiagnosticReport/101/_history/1", entry.getLinkSelf().getValue());
+		assertEquals("2014-03-10T11:55:59Z", entry.getUpdated().getValueAsString());
+
+		DiagnosticReport res = (DiagnosticReport) entry.getResource();
+		assertEquals("Complete Blood Count", res.getName().getText().getValue());
+
+		assertThat(entry.getSummary().getValueAsString(), containsString("CBC Report for Wile"));
+
+	}
+
+	@Test
+	public void testJsonLikeTagList() throws IOException {
+
+		//@formatter:off
+		String tagListStr = "{\n" + 
+				"  \"resourceType\" : \"TagList\", " + 
+				"  \"category\" : [" + 
+				"    { " + 
+				"      \"term\" : \"term0\", " + 
+				"      \"label\" : \"label0\", " + 
+				"      \"scheme\" : \"scheme0\" " + 
+				"    }," +
+				"    { " + 
+				"      \"term\" : \"term1\", " + 
+				"      \"label\" : \"label1\", " + 
+				"      \"scheme\" : null " + 
+				"    }," +
+				"    { " + 
+				"      \"term\" : \"term2\", " + 
+				"      \"label\" : \"label2\" " + 
+				"    }" +
+				"  ] " + 
+				"}";
+		//@formatter:on
+
+		IJsonLikeParser jsonLikeParser = (IJsonLikeParser)ourCtx.newJsonParser().setPrettyPrint(true);
+		StringReader reader = new StringReader(tagListStr);
+		JsonLikeStructure jsonLikeStructure = new GsonStructure();
+		jsonLikeStructure.load(reader);
+		
+		TagList tagList = jsonLikeParser.parseTagList(jsonLikeStructure);
+		assertEquals(3, tagList.size());
+		assertEquals("term0", tagList.get(0).getTerm());
+		assertEquals("label0", tagList.get(0).getLabel());
+		assertEquals("scheme0", tagList.get(0).getScheme());
+		assertEquals("term1", tagList.get(1).getTerm());
+		assertEquals("label1", tagList.get(1).getLabel());
+		assertEquals(null, tagList.get(1).getScheme());
+		assertEquals("term2", tagList.get(2).getTerm());
+		assertEquals("label2", tagList.get(2).getLabel());
+		assertEquals(null, tagList.get(2).getScheme());
+
+		/*
+		 * Encode
+		 */
+
+		//@formatter:off
+		String expected = "{" + 
+				"\"resourceType\":\"TagList\"," + 
+				"\"category\":[" + 
+				"{" + 
+				"\"term\":\"term0\"," + 
+				"\"label\":\"label0\"," + 
+				"\"scheme\":\"scheme0\"" + 
+				"}," +
+				"{" + 
+				"\"term\":\"term1\"," + 
+				"\"label\":\"label1\"" + 
+				"}," +
+				"{" + 
+				"\"term\":\"term2\"," + 
+				"\"label\":\"label2\"" + 
+				"}" +
+				"]" + 
+				"}";
+		//@formatter:on
+
+		jsonLikeParser = (IJsonLikeParser)ourCtx.newJsonParser();
+		StringWriter stringWriter = new StringWriter();
+		jsonLikeStructure = new GsonStructure();
+		JsonLikeWriter jsonLikeWriter = jsonLikeStructure.getJsonLikeWriter(stringWriter);
+		jsonLikeParser.encodeTagListToJsonLikeWriter(tagList, jsonLikeWriter);
+		String encoded = stringWriter.toString();
+		assertEquals(expected, encoded);
+
+	}
+	
+
+	@BeforeClass
+	public static void beforeClass() {
+		ourCtx = FhirContext.forDstu1();
+	}
+
+	@AfterClass
+	public static void afterClassClearContext() {
+		TestUtil.clearAllStaticFieldsForUnitTest();
+	}
+
+}

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/parser/JsonParserDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/parser/JsonParserDstu2Test.java
@@ -1688,7 +1688,7 @@ public class JsonParserDstu2Test {
 			ourCtx.newJsonParser().parseResource(Conformance.class, input);
 			fail();
 		} catch (DataFormatException e) {
-			assertEquals("Syntax error parsing JSON FHIR structure: Expected ARRAY at element 'modifierExtension', found 'JsonObject'", e.getMessage());
+			assertEquals("Syntax error parsing JSON FHIR structure: Expected ARRAY at element 'modifierExtension', found 'OBJECT'", e.getMessage());
 		}
 	}
 

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/parser/jsonlike/JsonLikeParserDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/parser/jsonlike/JsonLikeParserDstu2Test.java
@@ -1,0 +1,44 @@
+package ca.uhn.fhir.parser.jsonlike;
+
+import java.io.StringReader;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IJsonLikeParser;
+import ca.uhn.fhir.parser.json.GsonStructure;
+import ca.uhn.fhir.parser.json.JsonLikeStructure;
+import ca.uhn.fhir.util.TestUtil;
+
+public class JsonLikeParserDstu2Test {
+	private static FhirContext ourCtx = FhirContext.forDstu2();
+	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(JsonLikeParserDstu2Test.class);
+
+	/**
+	 * Test for #146
+	 */
+	@Test
+	public void testJsonLikeParseAndEncodeBundleFromXmlToJson() throws Exception {
+		String content = IOUtils.toString(JsonLikeParserDstu2Test.class.getResourceAsStream("/bundle-example2.xml"));
+
+		ca.uhn.fhir.model.dstu2.resource.Bundle parsed = ourCtx.newXmlParser().parseResource(ca.uhn.fhir.model.dstu2.resource.Bundle.class, content);
+
+		String encoded = ourCtx.newJsonParser().setPrettyPrint(true).encodeResourceToString(parsed);
+		ourLog.info(encoded);
+		
+		JsonLikeStructure jsonLikeStructure = new GsonStructure();
+		jsonLikeStructure.load(new StringReader(encoded));
+		
+		IJsonLikeParser jsonLikeparser = (IJsonLikeParser)ourCtx.newJsonParser();
+		
+		ca.uhn.fhir.model.dstu2.resource.Bundle bundle = jsonLikeparser.parseResource(ca.uhn.fhir.model.dstu2.resource.Bundle.class, jsonLikeStructure);
+		
+	}
+	
+	@AfterClass
+	public static void afterClassClearContext() {
+		TestUtil.clearAllStaticFieldsForUnitTest();
+	}
+}


### PR DESCRIPTION
(resubmitting after recovering my branch from a couple of bad merges)

This enhancement addresses the need to be able to serialize FHIR resources to and from streams other that Json-P or Gson. Here are two examples:

1) When building an equivalent of the jpaserver implemented in native MongoDB (no JPA or JDO), it was necessary to be able to serialize/deserialize FHIR resources via BSONReader and BSONWriter. This is possible (with some pain) with Json-P but is not at all possible with Gson.

2) We have built a general purpose data mapping engine that is able to map from a set of customer/application-specific sets of data into FHIR resources. The output of this mapping engine is a JSON-like data structure implemented in Java Maps, Lists, and scalars.

This pull request extends the IParser interface and updates the JSONParser to implement the sub-interface so that any sort of Json-like data structure or framework can be integrated in the future.
