### PR TITLE
Hacky but workable fix for race condition surfaced by If-None-Exists creates

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -636,19 +636,21 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> implements IDao {
 	@SuppressWarnings("unchecked")
 	public <R extends IBaseResource> IFhirResourceDao<R> getDao(Class<R> theType) {
 		if (myResourceTypeToDao == null) {
-			myResourceTypeToDao = new HashMap<Class<? extends IBaseResource>, IFhirResourceDao<?>>();
+			Map<Class<? extends IBaseResource>, IFhirResourceDao<?>> theResourceTypeToDao = new HashMap<Class<? extends IBaseResource>, IFhirResourceDao<?>>();
 			for (IFhirResourceDao<?> next : myResourceDaos) {
-				myResourceTypeToDao.put(next.getResourceType(), next);
+				theResourceTypeToDao.put(next.getResourceType(), next);
 			}
 
 			if (this instanceof IFhirResourceDao<?>) {
 				IFhirResourceDao<?> thiz = (IFhirResourceDao<?>) this;
-				myResourceTypeToDao.put(thiz.getResourceType(), thiz);
+				theResourceTypeToDao.put(thiz.getResourceType(), thiz);
 			}
 
+			myResourceTypeToDao = theResourceTypeToDao;
 		}
 
-		return (IFhirResourceDao<R>) myResourceTypeToDao.get(theType);
+		IFhirResourceDao<R> dao = (IFhirResourceDao<R>) myResourceTypeToDao.get(theType);
+		return dao;
 	}
 
 	@Override


### PR DESCRIPTION
Per our discussion here: https://github.com/jamesagnew/hapi-fhir/commit/3db40916010bcf0c4fd48230625c26d8f37517e5

Some notes from other attempts I made to fix this in a less hacky way:

* Tried to `@Autowire` `myResourceDaos` from a setter (rather than using the annotation on a field), and initialize `myResourceTypeToDao` in that setter, instead. Couldn't get it to work: Spring started throwing odd bean dependency errors. Don't really understand why.
* Tried to move the exceptions being thrown on `null` `getDao(Class)` results into that method, but that was breaking a test case. Didn't investigate why.