### PR TITLE
Ensure ParameterUtil.splitParameterString correctly parses consecutive unescaped delimiter

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/ParameterUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/ParameterUtil.java
@@ -108,8 +108,10 @@ public class ParameterUtil {
 						} else {
 							if (b.length() > 0) {
 								retVal.add(b.toString());
-								b.setLength(0);
+							} else {
+								retVal.add(null);
 							}
+							b.setLength(0);
 						}
 					}
 				} else {

--- a/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/rest/param/QuantityParamTest.java
+++ b/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/rest/param/QuantityParamTest.java
@@ -59,6 +59,30 @@ public class QuantityParamTest {
 		assertEquals("5.4||", p.getValueAsQueryToken(ourCtx));
 	}
  
+	@Test
+	public void testNoSystem() {
+		// http://hl7.org/fhir/2017Jan/search.html#quantity
+		// sample url: [baseurl]/Observation?value-quantity=5.5||mg
+		String query = "5.5||mg";
+		QuantityParam param = new QuantityParam();
+		param.setValueAsQueryToken(null, "value-quantity", null, query);
+		// Check parts. The 'mg' part should be put in the units not the system
+		// System.out.println(param);
+		assertEquals(null, param.getPrefix());
+		assertEquals("5.5", param.getValue().toPlainString());
+		assertEquals(null, param.getSystem());
+		assertEquals("mg", param.getUnits());
+		
+		// Make sure we don't break on this one...
+		query = "5.5| |mg";
+		param = new QuantityParam();
+		param.setValueAsQueryToken(null, "value-quantity", null, query);
+		// System.out.println(param);
+		assertEquals(null, param.getPrefix());
+		assertEquals("5.5", param.getValue().toPlainString());
+		assertEquals(null, param.getSystem());
+		assertEquals("mg", param.getUnits());
+	}
 
 	@AfterClass
 	public static void afterClassClearContext() {


### PR DESCRIPTION
This PR fixes #514 and makes modifications to ParameterUtil.splitParameterString such that a QuantityParam value of '5.5||mg' the 'mg' is treated as the 'unit' and not as the 'system'.