### PR TITLE
Full resource/composite Tinder model with generic templates

### DIFF
--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/AbstractGenerator.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/AbstractGenerator.java
@@ -1,0 +1,229 @@
+package ca.uhn.fhir.tinder;
+/*
+ * #%L
+ * HAPI FHIR Tinder Plug-In
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeSet;
+
+import org.apache.maven.plugin.MojoFailureException;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.context.FhirVersionEnum;
+import ca.uhn.fhir.tinder.GeneratorContext.ProfileFileDefinition;
+import ca.uhn.fhir.tinder.parser.DatatypeGeneratorUsingSpreadsheet;
+import ca.uhn.fhir.tinder.parser.ProfileParser;
+import ca.uhn.fhir.tinder.parser.ResourceGeneratorUsingSpreadsheet;
+
+public abstract class AbstractGenerator {
+
+	protected abstract void logInfo (String message);
+	protected abstract void logDebug (String message);
+	
+	public void prepare (GeneratorContext context) throws ExecutionException, FailureException {
+
+		/*
+		 * Deal with the FHIR spec version
+		 */
+		FhirContext fhirContext;
+		String packageSuffix = "";
+		if ("dstu".equals(context.getVersion())) {
+			fhirContext = FhirContext.forDstu1();
+		} else if ("dstu2".equals(context.getVersion())) {
+			fhirContext = FhirContext.forDstu2();
+		} else if ("dstu3".equals(context.getVersion())) {
+			fhirContext = FhirContext.forDstu3();
+			packageSuffix = ".dstu3";
+		} else {
+			throw new FailureException("Unknown version configured: " + context.getVersion());
+		}
+		context.setPackageSuffix(packageSuffix);
+		
+		/*
+		 * Deal with which resources to process
+		 */
+		List<String> includeResources = context.getIncludeResources();
+		List<String> excludeResources = context.getExcludeResources();
+		
+		if (includeResources == null || includeResources.isEmpty()) {
+			includeResources = new ArrayList<String>();
+			
+			logInfo("No resource names supplied, going to use all resources from version: "+fhirContext.getVersion().getVersion());
+			
+			Properties p = new Properties();
+			try {
+				p.load(fhirContext.getVersion().getFhirVersionPropertiesFile());
+			} catch (IOException e) {
+				throw new FailureException("Failed to load version property file", e);
+			}
+
+			logDebug("Property file contains: "+p);
+
+			TreeSet<String> keys = new TreeSet<String>();
+			for(Object next : p.keySet()) {
+				keys.add((String) next);
+			}
+			for (String next : keys) {
+				if (next.startsWith("resource.")) {
+					includeResources.add(next.substring("resource.".length()).toLowerCase());
+				}
+			}
+			
+			/*
+			 * No spreadsheet existed for Binary in DSTU1 so we don't generate it.. this
+			 * is something we could work around, but at this point why bother since it's 
+			 * only an issue for DSTU1
+			 */
+			if (fhirContext.getVersion().getVersion() == FhirVersionEnum.DSTU1) {
+				includeResources.remove("binary");
+			}
+			if (fhirContext.getVersion().getVersion() == FhirVersionEnum.DSTU3) {
+				includeResources.remove("conformance");
+			}
+		}
+
+		for (int i = 0; i < includeResources.size(); i++) {
+			includeResources.set(i, includeResources.get(i).toLowerCase());
+		}
+
+		if (excludeResources != null) {
+			for (int i = 0; i < excludeResources.size(); i++) {
+				excludeResources.set(i, excludeResources.get(i).toLowerCase());
+			}
+			includeResources.removeAll(excludeResources);
+		}
+		context.setIncludeResources(includeResources);
+		
+		logInfo("Including the following elements: "+includeResources);
+		
+
+		/*
+		 * Fill in ValueSet and DataTypes used by the resources
+		 */
+		ValueSetGenerator vsp = null;
+		DatatypeGeneratorUsingSpreadsheet dtp = null;
+		ProfileParser pp = null;
+		Map<String, String> datatypeLocalImports = new HashMap<String, String>();
+
+		vsp = new ValueSetGenerator(context.getVersion());
+		vsp.setResourceValueSetFiles(context.getValueSetFiles());
+		context.setValueSetGenerator(vsp);
+		try {
+			vsp.parse();
+		} catch (Exception e) {
+			throw new FailureException("Failed to load valuesets", e);
+		}
+
+		/*
+		 * A few enums are not found by default because none of the generated classes
+		 * refer to them, but we still want them.
+		 */
+		vsp.getClassForValueSetIdAndMarkAsNeeded("NarrativeStatus");
+
+		logInfo("Loading Datatypes...");
+
+		dtp = new DatatypeGeneratorUsingSpreadsheet(context.getVersion(), context.getBaseDir());
+		context.setDatatypeGenerator(dtp);
+		try {
+			dtp.parse();
+			dtp.markResourcesForImports();
+		} catch (Exception e) {
+			throw new FailureException("Failed to load datatypes", e);
+		}
+		dtp.bindValueSets(vsp);
+
+		datatypeLocalImports = dtp.getLocalImports();
+
+		/*
+		 * Load the requested resources
+		 */
+		ResourceGeneratorUsingSpreadsheet rp = new ResourceGeneratorUsingSpreadsheet(context.getVersion(), context.getBaseDir());
+		context.setResourceGenerator(rp);
+		logInfo("Loading Resources...");
+		try {
+			rp.setBaseResourceNames(includeResources);
+			rp.parse();
+			rp.markResourcesForImports();
+		} catch (Exception e) {
+			throw new FailureException("Failed to load resources", e);
+		}
+
+		rp.bindValueSets(vsp);
+		rp.getLocalImports().putAll(datatypeLocalImports);
+		datatypeLocalImports.putAll(rp.getLocalImports());
+		rp.combineContentMaps(dtp);
+		dtp.combineContentMaps(rp);
+
+		if (context.getProfileFiles() != null) {
+			logInfo("Loading profiles...");
+			pp = new ProfileParser(context.getVersion(), context.getBaseDir());
+			context.setProfileParser(pp);
+			for (ProfileFileDefinition next : context.getProfileFiles()) {
+				logInfo("Parsing file: "+next.profileFile);
+				try {
+					pp.parseSingleProfile(new File(next.profileFile), next.profileSourceUrl);
+				} catch (MojoFailureException e) {
+					throw new FailureException(e);
+				}
+			}
+
+			pp.bindValueSets(vsp);
+			pp.markResourcesForImports();
+			pp.getLocalImports().putAll(datatypeLocalImports);
+			datatypeLocalImports.putAll(pp.getLocalImports());
+
+			pp.combineContentMaps(rp);
+			pp.combineContentMaps(dtp);
+			dtp.combineContentMaps(pp);
+		}
+	}
+
+	public class FailureException extends Exception {
+
+		public FailureException(String message, Throwable cause) {
+			super(message, cause);
+		}
+		public FailureException(Throwable cause) {
+			super(cause);
+		}
+
+		public FailureException(String message) {
+			super(message);
+		}
+
+	}
+
+	public class ExecutionException extends Exception {
+
+		public ExecutionException(String message, Throwable cause) {
+			super(message, cause);
+		}
+
+		public ExecutionException(String message) {
+			super(message);
+		}
+
+	}
+}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/GeneratorContext.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/GeneratorContext.java
@@ -1,0 +1,137 @@
+package ca.uhn.fhir.tinder;
+/*
+ * #%L
+ * HAPI FHIR Tinder Plug-In
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import ca.uhn.fhir.tinder.TinderStructuresMojo.ValueSetFileDefinition;
+import ca.uhn.fhir.tinder.parser.DatatypeGeneratorUsingSpreadsheet;
+import ca.uhn.fhir.tinder.parser.ProfileParser;
+import ca.uhn.fhir.tinder.parser.ResourceGeneratorUsingSpreadsheet;
+
+/**
+ * @author Bill.Denton
+ *
+ */
+public class GeneratorContext {
+	private String version;
+	private String packageSuffix;
+	private String baseDir;
+	private List<String> includeResources;
+	private List<String> excludeResources;
+	private List<ValueSetFileDefinition> valueSetFiles;
+	private List<ProfileFileDefinition> profileFiles;
+	private ResourceGeneratorUsingSpreadsheet resourceGenerator = null;
+	private ValueSetGenerator valueSetGenerator = null;
+	private DatatypeGeneratorUsingSpreadsheet datatypeGenerator = null;
+	private ProfileParser profileParser = null;
+	public String getVersion() {
+		return version;
+	}
+	public void setVersion(String version) {
+		this.version = version;
+	}
+	public String getPackageSuffix() {
+		return packageSuffix;
+	}
+	public void setPackageSuffix(String packageSuffix) {
+		this.packageSuffix = packageSuffix;
+	}
+	public String getBaseDir() {
+		return baseDir;
+	}
+	public void setBaseDir(String baseDir) {
+		this.baseDir = baseDir;
+	}
+	public List<String> getIncludeResources() {
+		return includeResources;
+	}
+	public void setIncludeResources(List<String> includeResources) {
+		this.includeResources = includeResources;
+	}
+	public List<String> getExcludeResources() {
+		return excludeResources;
+	}
+	public void setExcludeResources(List<String> excludeResources) {
+		this.excludeResources = excludeResources;
+	}
+	public List<ValueSetFileDefinition> getValueSetFiles() {
+		return valueSetFiles;
+	}
+	public void setValueSetFiles(List<ValueSetFileDefinition> valueSetFiles) {
+		this.valueSetFiles = valueSetFiles;
+	}
+	public List<ProfileFileDefinition> getProfileFiles() {
+		return profileFiles;
+	}
+	public void setProfileFiles(List<ProfileFileDefinition> profileFiles) {
+		this.profileFiles = profileFiles;
+	}
+	public ResourceGeneratorUsingSpreadsheet getResourceGenerator() {
+		return resourceGenerator;
+	}
+	public void setResourceGenerator(ResourceGeneratorUsingSpreadsheet resourceGenerator) {
+		this.resourceGenerator = resourceGenerator;
+	}
+	public ValueSetGenerator getValueSetGenerator() {
+		return valueSetGenerator;
+	}
+	public void setValueSetGenerator(ValueSetGenerator valueSetGenerator) {
+		this.valueSetGenerator = valueSetGenerator;
+	}
+	public DatatypeGeneratorUsingSpreadsheet getDatatypeGenerator() {
+		return datatypeGenerator;
+	}
+	public void setDatatypeGenerator(DatatypeGeneratorUsingSpreadsheet datatypeGenerator) {
+		this.datatypeGenerator = datatypeGenerator;
+	}
+	public ProfileParser getProfileParser() {
+		return profileParser;
+	}
+	public void setProfileParser(ProfileParser profileParser) {
+		this.profileParser = profileParser;
+	}
+
+	public static class ProfileFileDefinition {
+		@Parameter(required = true)
+		String profileFile;
+
+		@Parameter(required = true)
+		String profileSourceUrl;
+
+		public String getProfileFile() {
+			return profileFile;
+		}
+
+		public void setProfileFile(String profileFile) {
+			this.profileFile = profileFile;
+		}
+
+		public String getProfileSourceUrl() {
+			return profileSourceUrl;
+		}
+
+		public void setProfileSourceUrl(String profileSourceUrl) {
+			this.profileSourceUrl = profileSourceUrl;
+		}
+	}
+}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericMultiFileMojo.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericMultiFileMojo.java
@@ -156,6 +156,12 @@ import ca.uhn.fhir.tinder.parser.TargetType;
  *     <td valign="top" align="center">No. Defaults to same directory as the template file.</td>
  *   </tr>
  *   <tr>
