### PR TITLE
Use the charset from the content-type of the HttpEntity instead of always using the default charset.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpRequest.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpRequest.java
@@ -33,6 +33,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.ContentType;
 
 import ca.uhn.fhir.rest.client.api.IHttpRequest;
 import ca.uhn.fhir.rest.client.api.IHttpResponse;
@@ -93,8 +94,8 @@ public class ApacheHttpRequest implements IHttpRequest {
 		if (myRequest instanceof HttpEntityEnclosingRequest) {
 			HttpEntity entity = ((HttpEntityEnclosingRequest) myRequest).getEntity();
 			if (entity.isRepeatable()) {
-				//TODO  verify the charset
-				return IOUtils.toString(entity.getContent(), Charset.defaultCharset());
+				Charset charset = ContentType.parse(entity.getContentType().getValue()).getCharset();
+				return IOUtils.toString(entity.getContent(), charset);
 			}
 		}
 		return null;

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/client/apache/ApacheHttpRequestTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/client/apache/ApacheHttpRequestTest.java
@@ -1,0 +1,38 @@
+package ca.uhn.fhir.rest.client.apache;
+
+import static org.junit.Assert.assertEquals;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+public class ApacheHttpRequestTest {
+
+	private final String ENTITY_CONTENT = "Some entity with special characters: é";
+	private StringEntity httpEntity;
+	private HttpPost apacheRequest = new HttpPost("");
+
+	@Test
+	public void testGetRequestBodyFromStream() throws IOException {
+		httpEntity = new StringEntity(ENTITY_CONTENT, Charset.forName("ISO-8859-1"));
+		httpEntity.setContentType("text/plain; charset=ISO-8859-1");
+		apacheRequest.setEntity(httpEntity);
+
+		String result = new ApacheHttpRequest(null, apacheRequest).getRequestBodyFromStream();
+
+		assertEquals(ENTITY_CONTENT, result);
+	}
+
+	@Test
+	public void testGetRequestBodyFromStreamWithDefaultCharset() throws IOException {
+		httpEntity = new StringEntity(ENTITY_CONTENT, Charset.defaultCharset());
+		httpEntity.setContentType("text/plain");
+		apacheRequest.setEntity(httpEntity);
+
+		String result = new ApacheHttpRequest(null, apacheRequest).getRequestBodyFromStream();
+
+		assertEquals(ENTITY_CONTENT, result);
+	}
+}


### PR DESCRIPTION
We ran into a character encoding issue on a system where the default charset was not UTF-8. I believe this change fixes our issue. 