### PR TITLE
ResponseHighlighter enhancement proposal - hyperlinks and selections

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/interceptor/ResponseHighlighterInterceptor.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/interceptor/ResponseHighlighterInterceptor.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
  */
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Date;
 import java.util.Map;
 import java.util.Set;
@@ -33,6 +34,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -325,8 +327,13 @@ public class ResponseHighlighterInterceptor extends InterceptorAdapter {
 			b.append("	<head>\n");
 			b.append("		<meta charset=\"utf-8\" />\n");
 			b.append("       <style>\n");
-			b.append(".hlQuot {\n");
-			b.append("  color: #88F;\n");
+			b.append(".hlQuot { color: #88F; }\n");
+			b.append(".hlQuot a { text-decoration: none; color: #88F; }\n");
+			b.append(".hlQuot .uuid, .hlQuot .dateTime {\n");
+			b.append("  user-select: all;\n");
+			b.append("  -moz-user-select: all;\n");
+			b.append("  -webkit-user-select: all;\n");
+			b.append("  -ms-user-select: element;\n");
 			b.append("}\n");
 			b.append(".hlAttr {\n");
 			b.append("  color: #888;\n");
@@ -409,7 +416,16 @@ public class ResponseHighlighterInterceptor extends InterceptorAdapter {
 			b.append("<pre>");
 			b.append(format(encoded, encoding));
 			b.append("</pre>");
-			b.append("   </body>");
+			b.append("\n");
+			
+			InputStream jsStream = ResponseHighlighterInterceptor.class.getResourceAsStream("ResponseHighlighter.js");
+			String jsStr = jsStream != null ? IOUtils.toString(jsStream, "UTF-8") : "console.log('ResponseHighlighterInterceptor: javascript resource not found')";
+			jsStr = jsStr.replace("FHIR_BASE", theRequestDetails.getServerBaseForRequest());
+			b.append("<script type=\"text/javascript\">");
+			b.append(jsStr);
+			b.append("</script>\n");
+
+			b.append("</body>");
 			b.append("</html>");
 		//@formatter:off
 		String out = b.toString();

--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/rest/server/interceptor/ResponseHighlighter.js
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/rest/server/interceptor/ResponseHighlighter.js
@@ -1,0 +1,45 @@
+
+(function() {
+    'use strict';
+
+    /* bail out if user is testing a version of this script via Greasemonkey or Tampermonkey */
+    if (window.HAPI_ResponseHighlighter_userscript) {
+        console.log("HAPI ResponseHighlighter: userscript detected - not executing embedded script");
+        return;
+    }
+
+    /* adds hyperlinks and CSS styles to dates and UUIDs (e.g. to enable user-select: all) */
+    const logicalReferenceRegex = /^[A-Z][A-Za-z]+\/[0-9]+$/;
+    const dateTimeRegex = /^-?[0-9]{4}(-(0[1-9]|1[0-2])(-(0[0-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/; // from the spec - https://www.hl7.org/fhir/datatypes.html#datetime
+    const uuidRegex = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
+
+    const allQuotes = document.querySelectorAll(".hlQuot");
+    for (var i = 0; i < allQuotes.length; i++) {
+        const quote = allQuotes[i];
+        const text = quote.textContent.substr(1, quote.textContent.length - 2 /* remove quotes */);
+
+        const absHyperlink = text.startsWith("http://") || text.startsWith("https://");
+        const relHyperlink = text.match(logicalReferenceRegex);
+        const uuid = text.match(uuidRegex);
+        const dateTime = text.match(dateTimeRegex);
+
+        if (absHyperlink || relHyperlink) {
+            const link = document.createElement("a");
+            const href = absHyperlink ? text : "FHIR_BASE/" + text;
+            link.setAttribute("href", href);
+            link.textContent = '"' + text + '"';
+            quote.textContent = "";
+            quote.appendChild(link);
+        }
+
+        if (uuid || dateTime) {
+            const span = document.createElement("span");
+            span.setAttribute("class", uuid ? "uuid" : "dateTime");
+            span.textContent = text;
+            quote.textContent = "";
+            quote.appendChild(document.createTextNode('"'));
+            quote.appendChild(span);
+            quote.appendChild(document.createTextNode('"'));
+        }
+    }
+})();

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/interceptor/ResponseHighlightingInterceptorTest.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/interceptor/ResponseHighlightingInterceptorTest.java
@@ -213,7 +213,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		reqDetails.setServer(new RestfulServer(ourCtx));
 		reqDetails.setServletRequest(req);
@@ -251,7 +251,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		HashMap<String, String[]> params = new HashMap<String, String[]>();
 		params.put(Constants.PARAM_PRETTY, new String[] { Constants.PARAM_PRETTY_VALUE_TRUE });
@@ -286,7 +286,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		HashMap<String, String[]> params = new HashMap<String, String[]>();
 		params.put(Constants.PARAM_PRETTY, new String[] { Constants.PARAM_PRETTY_VALUE_TRUE });
@@ -326,7 +326,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		HashMap<String, String[]> params = new HashMap<String, String[]>();
 		reqDetails.setParameters(params);
@@ -360,7 +360,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		HashMap<String, String[]> params = new HashMap<String, String[]>();
 		params.put(Constants.PARAM_FORMAT, new String[] { Constants.FORMAT_HTML });
@@ -394,7 +394,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		HashMap<String, String[]> params = new HashMap<String, String[]>();
 		params.put(Constants.PARAM_FORMAT, new String[] { Constants.CT_HTML });
@@ -425,7 +425,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		reqDetails.setParameters(new HashMap<String, String[]>());
 		reqDetails.setServer(new RestfulServer(ourCtx));
@@ -463,7 +463,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		reqDetails.setParameters(new HashMap<String, String[]>());
 		RestfulServer server = new RestfulServer(ourCtx);
@@ -501,7 +501,7 @@ public class ResponseHighlightingInterceptorTest {
 		Patient resource = new Patient();
 		resource.addName().addFamily("FAMILY");
 
-		ServletRequestDetails reqDetails = new ServletRequestDetails();
+		ServletRequestDetails reqDetails = new TestServletRequestDetails();
 		reqDetails.setRequestType(RequestTypeEnum.GET);
 		reqDetails.setParameters(new HashMap<String, String[]>());
 		RestfulServer server = new RestfulServer(ourCtx);
@@ -865,6 +865,13 @@ public class ResponseHighlightingInterceptorTest {
 			return Collections.singletonList(p);
 		}
 
+	}
+
+	class TestServletRequestDetails extends ServletRequestDetails {
+		@Override
+		public String getServerBaseForRequest() {
+			return "/baseDstu3";
+		}
 	}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 			</snapshots>
 			<id>bintray-dnault-maven</id>
 			<name>bintray</name>
-			<url>http://dl.bintray.com/dnault/maven</url>
+			<url>https://dl.bintray.com/dnault/maven</url>
 		</repository>
 		<repository>
 			<id>jitpack.io</id>


### PR DESCRIPTION
This adds some JavaScript to the ResponseHighlighterInterceptor that creates hyperlinks for absolute URLs and relative references. There's also a prototype of smarter selections - dateTimes and UUIDs are set to use the "user-select: all" CSS property.

Only the latest Firefox, Chrome and Edge are currently supported. I've only tested using HAPI's CLI interface.

I've also made a userscript version for Greasemonkey (Firefox) and Tampermonkey (Chrome) which makes testing much easier: https://gist.github.com/eug48/eeb15b8d6d6091729af1233efcb19cd0