+ *     <td valign="top">velocityProperties</td>
+ *     <td valign="top">Specifies the full path to a java properties file
+ *     containing Velocity configuration properties</td>
+ *     <td valign="top" align="center">No.</td>
+ *   </tr>
+ *   <tr>
  *     <td valign="top">includeResources</td>
  *     <td valign="top">A list of the names of the resources or composite data types that should
  *     be used in the file generation</td>
@@ -238,6 +244,8 @@ public class TinderGenericMultiFileMojo extends AbstractMojo {
 	private File templateFile;
 	@Parameter(required = false)
 	private String velocityPath;
+	@Parameter(required = false)
+	private String velocityProperties;
 
 	@Parameter(required = false)
 	private List<String> includeResources;
@@ -319,6 +327,7 @@ public class TinderGenericMultiFileMojo extends AbstractMojo {
 			rp.setTemplate(template);
 			rp.setTemplateFile(templateFile);
 			rp.setVelocityPath(velocityPath);
+			rp.setVelocityProperties(velocityProperties);
 			rp.writeAll(targetType, targetDirectory, null, targetPackage);
 		}
 
@@ -333,6 +342,7 @@ public class TinderGenericMultiFileMojo extends AbstractMojo {
 			dtp.setTemplate(template);
 			dtp.setTemplateFile(templateFile);
 			dtp.setVelocityPath(velocityPath);
+			dtp.setVelocityProperties(velocityProperties);
 			dtp.writeAll(targetType, targetDirectory, null, targetPackage);
 		}
 
@@ -347,6 +357,7 @@ public class TinderGenericMultiFileMojo extends AbstractMojo {
 			vsp.setTemplate(template);
 			vsp.setTemplateFile(templateFile);
 			vsp.setVelocityPath(velocityPath);
+			vsp.setVelocityProperties(velocityProperties);
 			vsp.writeMarkedValueSets(targetType, targetDirectory, targetPackage);
 		}
 		
@@ -361,6 +372,7 @@ public class TinderGenericMultiFileMojo extends AbstractMojo {
 			pp.setTemplate(template);
 			pp.setTemplateFile(templateFile);
 			pp.setVelocityPath(velocityPath);
+			pp.setVelocityProperties(velocityProperties);
 			pp.writeAll(targetType, targetDirectory, null, targetPackage);
 		}
 		

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericMultiFileMojo.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericMultiFileMojo.java
@@ -2,12 +2,10 @@ package ca.uhn.fhir.tinder;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Properties;
-import java.util.TreeSet;
 
 import org.apache.http.ParseException;
+import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -17,115 +15,366 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.tinder.AbstractGenerator.ExecutionException;
+import ca.uhn.fhir.tinder.AbstractGenerator.FailureException;
+import ca.uhn.fhir.tinder.GeneratorContext.ProfileFileDefinition;
+import ca.uhn.fhir.tinder.TinderStructuresMojo.ValueSetFileDefinition;
+import ca.uhn.fhir.tinder.parser.DatatypeGeneratorUsingSpreadsheet;
+import ca.uhn.fhir.tinder.parser.ProfileParser;
 import ca.uhn.fhir.tinder.parser.ResourceGeneratorUsingSpreadsheet;
+import ca.uhn.fhir.tinder.parser.TargetType;
 
+/**
+ * Generate files from FHIR resource/composite metadata using Velocity templates.
+ * <p>
+ * Generates either source or resource files for each selected resource or
+ * composite data type. One file is generated for each selected entity. The
+ * files are generated using a Velocity template that can be taken from
+ * inside the hapi-timder-plugin project or can be located in other projects
+ * <p>
+ * The following Maven plug-in configuration properties are used with this plug-in 
+ * <p>
+ * <table border="1" cellpadding="2" cellspacing="0">
+ *   <tr>
+ *     <td valign="top"><b>Attribute</b></td>
+ *     <td valign="top"><b>Description</b></td>
+ *     <td align="center" valign="top"><b>Required</b></td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">version</td>
+ *     <td valign="top">The FHIR version whose resource metadata
+ *     is to be used to generate the files<br>
+ *     Valid values:&nbsp;<code><b>dstu</b></code>&nbsp;|&nbsp;<code><b>dstu2</b></code>&nbsp;|&nbsp;<code><b>dstu3</b></code></td>
+ *     <td valign="top" align="center">Yes</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">baseDir</td>
+ *     <td valign="top">The Maven project's base directory. This is used to 
+ *     possibly locate other assets within the project used in file generation.</td>
+ *     <td valign="top" align="center">No. Defaults to: <code>${project.build.directory}/..</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">generateResources</td>
+ *     <td valign="top">Should files be generated from FHIR resource metadata?<br>
+ *     Valid values:&nbsp;<code><b>true</b></code>&nbsp;|&nbsp;<code><b>false</b></code></td> 
+ *     <td valign="top" align="center" rowspan="4">At least one of these four options must be specified</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">generateDataTypes</td>
+ *     <td valign="top">Should files be generated from FHIR composite data type metadata?<br>
+ *     Valid values:&nbsp;<code><b>true</b></code>&nbsp;|&nbsp;<code><b>false</b></code></td> 
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">generateValueSets</td>
+ *     <td valign="top">Should files be generated from FHIR value set metadata?<br>
+ *     Valid values:&nbsp;<code><b>true</b></code>&nbsp;|&nbsp;<code><b>false</b></code></td> 
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">generateProfiles</td>
+ *     <td valign="top">Should files be generated from FHIR profile metadata?<br>
+ *     Valid values:&nbsp;<code><b>true</b></code>&nbsp;|&nbsp;<code><b>false</b></code></td> 
+ *   </tr>
+ *   <tr>
+ *     <td colspan="3" />
+ *   </tr>
+ *   <tr>
+ *     <td valign="top" colspan="3">Java source files can be generated
+ *     for FHIR resources or composite data types. There is one file
+ *     generated for each selected entity. The following configuration
+ *     properties control the naming of the generated source files:<br>
+ *     &nbsp;&nbsp;&nbsp;&nbsp;&lt;targetSourceDirectory&gt;/&lt;packageName&gt;/&lt;filenamePrefix&gt;<i>element-name</i>&lt;filenameSuffix&gt;<br>
+ *     where: <i>element-name</i> is the "title-case" name of the selected resource or composite data type.<br>
+ *     Note that all dots in the packageName will be replaced by the path separator character when building the
+ *     actual source file location. Also note that <code>.java</code> will be added to the filenameSuffix if it is not already included.
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">targetSourceDirectory</td>
+ *     <td valign="top">The Maven source directory to contain the generated files.</td>
+ *     <td valign="top" align="center">Yes when Java source files are to be generated</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">packageName</td>
+ *     <td valign="top">The Java package that will contain the generated classes.
+ *     This package is generated in the &lt;targetSourceDirectory&gt; if needed.</td>
+ *     <td valign="top" align="center">Yes when <i>targetSourceDirectory</i> is specified</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">filenamePrefix</td>
+ *     <td valign="top">The prefix string that is to be added onto the
+ *     beginning of the resource or composite data type name to become 
+ *     the Java class name or resource file name.</td>
+ *     <td valign="top" align="center">No</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">filenameSuffix</td>
+ *     <td valign="top">Suffix that will be added onto the end of the resource 
+ *     or composite data type name to become the Java class name or resource file name.</td>
+ *     <td valign="top" align="center">No.</code></td>
+ *   </tr>
+ *   <tr>
+ *     <td colspan="3" />
+ *   </tr>
+ *   <tr>
+ *     <td valign="top" colspan="3">Maven resource files can also be generated
+ *     for FHIR resources or composite data types. The following configuration
+ *     properties control the naming of the generated resource files:<br>
+ *     &nbsp;&nbsp;&nbsp;&nbsp;&lt;targetResourceDirectory&gt;/&lt;folderName&gt;/&lt;filenamePrefix&gt;<i>element-name</i>&lt;filenameSuffix&gt;<br>
+ *     where: <i>element-name</i> is the "title-case" name of the selected resource or composite data type.
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">targetResourceDirectory</td>
+ *     <td valign="top">The Maven resource directory to contain the generated files.</td>
+ *     <td valign="top" align="center">Yes when resource files are to be generated</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">folderName</td>
+ *     <td valign="top">The folder within the targetResourceDirectory where the generated files will be placed.
+ *     This folder is generated in the &lt;targetResourceDirectory&gt; if needed.</td>
+ *     <td valign="top" align="center">No</td>
+ *   </tr>
+ *   <tr>
+ *     <td colspan="3" />
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">template</td>
+ *     <td valign="top">The path of one of the <i>Velocity</i> templates
+ *     contained within the <code>hapi-tinder-plugin</code> Maven plug-in
+ *     classpath that will be used to generate the files.</td>
+ *     <td valign="top" align="center" rowspan="2">One of these two options must be configured</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">templateFile</td>
+ *     <td valign="top">The full path to the <i>Velocity</i> template that is
+ *     to be used to generate the files.</td> 
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">velocityPath</td>
+ *     <td valign="top">When using the <code>templateFile</code> option, this property
+ *     can be used to specify where Velocity macros and other resources are located.</td>
+ *     <td valign="top" align="center">No. Defaults to same directory as the template file.</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">includeResources</td>
+ *     <td valign="top">A list of the names of the resources or composite data types that should
+ *     be used in the file generation</td>
+ *     <td valign="top" align="center">No. Defaults to all defined resources except for DSTU2, 
+ *     the <code>Binary</code> resource is excluded and
+ *     for DSTU3, the <code>Conformance</code> resource is excluded.</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">excludeResources</td>
+ *     <td valign="top">A list of the names of the resources or composite data types that should
+ *     excluded from the file generation</td>
+ *     <td valign="top" align="center">No.</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">valueSetFiles</td>
+ *     <td valign="top">A list of files containing value-set resource definitions
+ *     to be used.</td>
+ *     <td valign="top" align="center">No. Defaults to all defined value-sets that 
+ *     are referenced from the selected resources.</td>
+ *   </tr>
+ *   <tr>
+ *     <td valign="top">profileFiles</td>
+ *     <td valign="top">A list of files containing profile definitions
+ *     to be used.</td>
+ *     <td valign="top" align="center">No. Defaults to the default profile
+ *     for each selected resource</td>
+ *   </tr>
+ * </table>
+ * 
+ * 
+ * 
+ * @author Bill.Denton
+ *
+ */
 @Mojo(name = "generate-multi-files", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class TinderGenericMultiFileMojo extends AbstractMojo {
 
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(TinderGenericMultiFileMojo.class);
 
+	@Parameter(required = true)
+	private String version;
+
+	@Parameter(required = true, defaultValue = "${project.build.directory}/..")
+	private String baseDir;
+
+	@Parameter(required = false, defaultValue="false")
+	private boolean generateResources;
+
+	@Parameter(required = false, defaultValue = "false")
+	private boolean generateDatatypes;
+
+	@Parameter(required = false, defaultValue = "false")
+	private boolean generateValueSets;
+
+	@Parameter(required = false, defaultValue = "false")
+	private boolean generateProfiles;
+	
+	@Parameter(required = false)
+	private File targetSourceDirectory;
+
+	@Parameter(required = false)
+	private String packageName;
+
+	@Parameter(required = false)
+	private String filenamePrefix;
+	
+	@Parameter(required = false)
+	private String filenameSuffix;
+	
+	@Parameter(required = false)
+	private File targetResourceDirectory;
+
+	@Parameter(required = false)
+	private String folderName;
+	
 	// one of these two is required
 	@Parameter(required = false)
 	private String template;
 	@Parameter(required = false)
 	private File templateFile;
-	
-	@Parameter(required = true, defaultValue = "ResourceProvider")
-	private String filenameSuffix;
-	
-	@Parameter(required = true, defaultValue = "${project.build.directory}/generated-sources/tinder")
-	private File targetDirectory;
-
-	@Parameter(required = true)
-	private String packageBase;
+	@Parameter(required = false)
+	private String velocityPath;
 
 	@Parameter(required = false)
-	private List<String> baseResourceNames;
+	private List<String> includeResources;
 
 	@Parameter(required = false)
-	private List<String> excludeResourceNames;
+	private List<String> excludeResources;
 
-	@Parameter(required = true, defaultValue = "${project.build.directory}/..")
-	private String baseDir;
+	@Parameter(required = false)
+	private List<ValueSetFileDefinition> valueSetFiles;
 
-	@Parameter(required = true)
-	private String version;
+	@Parameter(required = false)
+	private List<ProfileFileDefinition> profileFiles;
 
 	@Component
 	private MavenProject myProject;
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
-
-		FhirContext fhirContext;
-		if ("dstu".equals(version)) {
-			fhirContext = FhirContext.forDstu1();
-		} else if ("dstu2".equals(version)) {
-			fhirContext = FhirContext.forDstu2();
-		} else if ("dstu3".equals(version)) {
-			fhirContext = FhirContext.forDstu3();
-		} else {
-			throw new MojoFailureException("Unknown version configured: " + version);
-		}
 		
-		if (baseResourceNames == null || baseResourceNames.isEmpty()) {
-			baseResourceNames = new ArrayList<String>();
-			
-			ourLog.info("No resource names supplied, going to use all resources from version: {}",fhirContext.getVersion().getVersion());
-			
-			Properties p = new Properties();
-			try {
-				p.load(fhirContext.getVersion().getFhirVersionPropertiesFile());
-			} catch (IOException e) {
-				throw new MojoFailureException("Failed to load version property file", e);
-			}
-
-			ourLog.debug("Property file contains: {}",p);
-
-			TreeSet<String> keys = new TreeSet<String>();
-			for(Object next : p.keySet()) {
-				keys.add((String) next);
-			}
-			for (String next : keys) {
-				if (next.startsWith("resource.")) {
-					baseResourceNames.add(next.substring("resource.".length()).toLowerCase());
-				}
-			}
-		}
-
-		for (int i = 0; i < baseResourceNames.size(); i++) {
-			baseResourceNames.set(i, baseResourceNames.get(i).toLowerCase());
-		}
-
-		if (excludeResourceNames != null) {
-			for (int i = 0; i < excludeResourceNames.size(); i++) {
-				excludeResourceNames.set(i, excludeResourceNames.get(i).toLowerCase());
-			}
-			baseResourceNames.removeAll(excludeResourceNames);
-		}
+		GeneratorContext context = new GeneratorContext();
+		context.setVersion(version);
+		context.setBaseDir(baseDir);
+		context.setIncludeResources(includeResources);
+		context.setExcludeResources(excludeResources);
+		context.setValueSetFiles(valueSetFiles);
+		context.setProfileFiles(profileFiles);
 		
-		ourLog.info("Including the following resources: {}", baseResourceNames);
-		
-		File packageDirectoryBase = new File(targetDirectory, packageBase.replace(".", File.separatorChar + ""));
-		packageDirectoryBase.mkdirs();
-
-		ResourceGeneratorUsingSpreadsheet gen = new ResourceGeneratorUsingSpreadsheet(version, baseDir);
-		gen.setBaseResourceNames(baseResourceNames);
-
+		Generator generator = new Generator();
 		try {
-			gen.parse();
-
-			gen.setFilenameSuffix(filenameSuffix);
-			gen.setTemplate(template);
-			gen.setTemplateFile(templateFile);
-			gen.writeAll(packageDirectoryBase, null,packageBase);
-
-		} catch (Exception e) {
-			throw new MojoFailureException("Failed to generate files", e);
+			generator.prepare(context);
+		} catch (ExecutionException e) {
+			throw new MojoExecutionException(e.getMessage(), e.getCause());
+		} catch (FailureException e) {
+			throw new MojoFailureException(e.getMessage(), e.getCause());
+		}
+		
+		/*
+		 * Deal with the generation target
+		 */
+		TargetType targetType = null;
+		File targetDirectory = null;
+		if (targetSourceDirectory != null) {
+			if (targetResourceDirectory != null) {
+				throw new MojoFailureException("Both [targetSourceDirectory] and [targetResourceDirectory] are specified. Please choose just one.");
+			}
+			targetType = TargetType.SOURCE;
+			if (null == packageName) {
+				throw new MojoFailureException("The [packageName] property must be specified when generating Java source code.");
+			}
+			targetDirectory = new File(targetSourceDirectory, packageName.replace('.', File.separatorChar));
+		} else
+		if (targetResourceDirectory != null) {
+			if (targetSourceDirectory != null) {
+				throw new MojoFailureException("Both [targetSourceDirectory] and [targetResourceDirectory] are specified. Please choose just one.");
+			}
+			targetType = TargetType.RESOURCE;
+			if (folderName != null) {
+				targetDirectory = new File(targetResourceDirectory, folderName);
+			} else {
+				targetDirectory = targetResourceDirectory;
+			}
+		} else {
+			throw new MojoFailureException("Either [targetSourceDirectory] or [targetResourceDirectory] must be specified.");
+		}
+		targetDirectory.mkdirs();
+		ourLog.info(" * Output ["+targetType.toString()+"] Directory: " + targetDirectory.getAbsolutePath());
+		
+		/*
+		 * Write resources if selected
+		 */
+		ResourceGeneratorUsingSpreadsheet rp = context.getResourceGenerator();
+		if (generateResources && rp != null) {
+			ourLog.info("Writing Resources...");
+			rp.setFilenamePrefix(filenamePrefix);
+			rp.setFilenameSuffix(filenameSuffix);
+			rp.setTemplate(template);
+			rp.setTemplateFile(templateFile);
+			rp.setVelocityPath(velocityPath);
+			rp.writeAll(targetType, targetDirectory, null, packageName);
 		}
 
-		myProject.addCompileSourceRoot(targetDirectory.getAbsolutePath());
+		/*
+		 * Write composite datatypes
+		 */
+		DatatypeGeneratorUsingSpreadsheet dtp = context.getDatatypeGenerator();
+		if (generateDatatypes && dtp != null) {
+			ourLog.info("Writing Composite Datatypes...");
+			dtp.setFilenamePrefix(filenamePrefix);
+			dtp.setFilenameSuffix(filenameSuffix);
+			dtp.setTemplate(template);
+			dtp.setTemplateFile(templateFile);
+			dtp.setVelocityPath(velocityPath);
+			dtp.writeAll(targetType, targetDirectory, null, packageName);
+		}
+
+		/*
+		 * Write valuesets
+		 */
+		ValueSetGenerator vsp = context.getValueSetGenerator();
+		if (generateValueSets && vsp != null) {
+			ourLog.info("Writing ValueSet Enums...");
+			vsp.setFilenamePrefix(filenamePrefix);
+			vsp.setFilenameSuffix(filenameSuffix);
+			vsp.setTemplate(template);
+			vsp.setTemplateFile(templateFile);
+			vsp.setVelocityPath(velocityPath);
+			vsp.writeMarkedValueSets(targetType, targetDirectory, packageName);
+		}
+		
+		/*
+		 * Write profiles
+		 */
+		ProfileParser pp = context.getProfileParser();
+		if (generateProfiles && pp != null) {
+			ourLog.info("Writing Profiles...");
+			pp.setFilenamePrefix(filenamePrefix);
+			pp.setFilenameSuffix(filenameSuffix);
+			pp.setTemplate(template);
+			pp.setTemplateFile(templateFile);
+			pp.setVelocityPath(velocityPath);
+			pp.writeAll(targetType, targetDirectory, null, packageName);
+		}
+		
+		switch (targetType) {
+			case SOURCE: {
+				myProject.addCompileSourceRoot(targetDirectory.getAbsolutePath());
+				break;
+			}
+			case RESOURCE: {
+				Resource resource = new Resource();
+				resource.setDirectory(targetDirectory.getAbsolutePath());
+				resource.addInclude("*");
+				myProject.addResource(resource);
+				break;
+			}
+			default:
+		}
 
 	}
 
@@ -149,10 +398,20 @@ public class TinderGenericMultiFileMojo extends AbstractMojo {
 		TinderGenericMultiFileMojo mojo = new TinderGenericMultiFileMojo();
 		mojo.myProject = new MavenProject();
 		mojo.version = "dstu2";
-		mojo.packageBase = "ca.uhn.test";
+		mojo.packageName = "ca.uhn.test";
 		mojo.template = "/vm/jpa_resource_provider.vm";
-		mojo.targetDirectory = new File("target/generated/valuesets");
+		mojo.targetSourceDirectory = new File("target/generated/valuesets");
 		mojo.execute();
 	}
 
+	class Generator extends AbstractGenerator {
+		@Override
+		protected void logInfo(String message) {
+			ourLog.info(message);
+		}
+		@Override
+		protected void logDebug(String message) {
+			ourLog.debug(message);
+		}
+	}
 }

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericSingleFileMojo.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/TinderGenericSingleFileMojo.java
@@ -151,6 +151,12 @@ import ca.uhn.fhir.tinder.parser.TargetType;
  *     <td valign="top" align="center">No. Defaults to same directory as the template file.</td>
  *   </tr>
  *   <tr>
+ *     <td valign="top">velocityProperties</td>
+ *     <td valign="top">Specifies the full path to a java properties file
+ *     containing Velocity configuration properties</td>
+ *     <td valign="top" align="center">No.</td>
+ *   </tr>
+ *   <tr>
  *     <td valign="top">includeResources</td>
  *     <td valign="top">A list of the names of the resources or composite data types that should
  *     be used in the file generation</td>
@@ -227,6 +233,8 @@ public class TinderGenericSingleFileMojo extends AbstractMojo {
 	private File templateFile;
 	@Parameter(required = false)
 	private String velocityPath;
+	@Parameter(required = false)
+	private String velocityProperties;
 
 	@Parameter(required = false)
 	private List<String> includeResources;
@@ -311,27 +319,13 @@ public class TinderGenericSingleFileMojo extends AbstractMojo {
 			/*
 			 * Next, deal with the template and initialize velocity
 			 */
-			VelocityEngine v = new VelocityEngine();
+			VelocityEngine v = VelocityHelper.configureVelocityEngine(templateFile, velocityPath, velocityProperties);
 			InputStream templateIs = null;
 			if (templateFile != null) {
 				templateIs = new FileInputStream(templateFile);
-				v.setProperty("resource.loader", "file");
-				v.setProperty("file.resource.loader.class", "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
-				if (velocityPath != null) {
-					v.setProperty("file.resource.loader.path", velocityPath);
-				} else {
-					String path = templateFile.getCanonicalFile().getParent();
-					if (null == path) {
-						path = ".";
-					}
-					v.setProperty("file.resource.loader.path", path);
-				}
 			} else {
 				templateIs = this.getClass().getResourceAsStream(template);
-				v.setProperty("resource.loader", "cp");
-				v.setProperty("cp.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
 			}
-			v.setProperty("runtime.references.strict", Boolean.TRUE);
 			InputStreamReader templateReader = new InputStreamReader(templateIs);
 	
 			/*

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ValueSetGenerator.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ValueSetGenerator.java
@@ -60,6 +60,7 @@ public class ValueSetGenerator {
 	private String myTemplate = null;
 	private File myTemplateFile = null;
 	private String myVelocityPath = null;
+	private String myVelocityProperties = null;
 
 	public ValueSetGenerator(String theVersion) {
 		myVersion = theVersion;
@@ -322,6 +323,10 @@ public class ValueSetGenerator {
 		myVelocityPath = theVelocityPath;
 	}
 
+	public void setVelocityProperties(String theVelocityProperties) {
+		myVelocityProperties = theVelocityProperties;
+	}
+
 	public void write(Collection<ValueSetTm> theValueSets, File theOutputDirectory, String thePackageBase) throws IOException {
 		write(TargetType.SOURCE, theValueSets, theOutputDirectory, thePackageBase);
 	}
@@ -364,30 +369,16 @@ public class ValueSetGenerator {
 		ctx.put("packageBase", thePackageBase);
 		ctx.put("esc", new EscapeTool());
 
-		VelocityEngine v = new VelocityEngine();
+		VelocityEngine v = VelocityHelper.configureVelocityEngine(myTemplateFile, myVelocityPath, myVelocityProperties);
 		if (myTemplateFile != null) {
 			templateIs = new FileInputStream(myTemplateFile);
-			v.setProperty("resource.loader", "file");
-			v.setProperty("file.resource.loader.class", "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
-			if (myVelocityPath != null) {
-				v.setProperty("file.resource.loader.path", myVelocityPath);
-			} else {
-				String path = myTemplateFile.getCanonicalFile().getParent();
-				if (null == path) {
-					path = ".";
-				}
-				v.setProperty("file.resource.loader.path", path);
-			}
 		} else {
 			String templateName = myTemplate;
 			if (null == templateName) {
 				templateName = "/vm/valueset.vm";
 			}
 			templateIs = this.getClass().getResourceAsStream(templateName);
-			v.setProperty("resource.loader", "cp");
-			v.setProperty("cp.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
 		}
-		v.setProperty("runtime.references.strict", Boolean.TRUE);
 
 		InputStreamReader templateReader = new InputStreamReader(templateIs, "UTF-8");
 		v.evaluate(ctx, w, "", templateReader);

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/VelocityHelper.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/VelocityHelper.java
@@ -1,0 +1,88 @@
+package ca.uhn.fhir.tinder;
+/*
+ * #%L
+ * HAPI FHIR Tinder Plug-In
+ * %%
+ * Copyright (C) 2014 - 2016 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+
+public class VelocityHelper {
+
+	public static VelocityEngine configureVelocityEngine (File templateFile, String velocityPath, String propertyFile) throws IOException {
+		VelocityEngine result = new VelocityEngine();
+		boolean haveResourceLoader = false;
+		boolean haveRuntimeReferences = false;
+		
+		if (propertyFile != null) {
+			File propFile = new File(propertyFile);
+			if (propFile.exists() && propFile.isFile() && propFile.canRead()) {
+				InputStream propsIn = new FileInputStream(propFile);
+				Properties props = new Properties();
+				props.load(propsIn);
+				propsIn.close();
+				for (Entry<?,?> entry : props.entrySet()) {
+					String key = (String)entry.getKey();
+					result.setProperty(key, entry.getValue());
+					if (RuntimeConstants.RESOURCE_LOADER.equals(key)) {
+						haveResourceLoader = true;
+					} else
+					if (RuntimeConstants.RUNTIME_REFERENCES_STRICT.equals(key)) {
+						haveRuntimeReferences = true;
+					}
+				}
+			} else {
+				throw new FileNotFoundException("Velocity property file ["+propertyFile+"] does not exist or is not readable.");
+			}
+		}
+		
+		if (!haveResourceLoader) {
+			if (templateFile != null) {
+				result.setProperty(RuntimeConstants.RESOURCE_LOADER, "file");
+				result.setProperty("file.resource.loader.class", "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
+				if (velocityPath != null) {
+					result.setProperty(RuntimeConstants.FILE_RESOURCE_LOADER_PATH, velocityPath);
+				} else {
+					String path = templateFile.getCanonicalFile().getParent();
+					if (null == path) {
+						path = ".";
+					}
+					result.setProperty(RuntimeConstants.FILE_RESOURCE_LOADER_PATH, path);
+				}
+			} else {
+				result.setProperty("resource.loader", "cp");
+				result.setProperty("cp.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
+			}
+		}
+		
+		if (!haveRuntimeReferences) {
+			result.setProperty(RuntimeConstants.RUNTIME_REFERENCES_STRICT, Boolean.TRUE);
+		}
+		
+		return result;
+	}
+}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ant/TinderGeneratorTask.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ant/TinderGeneratorTask.java
@@ -44,6 +44,7 @@ import ca.uhn.fhir.tinder.GeneratorContext;
 import ca.uhn.fhir.tinder.GeneratorContext.ProfileFileDefinition;
 import ca.uhn.fhir.tinder.TinderStructuresMojo.ValueSetFileDefinition;
 import ca.uhn.fhir.tinder.ValueSetGenerator;
+import ca.uhn.fhir.tinder.VelocityHelper;
 import ca.uhn.fhir.tinder.parser.BaseStructureSpreadsheetParser;
 import ca.uhn.fhir.tinder.parser.DatatypeGeneratorUsingSpreadsheet;
 import ca.uhn.fhir.tinder.parser.ProfileParser;
@@ -206,6 +207,12 @@ import ca.uhn.fhir.tinder.parser.TargetType;
  *     <td valign="top" align="center">No. Defaults to same directory as the template file.</td>
  *   </tr>
  *   <tr>
+ *     <td valign="top">velocityProperties</td>
+ *     <td valign="top">Specifies the full path to a java properties file
+ *     containing Velocity configuration properties</td>
+ *     <td valign="top" align="center">No.</td>
+ *   </tr>
+ *   <tr>
  *     <td valign="top">includeResources</td>
  *     <td valign="top">A list of the names of the resources or composite data types that should
  *     be used in the file generation</td>
@@ -275,6 +282,8 @@ public class TinderGeneratorTask extends Task {
 	private File templateFile;
 
 	private String velocityPath;
+
+	private String velocityProperties;
 
 	private List<String> includeResources;
 
@@ -367,27 +376,13 @@ public class TinderGeneratorTask extends Task {
 				/*
 				 * Next, deal with the template and initialize velocity
 				 */
-				VelocityEngine v = new VelocityEngine();
+				VelocityEngine v = VelocityHelper.configureVelocityEngine(templateFile, velocityPath, velocityProperties);
 				InputStream templateIs = null;
 				if (templateFile != null) {
 					templateIs = new FileInputStream(templateFile);
-					v.setProperty("resource.loader", "file");
-					v.setProperty("file.resource.loader.class", "org.apache.velocity.runtime.resource.loader.FileResourceLoader");
-					if (velocityPath != null) {
-						v.setProperty("file.resource.loader.path", velocityPath);
-					} else {
-						String path = templateFile.getCanonicalFile().getParent();
-						if (null == path) {
-							path = ".";
-						}
-						v.setProperty("file.resource.loader.path", path);
-					}
 				} else {
 					templateIs = this.getClass().getResourceAsStream(template);
-					v.setProperty("resource.loader", "cp");
-					v.setProperty("cp.resource.loader.class", "org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader");
 				}
-				v.setProperty("runtime.references.strict", Boolean.TRUE);
 				InputStreamReader templateReader = new InputStreamReader(templateIs);
 		
 				/*
@@ -457,6 +452,7 @@ public class TinderGeneratorTask extends Task {
 					rp.setTemplate(template);
 					rp.setTemplateFile(templateFile);
 					rp.setVelocityPath(velocityPath);
+					rp.setVelocityProperties(velocityProperties);
 					rp.writeAll(targetType, targetDirectory, null, targetPackage);
 				}
 
@@ -471,6 +467,7 @@ public class TinderGeneratorTask extends Task {
 					dtp.setTemplate(template);
 					dtp.setTemplateFile(templateFile);
 					dtp.setVelocityPath(velocityPath);
+					dtp.setVelocityProperties(velocityProperties);
 					dtp.writeAll(targetType, targetDirectory, null, targetPackage);
 				}
 
@@ -485,6 +482,7 @@ public class TinderGeneratorTask extends Task {
 					vsp.setTemplate(template);
 					vsp.setTemplateFile(templateFile);
 					vsp.setVelocityPath(velocityPath);
+					vsp.setVelocityProperties(velocityProperties);
 					vsp.writeMarkedValueSets(targetType, targetDirectory, targetPackage);
 				}
 				
@@ -499,6 +497,7 @@ public class TinderGeneratorTask extends Task {
 					pp.setTemplate(template);
 					pp.setTemplateFile(templateFile);
 					pp.setVelocityPath(velocityPath);
+					pp.setVelocityProperties(velocityProperties);
 					pp.writeAll(targetType, targetDirectory, null, targetPackage);
 				}
 			}
@@ -609,6 +608,10 @@ public class TinderGeneratorTask extends Task {
 
 	public void setVelocityPath(String velocityPath) {
 		this.velocityPath = velocityPath;
+	}
+
+	public void setVelocityProperties(String velocityProperties) {
+		this.velocityProperties = velocityProperties;
 	}
 
 	public void setIncludeResources(String names) {

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ant/TinderGeneratorTask.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/ant/TinderGeneratorTask.java
@@ -595,7 +595,7 @@ public class TinderGeneratorTask extends Task {
 		this.targetResourceDirectory = targetResourceDirectory;
 	}
 
-	public void setTaargetFolder(String targetFolder) {
+	public void setTargetFolder(String targetFolder) {
 		this.targetFolder = targetFolder;
 	}
 

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/Child.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/Child.java
@@ -148,14 +148,21 @@ public abstract class Child extends BaseElement {
 		return false;
 	}
 
+	public boolean isPrimitive (String theType) {
+		return isPrimitiveInternal(theType);
+	}
+
 	public boolean isPrimitive() {
 		
 		if (IDatatype.class.getSimpleName().equals(getReferenceType())) {
 			return false;
 		}
-		
+		return isPrimitiveInternal(getSingleType());
+	}
+
+	protected boolean isPrimitiveInternal (String theType) {
 		try {
-			String name = "ca.uhn.fhir.model.primitive." + getSingleType();
+			String name = "ca.uhn.fhir.model.primitive." + theType;
 			Class.forName(name);
 			return true;
 		} catch (ClassNotFoundException e) {
@@ -163,8 +170,16 @@ public abstract class Child extends BaseElement {
 		}
 	}
 
+	public String getPrimitiveType (String theType) throws ClassNotFoundException {
+		return getPrimitiveTypeInternal(theType);
+	}
+
 	public String getPrimitiveType() throws ClassNotFoundException {
-		String name = "ca.uhn.fhir.model.primitive." + getSingleType();
+		return getPrimitiveTypeInternal(getSingleType());
+	}
+
+	protected String getPrimitiveTypeInternal (String theType) throws ClassNotFoundException {
+		String name = "ca.uhn.fhir.model.primitive." + theType;
 		Class<?> clazz = Class.forName(name);
 		if (clazz.equals(IdDt.class)) {
 			return String.class.getSimpleName();

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/Child.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/Child.java
@@ -148,6 +148,10 @@ public abstract class Child extends BaseElement {
 		return false;
 	}
 
+	public boolean isBlockRef() {
+		return false;
+	}
+
 	public boolean isPrimitive (String theType) {
 		return isPrimitiveInternal(theType);
 	}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/ResourceBlockCopy.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/ResourceBlockCopy.java
@@ -2,5 +2,17 @@ package ca.uhn.fhir.tinder.model;
 
 public class ResourceBlockCopy extends Child {
 
+	private ResourceBlock referencedBlock = null;
 	
+	@Override
+	public boolean isBlockRef() {
+		return referencedBlock != null;
+	}
+
+	public ResourceBlock getReferencedBlock () {
+		return this.referencedBlock;
+	}
+	public void setReferencedBlock (ResourceBlock referencedBlock) {
+		this.referencedBlock = referencedBlock;
+	}
 }

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/BaseStructureParser.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/BaseStructureParser.java
@@ -180,11 +180,11 @@ public abstract class BaseStructureParser {
 	}
 
 	protected String getFilenamePrefix() {
-		return myFilenamePrefix;
+		return myFilenamePrefix != null ? myFilenamePrefix : "";
 	}
 
 	protected String getFilenameSuffix() {
-		return myFilenameSuffix;
+		return myFilenameSuffix != null ? myFilenameSuffix : "";
 	}
 
 	public Map<String, String> getLocalImports() {
@@ -536,6 +536,7 @@ public abstract class BaseStructureParser {
 			capitalize = "Dstu1";
 		}
 		ctx.put("versionCapitalized", capitalize);
+		ctx.put("this", theResource);
 
 		VelocityEngine v = new VelocityEngine();
 		InputStream templateIs = null;

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/BaseStructureParser.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/BaseStructureParser.java
@@ -547,6 +547,7 @@ public abstract class BaseStructureParser {
 		VelocityEngine v = VelocityHelper.configureVelocityEngine(getTemplateFile(), getVelocityPath(), myVelocityProperties);
 		InputStream templateIs = null;
 		if (getTemplateFile() != null) {
+			templateIs = new FileInputStream(getTemplateFile());
 		} else {
 			templateIs = this.getClass().getResourceAsStream(getTemplate());
 		}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/DatatypeGeneratorUsingSpreadsheet.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/DatatypeGeneratorUsingSpreadsheet.java
@@ -34,21 +34,16 @@ public class DatatypeGeneratorUsingSpreadsheet extends BaseStructureSpreadsheetP
 
 	public DatatypeGeneratorUsingSpreadsheet(String theVersion, String theBaseDir) {
 		super(theVersion, theBaseDir);
+		super.setFilenameSuffix("Dt");
 	}
 
 	@Override
 	protected String getTemplate() {
+		String template = super.getTemplate();
+		if (template != null) {
+			return template;
+		}
 		return "dstu".equals(getVersion()) ? "/vm/dt_composite_dstu.vm" : "/vm/dt_composite.vm";
-	}
-	
-	@Override
-	protected File getTemplateFile() {
-		return null;
-	}
-
-	@Override
-	protected String getFilenameSuffix() {
-		return "Dt";
 	}
 
 	@Override

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/ProfileParser.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/ProfileParser.java
@@ -40,6 +40,7 @@ public class ProfileParser extends BaseStructureParser {
 
 	public ProfileParser(String theVersion, String theBaseDir) {
 		super(theVersion, theBaseDir);
+		super.setFilenameSuffix("");
 	}
 
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(ProfileParser.class);
@@ -54,12 +55,11 @@ public class ProfileParser extends BaseStructureParser {
 	}
 
 	@Override
-	protected String getFilenameSuffix() {
-		return "";
-	}
-
-	@Override
 	protected String getTemplate() {
+		String template = super.getTemplate();
+		if (template != null) {
+			return template;
+		}
 		return "dstu".equals(getVersion()) ? "/vm/resource_dstu.vm" : "/vm/resource.vm";
 	}
 	

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/ResourceGeneratorUsingSpreadsheet.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/ResourceGeneratorUsingSpreadsheet.java
@@ -1,6 +1,5 @@
 package ca.uhn.fhir.tinder.parser;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -13,14 +12,12 @@ import ca.uhn.fhir.tinder.model.BaseRootType;
 import ca.uhn.fhir.tinder.model.Resource;
 
 public class ResourceGeneratorUsingSpreadsheet extends BaseStructureSpreadsheetParser {
-	private String myFilenameSuffix = "";
 	private List<String> myInputStreamNames;
 	private ArrayList<InputStream> myInputStreams;
-	private String myTemplate = null;
-	private File myTemplateFile = null;
 
 	public ResourceGeneratorUsingSpreadsheet(String theVersion, String theBaseDir) {
 		super(theVersion, theBaseDir);
+		super.setFilenameSuffix("");
 	}
 
 	public List<String> getInputStreamNames() {
@@ -68,26 +65,9 @@ public class ResourceGeneratorUsingSpreadsheet extends BaseStructureSpreadsheetP
 		}
 	}
 
-	public void setFilenameSuffix(String theFilenameSuffix) {
-		myFilenameSuffix = theFilenameSuffix;
-	}
-
-	public void setTemplate(String theTemplate) {
-		myTemplate = theTemplate;
-	}
-
-	public void setTemplateFile (File theTemplateFile) {
-		myTemplateFile = theTemplateFile;
-	}
-
 	@Override
 	protected BaseRootType createRootType() {
 		return new Resource();
-	}
-
-	@Override
-	protected String getFilenameSuffix() {
-		return myFilenameSuffix;
 	}
 
 	@Override
@@ -97,18 +77,14 @@ public class ResourceGeneratorUsingSpreadsheet extends BaseStructureSpreadsheetP
 
 	@Override
 	protected String getTemplate() {
-		if (myTemplate != null) {
-			return myTemplate;
+		String template = super.getTemplate();
+		if (template != null) {
+			return template;
 		} else if ("dstu".equals(getVersion())) {
 			return "/vm/resource_dstu.vm";
 		} else {
 			return "/vm/resource.vm";
 		}
-	}
-
-	@Override
-	protected File getTemplateFile() {
-		return myTemplateFile;
 	}
 
 	@Override

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/TargetType.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/parser/TargetType.java
@@ -1,0 +1,22 @@
+/**
+ * 
+ */
+package ca.uhn.fhir.tinder.parser;
+
+/**
+ * @author Bill.Denton
+ *
+ */
+public enum TargetType {
+	/*
+	 * The primary target of a generator is Java source code
+	 * but others might also be generated.
+	 */
+	SOURCE,
+	
+	/*
+	 * The generator will primarilly produce non-source
+	 * files that should be added to Maven Resources
+	 */
+	RESOURCE
+}

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -24,6 +24,11 @@
 			<artifactId>hapi-fhir-structures-dstu</artifactId>
 			<version>2.2-SNAPSHOT</version>
 		</dependency>
+		<dependency>
+			<groupId>ca.uhn.hapi.fhir</groupId>
+			<artifactId>hapi-fhir-structures-dstu2</artifactId>
+			<version>2.2-SNAPSHOT</version>
+		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
@@ -104,14 +109,34 @@
 						</goals>
 						<configuration>
 							<version>dstu</version>
+							<generateResources>true</generateResources>
 							<templateFile>${project.basedir}/src/test/resources/templates/resource_test.vm</templateFile>
-							<packageBase>ca.uhn.test.generic.multi</packageBase>
-							<targetDirectory>${project.build.directory}/generated-sources/tinder</targetDirectory>
+							<targetSourceDirectory>${project.build.directory}/generated-sources/tinder</targetSourceDirectory>
+							<targetPackage>ca.uhn.test.generic.multi</targetPackage>
 							<filenameSuffix>ResourceTest.java</filenameSuffix>
-							<baseResourceNames>
-								<baseResourceName>patient</baseResourceName>
-								<baseResourceName>organization</baseResourceName>
-							</baseResourceNames>
+							<includeResources>
+								<includeResource>patient</includeResource>
+								<includeResource>organization</includeResource>
+							</includeResources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>generic_multi_json</id>
+						<goals>
+							<goal>generate-multi-files</goal>
+						</goals>
+						<configuration>
+							<version>dstu2</version>
+							<generateResources>true</generateResources>
+							<templateFile>${project.basedir}/src/test/resources/templates/resource_map.vm</templateFile>
+							<velocityPath>${project.basedir}/src/test/resources/macros</velocityPath>
+							<targetResourceDirectory>${project.build.directory}/generated-resources/tinder</targetResourceDirectory>
+							<targetFolder>maps</targetFolder>
+							<filenameSuffix>_Map.json</filenameSuffix>
+							<includeResources>
+								<includeResource>patient</includeResource>
+								<includeResource>organization</includeResource>
+							</includeResources>
 						</configuration>
 					</execution>
 					<execution>
@@ -121,15 +146,35 @@
 						</goals>
 						<configuration>
 							<version>dstu</version>
+							<generateResources>true</generateResources>
 							<templateFile>${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm</templateFile>
-							<packageBase>ca.uhn.test.generic.multi</packageBase>
-							<targetDirectory>${project.build.directory}/generated-sources/tinder</targetDirectory>
+							<targetSourceDirectory>${project.build.directory}/generated-sources/tinder</targetSourceDirectory>
 							<targetPackage>ca.uhn.test.generic.single</targetPackage>
+							<packageBase>ca.uhn.test.generic.multi</packageBase>
 							<targetFile>TestConfigDstu1.java</targetFile>
-							<baseResourceNames>
-								<baseResourceName>patient</baseResourceName>
-								<baseResourceName>organization</baseResourceName>
-							</baseResourceNames>
+							<includeResources>
+								<includeResource>patient</includeResource>
+								<includeResource>organization</includeResource>
+							</includeResources>
+						</configuration>
+					</execution>
+					<execution>
+						<id>generic_single_json</id>
+						<goals>
+							<goal>generate-single-file</goal>
+						</goals>
+						<configuration>
+							<version>dstu2</version>
+							<generateDatatypes>true</generateDatatypes>
+							<templateFile>${project.basedir}/src/test/resources/templates/composite_map.vm</templateFile>
+							<velocityPath>${project.basedir}/src/test/resources/macros</velocityPath>
+							<targetResourceDirectory>${project.build.directory}/generated-resources/tinder</targetResourceDirectory>
+							<targetFolder>maps</targetFolder>
+							<targetFile>Datatypes_Dstu2.json</targetFile>
+							<includeResources>
+								<includeResource>patient</includeResource>
+								<includeResource>organization</includeResource>
+							</includeResources>
 						</configuration>
 					</execution>
  					<!-- <execution> <id>client</id> <goals> <goal>generate-client</goal> </goals> <configuration> <clientClassName>ca.uhn.hitest.HiTest</clientClassName> <serverBaseHref>http://fhir.healthintersections.com.au/open</serverBaseHref> 
@@ -138,7 +183,17 @@
 				<dependencies>
 					<dependency>
 						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-base</artifactId>
+						<version>2.2-SNAPSHOT</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
 						<artifactId>hapi-fhir-structures-dstu</artifactId>
+						<version>2.2-SNAPSHOT</version>
+					</dependency>
+					<dependency>
+						<groupId>ca.uhn.hapi.fhir</groupId>
+						<artifactId>hapi-fhir-structures-dstu2</artifactId>
 						<version>2.2-SNAPSHOT</version>
 					</dependency>
 				</dependencies>
@@ -157,22 +212,24 @@
 						<taskdef name="hapi-tinder" classname="ca.uhn.fhir.tinder.ant.TinderGeneratorTask" classpathref="maven.plugin.classpath"/>
 		
 						<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test.vm"
-						             targetDir="${project.build.directory}/generated-sources/tinder"
-									 packageBase="ca.uhn.test.ant.multi"
-						             targetclassSuffix="ResourceTest.java"
+						             generateResources="true"
+						             targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
+									 targetPackage="ca.uhn.test.ant.multi"
+						             filenameSuffix="ResourceTest.java"
 				                     projectHome="${project.basedir}/.."
 						             version="dstu2"
-							         baseResourceNames="patient,organization"
+							         includeResources="patient,organization"
 						/>
 		
 						<hapi-tinder templateFile="${project.basedir}/src/test/resources/templates/resource_test_beans_java.vm"
-						             targetDir="${project.build.directory}/generated-sources/tinder"
+						             generateResources="true"
+						             targetSourceDirectory="${project.build.directory}/generated-sources/tinder"
 						             targetFile="TestConfigDstu2.java"
 									 targetPackage="ca.uhn.test.ant.single"
 									 packageBase="ca.uhn.test.ant.multi"
 				                     projectHome="${project.basedir}/.."
 						             version="dstu2"
-							         baseResourceNames="patient,organization"
+							         includeResources="patient,organization"
 						/>
 		
 		              </target>

--- a/hapi-tinder-test/pom.xml
+++ b/hapi-tinder-test/pom.xml
@@ -136,6 +136,8 @@
 							<includeResources>
 								<includeResource>patient</includeResource>
 								<includeResource>organization</includeResource>
+								<includeResource>bundle</includeResource>
+								<includeResource>composition</includeResource>
 							</includeResources>
 						</configuration>
 					</execution>

--- a/hapi-tinder-test/src/test/resources/macros/dump_templates.vm
+++ b/hapi-tinder-test/src/test/resources/macros/dump_templates.vm
@@ -1,0 +1,84 @@
+##################################################################
+## dumpBaseElement
+##################################################################
+#macro ( dumpBaseElement $lead, $elem )
+${lead}BaseElement:
+${lead}    binding: $!{elem.binding}
+${lead}    bindingClass: $!{elem.bindingClass}
+${lead}    cardMax: $!{elem.cardMax}
+${lead}    cardMin: $!{elem.cardMin}
+${lead}    comments: $!{elem.comments}       
+${lead}    declaringClassNameComplete: $!{elem.declaringClassNameComplete}
+${lead}    declaringClassNameCompleteForChildren: $!{elem.declaringClassNameCompleteForChildren}
+${lead}    definition: $!{elem.definition}
+${lead}    elementName: $!{elem.elementName}
+${lead}    elementParentName: $!{elem.elementParentName}
+${lead}    extensionUrl: $!{elem.extensionUrl}
+${lead}    name: $!{elem.name}
+${lead}    requirement: $!{elem.requirement}
+${lead}    shortName: $!{elem.shortName}
+${lead}    type: [#{foreach}(${t} in $!{elem.type})${t}#{if}($foreach.hasNext),#{end}#{end}]
+${lead}    v2Mapping: $!{elem.v2Mapping}
+${lead}    isExtensionLocal: $!{elem.extensionLocal}
+${lead}    isExtensionModifier: $!{elem.extensionModifier}
+${lead}    isHasExtensionUrl: $!{elem.hasExtensionUrl}
+${lead}    isHasMultipleTypes: $!{elem.hasMultipleTypes}
+${lead}    isModifier: $!{elem.modifier}
+${lead}    isResourceRef: $!{elem.resourceRef}
+${lead}    isSummary: $!{elem.summary}
+#end
+##################################################################
+## dumpChild
+##################################################################
+#macro ( dumpChild $lead, $child )
+${lead}Child:
+${lead}    annotationType: $!{child.annotationType}
+#set ( $st = $!{child.singleType} )
+${lead}    boundDatatype: #{if}(${st}=="CodeDt"||${st}=="CodeableConceptDt")$!{child.boundDatatype}#{end} .
+${lead}    cardMaxForChildAnnotation: $!{child.cardMaxForChildAnnotation}
+${lead}    elementNameSimplified: $!{child.elementNameSimplified}
+${lead}    methodName: $!{child.methodName}
+${lead}    referenceType: $!{child.referenceType}
+${lead}    referenceTypeForConstructor: $!{child.referenceTypeForConstructor}
+${lead}    referenceTypesForMultiple: $!{child.referenceTypesForMultiple}
+${lead}    singleType: $!{child.singleType}
+${lead}    variableName: $!{child.variableName}
+${lead}    isBlock: $!{child.block}
+${lead}    isPrimitive: $!{child.primitive}
+${lead}    primitiveType: #{if}(${child.primitive})$!{child.primitiveType}#{end} .
+${lead}    isBoundCode: $!{child.boundCode}
+${lead}    isRepeatable: $!{child.repeatable}
+${lead}    isSingleChildInstantiable: $!{child.singleChildInstantiable}
+#end ## of macro
+##################################################################
+## childVars
+##################################################################
+#macro ( childVars $lead, $childElements )
+#foreach ( $child in $childElements )
+
+${lead}Child: $!{child.elementName}
+${lead}    Class: $child.class.name
+#dumpBaseElement ("${lead}    ", $child )
+#dumpChild ("${lead}    ", $child )
+#end ## end for-each on child
+#end ## of macro
+##################################################################
+## childResourceBlocks
+##################################################################
+#macro ( childResourceBlocks $lead, $resourceBlockChildren )
+#foreach ( $blockChild in $resourceBlockChildren )
+
+${lead}Block: $!{blockChild.name}
+${lead}    Class: $blockChild.class.name
+#dumpBaseElement ("${lead}    ", $blockChild )
+#dumpChild ("${lead}    ", $blockChild )
+${lead}    ResourceBlock:
+${lead}        className: $!{blockChild.className}
+
+${lead}    Children:                               
+#childVars( "${lead}    ", $blockChild.children )
+
+${lead}    Blocks:                               
+#childResourceBlocks( "${lead}    ", $blockChild.resourceBlockChildren )
+#end
+#end

--- a/hapi-tinder-test/src/test/resources/macros/dump_templates.vm
+++ b/hapi-tinder-test/src/test/resources/macros/dump_templates.vm
@@ -45,6 +45,7 @@ ${lead}    referenceTypesForMultiple: $!{child.referenceTypesForMultiple}
 ${lead}    singleType: $!{child.singleType}
 ${lead}    variableName: $!{child.variableName}
 ${lead}    isBlock: $!{child.block}
+${lead}    isBlockRef: $!{child.blockRef}
 ${lead}    isPrimitive: $!{child.primitive}
 ${lead}    primitiveType: #{if}(${child.primitive})$!{child.primitiveType}#{end} .
 ${lead}    isBoundCode: $!{child.boundCode}

--- a/hapi-tinder-test/src/test/resources/macros/dump_templates.vm
+++ b/hapi-tinder-test/src/test/resources/macros/dump_templates.vm
@@ -4,6 +4,7 @@
 #macro ( dumpBaseElement $lead, $elem )
 ${lead}BaseElement:
 ${lead}    binding: $!{elem.binding}
+${lead}    bindingUri: $!{elem.bindingUrl}
 ${lead}    bindingClass: $!{elem.bindingClass}
 ${lead}    cardMax: $!{elem.cardMax}
 ${lead}    cardMin: $!{elem.cardMin}

--- a/hapi-tinder-test/src/test/resources/templates/composite_map.vm
+++ b/hapi-tinder-test/src/test/resources/templates/composite_map.vm
@@ -1,0 +1,21 @@
+#parse ( "dump_templates.vm" )
+#foreach ( $d in $datatypes )
+Type: ${d.elementName}
+    Class: $d.class.name
+#dumpBaseElement ("    ", $d)
+	BaseRootType:
+		id: $!{d.id}
+		profile: $!{d.profile}
+	Composite:
+		--
+        
+Children:        
+#childVars( "    ", $d.children )
+
+Blocks
+#childResourceBlocks("    ", $d.resourceBlockChildren)
+
+================================================================================
+================================================================================
+
+#end

--- a/hapi-tinder-test/src/test/resources/templates/resource_map.vm
+++ b/hapi-tinder-test/src/test/resources/templates/resource_map.vm
@@ -1,0 +1,17 @@
+#parse ( "dump_templates.vm" )
+Resource: ${elementName}
+    Class: ${this.class.name}
+#dumpBaseElement ("    ", ${this} )
+ 	BaseRootType:
+		id: $!{this.id}
+		profile: $!{this.profile}
+	Resource:
+		searchParameterNames: #{foreach}(${n} in ${this.searchParameterNames})${n}#{if}($foreach.hasNext), #{end}#{end}
+
+        
+Children:        
+#childVars( "    ", $children )
+
+Blocks:
+#childResourceBlocks( "    ", $resourceBlockChildren)
+


### PR DESCRIPTION
This PR enhances the generic single and multi-file Maven plugin and the Ant task as follows:

1) Provides the full Tinder data model with composites, valuesets, and profiles
2) Supports generating files for resources, composites, valuesets, and profiles
3) Supports Velocimacro files outside the tinder-plugin JAR
4) Provides filename prefix as well as suffix properties
5) Miscellaneous functional/naming alignment between all three functions

Still to be done in future work: provide full/proper STU3 support in Tinder
