### PR TITLE
Accept header and MIME type fixes for DSTU2_1

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirVersionEnum.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirVersionEnum.java
@@ -9,9 +9,9 @@ package ca.uhn.fhir.context;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,7 +28,7 @@ public enum FhirVersionEnum {
 	/*
 	 * ***********************
 	 * Don't auto-sort this type!!!
-	 * 
+	 *
 	 * Or more accurately, entries should be sorted from OLDEST FHIR release
 	 * to NEWEST FHIR release instead of alphabetically
 	 * ***********************
@@ -87,11 +87,11 @@ public enum FhirVersionEnum {
 	}
 
 	public boolean isNewerThan(FhirVersionEnum theVersion) {
-		return ordinal() > theVersion.ordinal();
+		return !isEquivalentTo(theVersion) && ordinal() > theVersion.ordinal();
 	}
 
 	public boolean isOlderThan(FhirVersionEnum theVersion) {
-		return ordinal() < theVersion.ordinal();
+		return !isEquivalentTo(theVersion) && ordinal() < theVersion.ordinal();
 	}
 
 	/**

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -791,19 +791,19 @@ public class RestfulServerUtils {
 
 	public static void addAcceptHeaderToRequest(EncodingEnum theEncoding, IHttpRequest theHttpRequest, FhirContext theContext) {
 		if (theEncoding == null) {
-			if (theContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU2) == false) {
+			if (theContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU2_1) == false) {
 				theHttpRequest.addHeader(Constants.HEADER_ACCEPT, Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY);
 			} else {
 				theHttpRequest.addHeader(Constants.HEADER_ACCEPT, Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_NON_LEGACY);
 			}
 		} else if (theEncoding == EncodingEnum.JSON) {
-			if (theContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU2) == false) {
+			if (theContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU2_1) == false) {
 				theHttpRequest.addHeader(Constants.HEADER_ACCEPT, Constants.CT_FHIR_JSON);
 			} else {
 				theHttpRequest.addHeader(Constants.HEADER_ACCEPT, Constants.HEADER_ACCEPT_VALUE_JSON_NON_LEGACY);
 			}
 		} else if (theEncoding == EncodingEnum.XML) {
-			if (theContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU2) == false) {
+			if (theContext.getVersion().getVersion().isNewerThan(FhirVersionEnum.DSTU2_1) == false) {
 				theHttpRequest.addHeader(Constants.HEADER_ACCEPT, Constants.CT_FHIR_XML);
 			} else {
 				theHttpRequest.addHeader(Constants.HEADER_ACCEPT, Constants.HEADER_ACCEPT_VALUE_XML_NON_LEGACY);

--- a/hapi-fhir-structures-dstu2.1/src/main/java/org/hl7/fhir/dstu2016may/hapi/rest/server/ServerConformanceProvider.java
+++ b/hapi-fhir-structures-dstu2.1/src/main/java/org/hl7/fhir/dstu2016may/hapi/rest/server/ServerConformanceProvider.java
@@ -222,8 +222,8 @@ public class ServerConformanceProvider implements IServerConformanceProvider<Con
 		retVal.setKind(ConformanceStatementKind.INSTANCE);
 		retVal.getSoftware().setName(myServerConfiguration.getServerName());
 		retVal.getSoftware().setVersion(myServerConfiguration.getServerVersion());
-		retVal.addFormat(Constants.CT_FHIR_XML_NEW);
-		retVal.addFormat(Constants.CT_FHIR_JSON_NEW);
+		retVal.addFormat(Constants.CT_FHIR_XML);
+		retVal.addFormat(Constants.CT_FHIR_JSON);
 		retVal.setStatus(ConformanceResourceStatus.ACTIVE);
 
 		ConformanceRestComponent rest = retVal.addRest();

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2_1Test.java
@@ -109,7 +109,7 @@ public class GenericClientDstu2_1Test {
 		byte[] body = IOUtils.toByteArray(((HttpEntityEnclosingRequestBase) capt.getAllValues().get(0)).getEntity().getContent());
 		return body;
 	}
-	
+
 	private String extractBodyAsString(ArgumentCaptor<HttpUriRequest> capt) throws IOException {
 		String body = IOUtils.toString(((HttpEntityEnclosingRequestBase) capt.getAllValues().get(0)).getEntity().getContent(), "UTF-8");
 		return body;
@@ -164,7 +164,7 @@ public class GenericClientDstu2_1Test {
 		assertEquals(patch, extractBodyAsString(capt));
 		assertEquals(Constants.CT_JSON_PATCH, capt.getAllValues().get(idx).getFirstHeader("Content-Type").getValue().replaceAll(";.*", ""));
 		idx++;
-		
+
 		OperationOutcome oo = (OperationOutcome) outcome.getOperationOutcome();
 		assertThat(oo.getText().getDivAsString(), containsString("OK!"));
 	}
@@ -201,7 +201,7 @@ public class GenericClientDstu2_1Test {
 		assertEquals(patch, extractBodyAsString(capt));
 		assertEquals(Constants.CT_JSON_PATCH, capt.getAllValues().get(idx).getFirstHeader("Content-Type").getValue().replaceAll(";.*", ""));
 		idx++;
-		
+
 		OperationOutcome oo = (OperationOutcome) outcome.getOperationOutcome();
 		assertThat(oo.getText().getDivAsString(), containsString("OK!"));
 	}
@@ -238,7 +238,7 @@ public class GenericClientDstu2_1Test {
 		assertEquals(patch, extractBodyAsString(capt));
 		assertEquals(Constants.CT_JSON_PATCH, capt.getAllValues().get(idx).getFirstHeader("Content-Type").getValue().replaceAll(";.*", ""));
 		idx++;
-		
+
 		OperationOutcome oo = (OperationOutcome) outcome.getOperationOutcome();
 		assertThat(oo.getText().getDivAsString(), containsString("OK!"));
 	}
@@ -276,7 +276,7 @@ public class GenericClientDstu2_1Test {
 		assertEquals(patch, extractBodyAsString(capt));
 		assertEquals(Constants.CT_JSON_PATCH, capt.getAllValues().get(idx).getFirstHeader("Content-Type").getValue().replaceAll(";.*", ""));
 		idx++;
-		
+
 		OperationOutcome oo = (OperationOutcome) outcome.getOperationOutcome();
 		assertThat(oo.getText().getDivAsString(), containsString("OK!"));
 	}
@@ -314,7 +314,7 @@ public class GenericClientDstu2_1Test {
 		assertEquals(patch, extractBodyAsString(capt));
 		assertEquals(Constants.CT_JSON_PATCH, capt.getAllValues().get(idx).getFirstHeader("Content-Type").getValue().replaceAll(";.*", ""));
 		idx++;
-		
+
 		OperationOutcome oo = (OperationOutcome) outcome.getOperationOutcome();
 		assertThat(oo.getText().getDivAsString(), containsString("OK!"));
 	}
@@ -351,11 +351,11 @@ public class GenericClientDstu2_1Test {
 		assertEquals(patch, extractBodyAsString(capt));
 		assertEquals(Constants.CT_XML_PATCH, capt.getAllValues().get(idx).getFirstHeader("Content-Type").getValue().replaceAll(";.*", ""));
 		idx++;
-		
+
 		OperationOutcome oo = (OperationOutcome) outcome.getOperationOutcome();
 		assertThat(oo.getText().getDivAsString(), containsString("OK!"));
 	}
-	
+
 	@Test
 	public void testPatchInvalid() throws Exception {
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://example.com/fhir");
@@ -397,9 +397,9 @@ public class GenericClientDstu2_1Test {
 			.execute();
 		//@formatter:on
 		assertEquals("http://example.com/fhir/Device?_format=json", UrlUtil.unescape(capt.getAllValues().get(idx).getURI().toString()));
-		assertEquals("application/fhir+json;q=1.0, application/json+fhir;q=0.9", capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
+		assertEquals(Constants.CT_FHIR_JSON+";q=1.0, application/json+fhir;q=0.9", capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
 		idx++;
-		
+
 		//@formatter:off
 		client.setEncoding(EncodingEnum.XML);
 		client.search()
@@ -408,9 +408,9 @@ public class GenericClientDstu2_1Test {
 			.execute();
 		//@formatter:on
 		assertEquals("http://example.com/fhir/Device?_format=xml", UrlUtil.unescape(capt.getAllValues().get(idx).getURI().toString()));
-		assertEquals("application/fhir+xml;q=1.0, application/xml+fhir;q=0.9", capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
+		assertEquals(Constants.CT_FHIR_XML+";q=1.0, application/xml+fhir;q=0.9", capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
 		idx++;
-		
+
 	}
 
 	@Test
@@ -491,9 +491,9 @@ public class GenericClientDstu2_1Test {
 		assertArrayEquals(new byte[] { 0, 1, 2, 3, 4 }, ourCtx.newXmlParser().parseResource(Binary.class, extractBodyAsString(capt)).getContent());
 
 	}
-	
-	
-	
+
+
+
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testClientFailures() throws Exception {
@@ -603,7 +603,7 @@ public class GenericClientDstu2_1Test {
 		assertEquals(myAnswerCount, capt.getAllValues().size());
 		assertEquals("http://example.com/fhir/Patient", capt.getAllValues().get(0).getURI().toASCIIString());
 		assertEquals(Constants.CT_FHIR_XML, capt.getAllValues().get(0).getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
-		
+
 		assertEquals("http://foo.com/base/Patient/222/_history/3", capt.getAllValues().get(1).getURI().toASCIIString());
 	}
 
@@ -1034,7 +1034,7 @@ public class GenericClientDstu2_1Test {
 
 		assertEquals("http://example.com/fhir/Patient", capt.getAllValues().get(idx).getURI().toString());
 		idx++;
-		
+
 		//@formatter:off
       client
       	.search()
@@ -1060,22 +1060,22 @@ public class GenericClientDstu2_1Test {
 		idx++;
 
 	}
-	
+
 	@Test
 	public void testPutDoesntForceAllIdsJson() throws Exception {
 		IParser p = ourCtx.newJsonParser();
-		
+
 		Patient patient = new Patient();
 		patient.setId("PATIENT1");
 		patient.addName().addFamily("PATIENT1");
-		
+
 		Bundle bundle = new Bundle();
 		bundle.setId("BUNDLE1");
 		bundle.addEntry().setResource(patient);
-		
+
 		final String encoded = p.encodeResourceToString(bundle);
 		assertEquals("{\"resourceType\":\"Bundle\",\"id\":\"BUNDLE1\",\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"PATIENT1\",\"name\":[{\"family\":[\"PATIENT1\"]}]}}]}", encoded);
-		
+
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
 		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
 		when(myHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
@@ -1097,29 +1097,29 @@ public class GenericClientDstu2_1Test {
 			.prefer(PreferReturnEnum.REPRESENTATION)
 			.encodedJson()
 			.execute();
-		
+
 		HttpPut httpRequest = (HttpPut) capt.getValue();
 		assertEquals("http://example.com/fhir/Bundle/BUNDLE1", httpRequest.getURI().toASCIIString());
-		
+
 		String requestString = IOUtils.toString(httpRequest.getEntity().getContent(), StandardCharsets.UTF_8);
 		assertEquals(encoded, requestString);
 	}
-	
+
 	@Test
 	public void testPutDoesntForceAllIdsXml() throws Exception {
 		IParser p = ourCtx.newXmlParser();
-		
+
 		Patient patient = new Patient();
 		patient.setId("PATIENT1");
 		patient.addName().addFamily("PATIENT1");
-		
+
 		Bundle bundle = new Bundle();
 		bundle.setId("BUNDLE1");
 		bundle.addEntry().setResource(patient);
-		
+
 		final String encoded = p.encodeResourceToString(bundle);
 		assertEquals("<Bundle xmlns=\"http://hl7.org/fhir\"><id value=\"BUNDLE1\"/><entry><resource><Patient xmlns=\"http://hl7.org/fhir\"><id value=\"PATIENT1\"/><name><family value=\"PATIENT1\"/></name></Patient></resource></entry></Bundle>", encoded);
-		
+
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
 		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
 		when(myHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
@@ -1140,10 +1140,10 @@ public class GenericClientDstu2_1Test {
 			.resource(bundle)
 			.prefer(PreferReturnEnum.REPRESENTATION)
 			.execute();
-		
+
 		HttpPut httpRequest = (HttpPut) capt.getValue();
 		assertEquals("http://example.com/fhir/Bundle/BUNDLE1", httpRequest.getURI().toASCIIString());
-		
+
 		String requestString = IOUtils.toString(httpRequest.getEntity().getContent(), StandardCharsets.UTF_8);
 		assertEquals(encoded, requestString);
 	}
@@ -1231,7 +1231,7 @@ public class GenericClientDstu2_1Test {
 	}
 
 	@Test
-	public void testSearchByDate() throws Exception {		
+	public void testSearchByDate() throws Exception {
 		final String msg = "{\"resourceType\":\"Bundle\",\"id\":null,\"base\":\"http://localhost:57931/fhir/contextDev\",\"total\":1,\"link\":[{\"relation\":\"self\",\"url\":\"http://localhost:57931/fhir/contextDev/Patient?identifier=urn%3AMultiFhirVersionTest%7CtestSubmitPatient01&_format=json\"}],\"entry\":[{\"resource\":{\"resourceType\":\"Patient\",\"id\":\"1\",\"meta\":{\"versionId\":\"1\",\"lastUpdated\":\"2014-12-20T18:41:29.706-05:00\"},\"identifier\":[{\"system\":\"urn:MultiFhirVersionTest\",\"value\":\"testSubmitPatient01\"}]}}]}";
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -1646,7 +1646,7 @@ public class GenericClientDstu2_1Test {
 		int idx = 0;
 
 		Collection<String> values = Arrays.asList("VAL1", "VAL2", "VAL3A,B");
-		
+
 		//@formatter:off
 		client.search()
 			.forResource("Patient")
@@ -1701,7 +1701,7 @@ public class GenericClientDstu2_1Test {
 			.returnBundle(Bundle.class)
 			.execute();
 		assertEquals("http://example.com/fhir/Patient?_sort=-address", capt.getAllValues().get(idx++).getURI().toASCIIString());
-		
+
 			client
 			.search()
 			.forResource(Patient.class)
@@ -2019,7 +2019,7 @@ public class GenericClientDstu2_1Test {
 		MyPatientWithExtensions patient = new MyPatientWithExtensions();
 		patient.setId("123");
 		patient.getText().setDivAsString("OK!");
-		
+
 		final String respString = p.encodeResourceToString(patient);
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
 		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
@@ -2035,7 +2035,7 @@ public class GenericClientDstu2_1Test {
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://example.com/fhir");
 		MyPatientWithExtensions read = client.read().resource(MyPatientWithExtensions.class).withId(new IdType("1")).execute();
 		assertEquals("<div xmlns=\"http://www.w3.org/1999/xhtml\">OK!</div>", read.getText().getDivAsString());
-		
+
 		// Ensure that we haven't overridden the default type for the name
 		assertFalse(MyPatientWithExtensions.class.isAssignableFrom(Patient.class));
 		assertFalse(Patient.class.isAssignableFrom(MyPatientWithExtensions.class));
@@ -2044,7 +2044,7 @@ public class GenericClientDstu2_1Test {
 		IParser parser = ourCtx.newXmlParser();
 		String encoded = parser.encodeResourceToString(pt);
 		pt = (Patient) parser.parseResource(encoded);
-		
+
 	}
 
 	@Test
@@ -2052,13 +2052,13 @@ public class GenericClientDstu2_1Test {
 		IParser p = ourCtx.newXmlParser();
 
 		Bundle b = new Bundle();
-		
+
 		MyPatientWithExtensions patient = new MyPatientWithExtensions();
 		patient.setId("123");
 		patient.getText().setDivAsString("OK!");
 		b.addEntry().setResource(patient);
-		
-		
+
+
 		final String respString = p.encodeResourceToString(b);
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
 		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
@@ -2073,7 +2073,7 @@ public class GenericClientDstu2_1Test {
 
 		IGenericClient client = ourCtx.newRestfulGenericClient("http://example.com/fhir");
 		Bundle bundle = client.search().forResource(MyPatientWithExtensions.class).returnBundle(Bundle.class).execute();
-		
+
 		assertEquals(1, bundle.getEntry().size());
 		assertEquals(MyPatientWithExtensions.class, bundle.getEntry().get(0).getResource().getClass());
 	}
@@ -2089,8 +2089,8 @@ public class GenericClientDstu2_1Test {
 		assertEquals(expectedUserAgent(), capt.getAllValues().get(0).getHeaders("User-Agent")[0].getValue());
 	}
 
-	
-	
+
+
 	@AfterClass
 	public static void afterClassClearContext() {
 		TestUtil.clearAllStaticFieldsForUnitTest();
@@ -2100,5 +2100,5 @@ public class GenericClientDstu2_1Test {
 	public static void beforeClass() {
 		ourCtx = FhirContext.forDstu2_1();
 	}
-	
+
 }

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2_1Test.java
@@ -397,7 +397,7 @@ public class GenericClientDstu2_1Test {
 			.execute();
 		//@formatter:on
 		assertEquals("http://example.com/fhir/Device?_format=json", UrlUtil.unescape(capt.getAllValues().get(idx).getURI().toString()));
-		assertEquals(Constants.CT_FHIR_JSON+";q=1.0, application/json+fhir;q=0.9", capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
+		assertEquals(Constants.CT_FHIR_JSON, capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
 		idx++;
 
 		//@formatter:off
@@ -408,7 +408,7 @@ public class GenericClientDstu2_1Test {
 			.execute();
 		//@formatter:on
 		assertEquals("http://example.com/fhir/Device?_format=xml", UrlUtil.unescape(capt.getAllValues().get(idx).getURI().toString()));
-		assertEquals(Constants.CT_FHIR_XML+";q=1.0, application/xml+fhir;q=0.9", capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
+		assertEquals(Constants.CT_FHIR_XML, capt.getAllValues().get(idx).getFirstHeader(Constants.HEADER_ACCEPT).getValue());
 		idx++;
 
 	}
@@ -448,7 +448,7 @@ public class GenericClientDstu2_1Test {
 		validateUserAgent(capt);
 
 		assertEquals("application/xml+fhir;charset=utf-8", capt.getAllValues().get(0).getHeaders("Content-Type")[0].getValue().toLowerCase().replace(" ", ""));
-		assertEquals(Constants.HEADER_ACCEPT_VALUE_XML_NON_LEGACY, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
+		assertEquals(Constants.CT_FHIR_XML, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
 		Binary output = ourCtx.newXmlParser().parseResource(Binary.class, extractBodyAsString(capt));
 		assertEquals(Constants.CT_FHIR_JSON, output.getContentType());
 
@@ -487,7 +487,7 @@ public class GenericClientDstu2_1Test {
 		validateUserAgent(capt);
 
 		assertEquals("application/xml+fhir;charset=utf-8", capt.getAllValues().get(0).getHeaders("Content-Type")[0].getValue().toLowerCase().replace(" ", ""));
-		assertEquals(Constants.HEADER_ACCEPT_VALUE_XML_NON_LEGACY, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
+		assertEquals(Constants.CT_FHIR_XML, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
 		assertArrayEquals(new byte[] { 0, 1, 2, 3, 4 }, ourCtx.newXmlParser().parseResource(Binary.class, extractBodyAsString(capt)).getContent());
 
 	}
@@ -1786,7 +1786,7 @@ public class GenericClientDstu2_1Test {
 		validateUserAgent(capt);
 
 		assertEquals("application/xml+fhir;charset=utf-8", capt.getAllValues().get(0).getHeaders("Content-Type")[0].getValue().toLowerCase().replace(" ", ""));
-		assertEquals(Constants.HEADER_ACCEPT_VALUE_XML_NON_LEGACY, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
+		assertEquals(Constants.CT_FHIR_XML, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
 		String body = extractBodyAsString(capt);
 		assertThat(body, containsString("<id value=\"111\"/>"));
 	}
@@ -1917,7 +1917,7 @@ public class GenericClientDstu2_1Test {
 		validateUserAgent(capt);
 
 		assertEquals("application/foo", capt.getAllValues().get(0).getHeaders("Content-Type")[0].getValue());
-		assertEquals(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_NON_LEGACY, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
+		assertEquals(Constants.HEADER_ACCEPT_VALUE_XML_OR_JSON_LEGACY, capt.getAllValues().get(0).getHeaders("Accept")[0].getValue());
 		assertArrayEquals(new byte[] { 0, 1, 2, 3, 4 }, extractBodyAsByteArray(capt));
 
 	}

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/GenericClientDstu2_1Test.java
@@ -1079,7 +1079,7 @@ public class GenericClientDstu2_1Test {
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
 		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
 		when(myHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
-		when(myHttpResponse.getEntity().getContentType()).thenReturn(new BasicHeader("content-type", Constants.CT_FHIR_JSON_NEW + "; charset=UTF-8"));
+		when(myHttpResponse.getEntity().getContentType()).thenReturn(new BasicHeader("content-type", Constants.CT_FHIR_JSON + "; charset=UTF-8"));
 		when(myHttpResponse.getEntity().getContent()).thenAnswer(new Answer<ReaderInputStream>() {
 			@Override
 			public ReaderInputStream answer(InvocationOnMock theInvocation) throws Throwable {

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/PatchClientDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/client/PatchClientDstu2_1Test.java
@@ -116,7 +116,7 @@ public class PatchClientDstu2_1Test {
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
 		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
 		when(myHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
-		when(myHttpResponse.getEntity().getContentType()).thenReturn(new BasicHeader("content-type", Constants.CT_FHIR_XML_NEW + "; charset=UTF-8"));
+		when(myHttpResponse.getEntity().getContentType()).thenReturn(new BasicHeader("content-type", Constants.CT_FHIR_XML + "; charset=UTF-8"));
 		when(myHttpResponse.getEntity().getContent()).thenAnswer(new Answer<ReaderInputStream>() {
 			@Override
 			public ReaderInputStream answer(InvocationOnMock theInvocation) throws Throwable {

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/CreateDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/CreateDstu2_1Test.java
@@ -67,7 +67,7 @@ public class CreateDstu2_1Test {
 	public void testCreateReturnsLocationHeader() throws Exception {
 
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
-		httpPost.setEntity(new StringEntity("{\"resourceType\":\"Patient\", \"status\":\"active\"}", ContentType.parse("application/fhir+json; charset=utf-8")));
+		httpPost.setEntity(new StringEntity("{\"resourceType\":\"Patient\", \"status\":\"active\"}", ContentType.parse(Constants.CT_FHIR_JSON+"; charset=utf-8")));
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -88,7 +88,7 @@ public class CreateDstu2_1Test {
 		ourReturnOo = new OperationOutcome().addIssue(new OperationOutcomeIssueComponent().setDiagnostics("DIAG"));
 		
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
-		httpPost.setEntity(new StringEntity("{\"resourceType\":\"Patient\", \"status\":\"active\"}", ContentType.parse("application/fhir+json; charset=utf-8")));
+		httpPost.setEntity(new StringEntity("{\"resourceType\":\"Patient\", \"status\":\"active\"}", ContentType.parse(Constants.CT_FHIR_JSON+"; charset=utf-8")));
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -146,7 +146,7 @@ public class CreateDstu2_1Test {
 	public void testCreateWithIncorrectContent2() throws Exception {
 
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
-		httpPost.setEntity(new StringEntity("{\"foo\":\"bar\"}", ContentType.parse("application/fhir+xml; charset=utf-8")));
+		httpPost.setEntity(new StringEntity("{\"foo\":\"bar\"}", ContentType.parse(Constants.CT_FHIR_XML+"; charset=utf-8")));
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -165,7 +165,7 @@ public class CreateDstu2_1Test {
 	public void testCreateWithIncorrectContent3() throws Exception {
 
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
-		httpPost.setEntity(new StringEntity("{\"foo\":\"bar\"}", ContentType.parse("application/fhir+json; charset=utf-8")));
+		httpPost.setEntity(new StringEntity("{\"foo\":\"bar\"}", ContentType.parse(Constants.CT_FHIR_JSON+"; charset=utf-8")));
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/SearchPostDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/SearchPostDstu2_1Test.java
@@ -71,7 +71,7 @@ public class SearchPostDstu2_1Test {
 		ourLastMethod = null;
 		ourLastSortSpec = null;
 		ourLastName = null;
-		
+
 		for (IServerInterceptor next : new ArrayList<IServerInterceptor>(ourServlet.getInterceptors())) {
 			ourServlet.unregisterInterceptor(next);
 		}
@@ -82,14 +82,14 @@ public class SearchPostDstu2_1Test {
 	 */
 	@Test
 	public void testSearchWithMixedParamsNoInterceptorsYesParams() throws Exception {
-		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient/_search?_format=application/fhir+json");
+		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient/_search?_format="+Constants.CT_FHIR_JSON);
 		httpPost.addHeader("Cache-Control","no-cache");
 		List<NameValuePair> parameters = Lists.newArrayList();
 		parameters.add(new BasicNameValuePair("name", "Smith"));
 		httpPost.setEntity(new UrlEncodedFormEntity(parameters));
 
 		ourLog.info("Outgoing post: {}", httpPost);
-		
+
 		CloseableHttpResponse status = ourClient.execute(httpPost);
 		try {
 			String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -120,7 +120,7 @@ public class SearchPostDstu2_1Test {
 		httpPost.setEntity(new UrlEncodedFormEntity(parameters));
 
 		ourLog.info("Outgoing post: {}", httpPost);
-		
+
 		CloseableHttpResponse status = ourClient.execute(httpPost);
 		try {
 			String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -145,15 +145,15 @@ public class SearchPostDstu2_1Test {
 	@Test
 	public void testSearchWithMixedParamsYesInterceptorsYesParams() throws Exception {
 		ourServlet.registerInterceptor(new ParamLoggingInterceptor());
-		
-		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient/_search?_format=application/fhir+json");
+
+		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient/_search?_format="+Constants.CT_FHIR_JSON);
 		httpPost.addHeader("Cache-Control","no-cache");
 		List<NameValuePair> parameters = Lists.newArrayList();
 		parameters.add(new BasicNameValuePair("name", "Smith"));
 		httpPost.setEntity(new UrlEncodedFormEntity(parameters));
 
 		ourLog.info("Outgoing post: {}", httpPost);
-		
+
 		CloseableHttpResponse status = ourClient.execute(httpPost);
 		try {
 			String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -178,7 +178,7 @@ public class SearchPostDstu2_1Test {
 	@Test
 	public void testSearchWithMixedParamsYesInterceptorsNoParams() throws Exception {
 		ourServlet.registerInterceptor(new ParamLoggingInterceptor());
-		
+
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient/_search");
 		httpPost.addHeader("Cache-Control","no-cache");
 		List<NameValuePair> parameters = Lists.newArrayList();
@@ -186,7 +186,7 @@ public class SearchPostDstu2_1Test {
 		httpPost.setEntity(new UrlEncodedFormEntity(parameters));
 
 		ourLog.info("Outgoing post: {}", httpPost);
-		
+
 		CloseableHttpResponse status = ourClient.execute(httpPost);
 		try {
 			String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -204,7 +204,7 @@ public class SearchPostDstu2_1Test {
 		}
 
 	}
-	
+
 	@AfterClass
 	public static void afterClassClearContext() throws Exception {
 		ourServer.stop();

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/SearchPostDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/SearchPostDstu2_1Test.java
@@ -101,7 +101,7 @@ public class SearchPostDstu2_1Test {
 			assertEquals(1, ourLastName.getValuesAsQueryTokens().size());
 			assertEquals(1, ourLastName.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().size());
 			assertEquals("Smith", ourLastName.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0).getValue());
-			assertEquals(Constants.CT_FHIR_JSON_NEW, status.getEntity().getContentType().getValue().replaceAll(";.*", ""));
+			assertEquals(Constants.CT_FHIR_JSON, status.getEntity().getContentType().getValue().replaceAll(";.*", ""));
 		} finally {
 			IOUtils.closeQuietly(status.getEntity().getContent());
 		}
@@ -165,7 +165,7 @@ public class SearchPostDstu2_1Test {
 			assertEquals(1, ourLastName.getValuesAsQueryTokens().size());
 			assertEquals(1, ourLastName.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().size());
 			assertEquals("Smith", ourLastName.getValuesAsQueryTokens().get(0).getValuesAsQueryTokens().get(0).getValue());
-			assertEquals(Constants.CT_FHIR_JSON_NEW, status.getEntity().getContentType().getValue().replaceAll(";.*", ""));
+			assertEquals(Constants.CT_FHIR_JSON, status.getEntity().getContentType().getValue().replaceAll(";.*", ""));
 		} finally {
 			IOUtils.closeQuietly(status.getEntity().getContent());
 		}

--- a/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/ServerMimetypeDstu2_1Test.java
+++ b/hapi-fhir-structures-dstu2.1/src/test/java/ca/uhn/fhir/rest/server/ServerMimetypeDstu2_1Test.java
@@ -66,7 +66,7 @@ public class ServerMimetypeDstu2_1Test {
 			ourLog.info(content);
 			Conformance conf = ourCtx.newXmlParser().parseResource(Conformance.class, content);
 			List<String> strings = toStrings(conf.getFormat());
-			assertThat(strings, contains(Constants.CT_FHIR_XML_NEW, Constants.CT_FHIR_JSON_NEW));
+			assertThat(strings, contains(Constants.CT_FHIR_XML, Constants.CT_FHIR_JSON));
 		} finally {
 			status.close();
 		}
@@ -141,7 +141,7 @@ public class ServerMimetypeDstu2_1Test {
 		String enc = ourCtx.newXmlParser().encodeResourceToString(p);
 		
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
-		httpPost.setEntity(new StringEntity(enc, ContentType.parse(Constants.CT_FHIR_XML_NEW + "; charset=utf-8")));
+		httpPost.setEntity(new StringEntity(enc, ContentType.parse(Constants.CT_FHIR_XML+ "; charset=utf-8")));
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -150,7 +150,7 @@ public class ServerMimetypeDstu2_1Test {
 		ourLog.info("Response was:\n{}", responseContent);
 
 		assertEquals(201, status.getStatusLine().getStatusCode());
-		assertEquals(Constants.CT_FHIR_XML_NEW, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
+		assertEquals(Constants.CT_FHIR_XML, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
 		assertEquals("<OperationOutcome xmlns=\"http://hl7.org/fhir\"><issue><diagnostics value=\"FAMILY\"/></issue></OperationOutcome>", responseContent);
 	}
 
@@ -162,7 +162,7 @@ public class ServerMimetypeDstu2_1Test {
 		
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
 		httpPost.setEntity(new StringEntity(enc, ContentType.parse(Constants.CT_FHIR_XML + "; charset=utf-8")));
-		httpPost.addHeader(Constants.HEADER_ACCEPT, Constants.CT_FHIR_XML_NEW);
+		httpPost.addHeader(Constants.HEADER_ACCEPT, Constants.CT_FHIR_XML);
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -171,7 +171,7 @@ public class ServerMimetypeDstu2_1Test {
 		ourLog.info("Response was:\n{}", responseContent);
 
 		assertEquals(201, status.getStatusLine().getStatusCode());
-		assertEquals(Constants.CT_FHIR_XML_NEW, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
+		assertEquals(Constants.CT_FHIR_XML, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
 		assertEquals("<OperationOutcome xmlns=\"http://hl7.org/fhir\"><issue><diagnostics value=\"FAMILY\"/></issue></OperationOutcome>", responseContent);
 	}
 
@@ -202,7 +202,7 @@ public class ServerMimetypeDstu2_1Test {
 		String enc = ourCtx.newJsonParser().encodeResourceToString(p);
 		
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
-		httpPost.setEntity(new StringEntity(enc, ContentType.parse(Constants.CT_FHIR_JSON_NEW + "; charset=utf-8")));
+		httpPost.setEntity(new StringEntity(enc, ContentType.parse(Constants.CT_FHIR_JSON+ "; charset=utf-8")));
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -211,7 +211,7 @@ public class ServerMimetypeDstu2_1Test {
 		ourLog.info("Response was:\n{}", responseContent);
 
 		assertEquals(201, status.getStatusLine().getStatusCode());
-		assertEquals(Constants.CT_FHIR_JSON_NEW, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
+		assertEquals(Constants.CT_FHIR_JSON, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
 		assertEquals("{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"diagnostics\":\"FAMILY\"}]}", responseContent);
 	}
 
@@ -223,7 +223,7 @@ public class ServerMimetypeDstu2_1Test {
 		
 		HttpPost httpPost = new HttpPost("http://localhost:" + ourPort + "/Patient");
 		httpPost.setEntity(new StringEntity(enc, ContentType.parse(Constants.CT_FHIR_JSON + "; charset=utf-8")));
-		httpPost.addHeader(Constants.HEADER_ACCEPT, Constants.CT_FHIR_JSON_NEW);
+		httpPost.addHeader(Constants.HEADER_ACCEPT, Constants.CT_FHIR_JSON);
 		HttpResponse status = ourClient.execute(httpPost);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -232,7 +232,7 @@ public class ServerMimetypeDstu2_1Test {
 		ourLog.info("Response was:\n{}", responseContent);
 
 		assertEquals(201, status.getStatusLine().getStatusCode());
-		assertEquals(Constants.CT_FHIR_JSON_NEW, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
+		assertEquals(Constants.CT_FHIR_JSON, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
 		assertEquals("{\"resourceType\":\"OperationOutcome\",\"issue\":[{\"diagnostics\":\"FAMILY\"}]}", responseContent);
 	}
 	
@@ -273,7 +273,7 @@ public class ServerMimetypeDstu2_1Test {
 	@Test
 	public void testSearchWithFormatXmlNew() throws Exception {
 
-		HttpGet httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient?_format=" + Constants.CT_FHIR_XML_NEW);
+		HttpGet httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient?_format=" + Constants.CT_FHIR_XML);
 		HttpResponse status = ourClient.execute(httpGet);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -284,7 +284,7 @@ public class ServerMimetypeDstu2_1Test {
 		assertEquals(200, status.getStatusLine().getStatusCode());
 		assertThat(responseContent, containsString("<Patient xmlns=\"http://hl7.org/fhir\">"));
 		assertThat(responseContent, not(containsString("http://hl7.org/fhir/")));
-		assertEquals(Constants.CT_FHIR_XML_NEW, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
+		assertEquals(Constants.CT_FHIR_XML, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
 	}
 
 
@@ -324,7 +324,7 @@ public class ServerMimetypeDstu2_1Test {
 	@Test
 	public void testSearchWithFormatJsonNew() throws Exception {
 
-		HttpGet httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient?_format=" + Constants.CT_FHIR_JSON_NEW);
+		HttpGet httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient?_format=" + Constants.CT_FHIR_JSON);
 		HttpResponse status = ourClient.execute(httpGet);
 
 		String responseContent = IOUtils.toString(status.getEntity().getContent(), StandardCharsets.UTF_8);
@@ -334,7 +334,7 @@ public class ServerMimetypeDstu2_1Test {
 
 		assertEquals(200, status.getStatusLine().getStatusCode());
 		assertThat(responseContent, containsString("\"resourceType\""));
-		assertEquals(Constants.CT_FHIR_JSON_NEW, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
+		assertEquals(Constants.CT_FHIR_JSON, status.getFirstHeader("content-type").getValue().replaceAll(";.*", ""));
 	}
 
 	@AfterClass


### PR DESCRIPTION
Fixes for the following problems:

1. The Capability resource incorrectly specifies the new MIME types as does the Accept header issued in client requests.
2. Further, FhirVersionEnum does not account for FhirVersionEnum#isEquivalentTo in the implementations of FhirVersionEnum#isNewerThan and FhirVersionEnum#isOlderThan
