### PR TITLE
return 404 instead of 400 when the FHIR resource/endpoint is not recognized/not supported

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -75,6 +75,7 @@ import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import ca.uhn.fhir.rest.server.exceptions.BaseServerResponseException;
 import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.exceptions.NotModifiedException;
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
 import ca.uhn.fhir.rest.server.interceptor.ExceptionHandlingInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
@@ -253,7 +254,7 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 		} else {
 			resourceBinding = myResourceNameToBinding.get(resourceName);
 			if (resourceBinding == null) {
-				throw new InvalidRequestException("Unknown resource type '" + resourceName + "' - Server knows how to handle: " + myResourceNameToBinding.keySet());
+				throw new ResourceNotFoundException("Unknown resource type '" + resourceName + "' - Server knows how to handle: " + myResourceNameToBinding.keySet());
 			}
 		}
 

--- a/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/rest/server/RestfulServerMethodTest.java
+++ b/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/rest/server/RestfulServerMethodTest.java
@@ -527,7 +527,7 @@ public class RestfulServerMethodTest {
 	}
 
 	@Test
-	public void testInvalidResourceTriggers400() throws Exception {
+	public void testInvalidResourceTriggers404() throws Exception {
 
 		HttpGet httpGet = new HttpGet("http://localhost:" + ourPort + "/FooResource?blah=bar");
 		HttpResponse status = ourClient.execute(httpGet);
@@ -537,7 +537,7 @@ public class RestfulServerMethodTest {
 
 		ourLog.info("Response was:\n{}", responseContent);
 
-		assertEquals(400, status.getStatusLine().getStatusCode());
+		assertEquals(404, status.getStatusLine().getStatusCode());
 	}
 
 	@Test

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/ServerFeaturesDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/ServerFeaturesDstu2Test.java
@@ -82,7 +82,7 @@ public class ServerFeaturesDstu2Test {
 		IOUtils.closeQuietly(status.getEntity().getContent());
 
 		ourLog.info(responseContent);
-		assertEquals(400, status.getStatusLine().getStatusCode());
+		assertEquals(404, status.getStatusLine().getStatusCode());
 	}
 
 	/**

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/interceptor/ResponseHighlightingInterceptorTest.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/interceptor/ResponseHighlightingInterceptorTest.java
@@ -171,7 +171,7 @@ public class ResponseHighlightingInterceptorTest {
 		IOUtils.closeQuietly(status.getEntity().getContent());
 
 		ourLog.info("Resp: {}", responseContent);
-		assertEquals(400, status.getStatusLine().getStatusCode());
+		assertEquals(404, status.getStatusLine().getStatusCode());
 
 		assertThat(responseContent, not(stringContainsInOrder("<span class='hlTagName'>OperationOutcome</span>", "Unknown resource type 'Foobar' - Server knows how to handle")));
 		assertThat(responseContent, (stringContainsInOrder("Unknown resource type 'Foobar'")));


### PR DESCRIPTION
This PR fixes #539.

This fix should also be compatible with DSTU2...

http://hl7.org/fhir/DSTU2/http.html#2.1.0.10.1
http://hl7.org/fhir/DSTU2/http.html#create

...and DSTU1

http://hl7.org/fhir/DSTU1/http.html#update
http://hl7.org/fhir/DSTU1/http.html#create