### PR TITLE
Revise saveConcept method to use save() instead of saveAndFlush()

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseHapiTerminologySvc.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseHapiTerminologySvc.java
@@ -396,7 +396,7 @@ public abstract class BaseHapiTerminologySvc implements IHapiTerminologySvc {
 		if (theConcept.getId() == null || theConcept.getIndexStatus() == null) {
 			retVal++;
 			theConcept.setIndexStatus(BaseHapiFhirDao.INDEX_STATUS_INDEXED);
-			myConceptDao.saveAndFlush(theConcept);
+			myConceptDao.save(theConcept);
 		}
 		
 		ourLog.trace("Saved {} and got PID {}", theConcept.getCode(), theConcept.getId());


### PR DESCRIPTION
Closes   #574 

Revise saveConcept method to use myConceptDao.save() instead of myConceptDao.saveAndFlush(), to avoid excessive CPU utilization when persisting a large CodeSystem (e.g. one with 399837 concepts).

Commentary:  It seems the Hibernate flush operation contains code which performs an O(N^2) operation on the cache, and saveAndFlush causes that to be performed N times.  Not good when N is 399837.

I think this change is reasonably safe, because saveConcept is only used within a transaction context.  However, this may also benefit from a review by someone more familiar with HAPI's inner workings.