### PR TITLE
Fix parsing of hexadecimal encoded entities.

### DIFF
--- a/hapi-fhir-base/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
+++ b/hapi-fhir-base/src/main/java/org/hl7/fhir/utilities/xhtml/XhtmlParser.java
@@ -577,8 +577,8 @@ public class XhtmlParser {
 		else if (c.charAt(0) == '#') {
 			if (isInteger(c.substring(1), 10))
 				s.append((char) Integer.parseInt(c.substring(1)));
-			else if (isInteger(c.substring(1), 16))
-				s.append((char) Integer.parseInt(c.substring(1), 16));
+			else if (c.charAt(1) == 'x' && isInteger(c.substring(2), 16))
+				s.append((char) Integer.parseInt(c.substring(2), 16));
 		} else if (c.equals("fnof"))
 			s.append((char) 402); // latin small f with hook = function = florin, U+0192 ISOtech -->
 		else if (c.equals("Alpha"))


### PR DESCRIPTION
I noticed this code was probably copied from another repo at http://gforge.hl7.org. Is this the correct place to fix this? Or should this (also) be fixed there?