### PR TITLE
Added a validation post-processing hook.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/interceptor/BaseValidatingInterceptor.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/interceptor/BaseValidatingInterceptor.java
@@ -268,6 +268,11 @@ abstract class BaseValidatingInterceptor<T> extends InterceptorAdapter {
 	protected void postProcessResult(RequestDetails theRequestDetails, ValidationResult theValidationResult) { }
 
 	/**
+	 * Hook for subclasses on failure (e.g. add a response header to an incoming resource upon rejection).
+	 */
+	protected void postProcessResultOnFailure(RequestDetails theRequestDetails, ValidationResult theValidationResult) { }
+
+	/**
 	 * Note: May return null
 	 */
 	protected ValidationResult validate(T theRequest, RequestDetails theRequestDetails) {
@@ -314,6 +319,7 @@ abstract class BaseValidatingInterceptor<T> extends InterceptorAdapter {
 		if (myFailOnSeverity != null) {
 			for (SingleValidationMessage next : validationResult.getMessages()) {
 				if (next.getSeverity().ordinal() >= myFailOnSeverity) {
+					postProcessResultOnFailure(theRequestDetails, validationResult);
 					fail(theRequestDetails, validationResult);
 					return validationResult;
 				}

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -202,6 +202,11 @@
 				the JPA database, improving performance of this operation. Thanks to
 				Joel Schneider for the pull request and analysis!
 			</action>
+			<action type="add">
+				A new post-processing hook for subclasses of BaseValidatingInterceptor is now
+				available. The hook exposes the request details on validation failure prior to throwing an
+				UnprocessableEntityException.
+			</action>
 		</release>
 		<release version="2.2" date="2016-12-20">
 			<action type="add">


### PR DESCRIPTION
This will expose request details and validation results to subclasses just prior to throwing an UnprocessableEntityException for failed requests.