### PR TITLE
#516 Report invalid values for enums through parser error handler

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/ParserState.java
@@ -2309,7 +2309,11 @@ class ParserState<T> {
 				if ("".equals(theValue)) {
 					myErrorHandler.invalidValue(null, theValue, "Attribute values must not be empty (\"\")");
 				} else {
-					myInstance.setValueAsString(theValue);
+					try {
+						myInstance.setValueAsString(theValue);
+					} catch (IllegalArgumentException e) {
+						myErrorHandler.invalidValue(null, theValue, e.getMessage());
+					}
 				}
 			} else if ("id".equals(theName)) {
 				if (myInstance instanceof IIdentifiableElement) {

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/JsonParserDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/JsonParserDstu3Test.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Sets;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
+import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.parser.IParserErrorHandler.IParseLocation;
 import ca.uhn.fhir.parser.PatientWithExtendedContactDstu3.CustomContactComponent;
 import ca.uhn.fhir.parser.XmlParserDstu3Test.TestPatientFor327;
@@ -1192,6 +1193,18 @@ public class JsonParserDstu3Test {
 		ourLog.info(str);
 		assertEquals("{\"resourceType\":\"Observation\",\"valueQuantity\":{\"value\":0.0000000000000001}}", str);
 	}
+
+        /**
+         * #516
+         */
+        @Test(expected=DataFormatException.class)
+        public void testInvalidEnumValue() {
+                String res = "{ \"resourceType\": \"ValueSet\", \"url\": \"http://sample/ValueSet/education-levels\", \"version\": \"1\", \"name\": \"Education Levels\", \"status\": \"draft\", \"compose\": { \"include\": [ { \"filter\": [ { \"property\": \"n\", \"op\": \"n\", \"value\": \"365460000\" } ], \"system\": \"http://snomed.info/sct\" } ], \"exclude\": [ { \"concept\": [ { \"code\": \"224298008\" }, { \"code\": \"365460000\" }, { \"code\": \"473462005\" }, { \"code\": \"424587006\" } ], \"system\": \"http://snomed.info/sct\" } ] }, \"description\": \"A selection of Education Levels\", \"text\": { \"status\": \"generated\", \"div\": \"<div xmlns=\\\"http://www.w3.org/1999/xhtml\\\"><h2>Education Levels</h2><tt>http://csiro.au/ValueSet/education-levels</tt><p>A selection of Education Levels</p></div>\" }, \"experimental\": true, \"date\": \"2016-07-26\" }";
+                IParser parser = ourCtx.newJsonParser();
+                parser.setParserErrorHandler(new StrictErrorHandler());
+                ValueSet parsed = parser.parseResource(ValueSet.class, res);
+                fail("DataFormat Invalid attribute exception should be thrown");
+        }
 
 	/**
 	 * #65


### PR DESCRIPTION
This patch catches the low-level IllegalArgumentException from the model code and instead reports an invalidValue through the parser's error handler.
Unit test included