### PR TITLE
Correctly serialize STU3 ConceptMap and ActivityDefinition element order

### DIFF
--- a/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/model/ActivityDefinition.java
+++ b/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/model/ActivityDefinition.java
@@ -47,7 +47,8 @@ import org.hl7.fhir.exceptions.FHIRException;
  * This resource allows for the definition of some activity to be performed, independent of a particular patient, practitioner, or other performance context.
  */
 @ResourceDef(name="ActivityDefinition", profile="http://hl7.org/fhir/Profile/ActivityDefinition")
-@ChildOrder(names={"url", "identifier", "version", "name", "title", "status", "experimental", "date", "publisher", "description", "purpose", "usage", "approvalDate", "lastReviewDate", "effectivePeriod", "useContext", "jurisdiction", "topic", "contributor", "contact", "copyright", "relatedArtifact", "library", "kind", "code", "timing[x]", "location", "participant", "product[x]", "quantity", "dosage", "bodySite", "transform", "dynamicValue"})
+//@ChildOrder(names={"url", "identifier", "version", "name", "title", "status", "experimental", "date", "publisher", "description", "purpose", "usage", "approvalDate", "lastReviewDate", "effectivePeriod", "useContext", "jurisdiction", "topic", "contributor", "contact", "copyright", "relatedArtifact", "library", "kind", "code", "timing[x]", "location", "participant", "product[x]", "quantity", "dosage", "bodySite", "transform", "dynamicValue"})
+@ChildOrder(names={"url", "identifier", "version", "name", "title", "status", "experimental", "date", "publisher", "description", "purpose", "usage", "approvalDate", "lastReviewDate", "effectivePeriod", "useContext", "jurisdiction", "topic", "contributor", "contact", "copyright", "relatedArtifact", "library", "kind", "code", "timing", "location", "participant", "product", "quantity", "dosage", "bodySite", "transform", "dynamicValue"})
 public class ActivityDefinition extends MetadataResource {
 
     public enum ActivityDefinitionKind {

--- a/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/model/ConceptMap.java
+++ b/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/model/ConceptMap.java
@@ -47,7 +47,8 @@ import org.hl7.fhir.exceptions.FHIRException;
  * A statement of relationships from one set of concepts to one or more other concepts - either code systems or data elements, or classes in class models.
  */
 @ResourceDef(name="ConceptMap", profile="http://hl7.org/fhir/Profile/ConceptMap")
-@ChildOrder(names={"url", "identifier", "version", "name", "title", "status", "experimental", "date", "publisher", "contact", "description", "useContext", "jurisdiction", "purpose", "copyright", "source[x]", "target[x]", "group"})
+//@ChildOrder(names={"url", "identifier", "version", "name", "title", "status", "experimental", "date", "publisher", "contact", "description", "useContext", "jurisdiction", "purpose", "copyright", "source[x]", "target[x]", "group"})
+@ChildOrder(names={"url", "identifier", "version", "name", "title", "status", "experimental", "date", "publisher", "contact", "description", "useContext", "jurisdiction", "purpose", "copyright", "source", "target", "group"})
 public class ConceptMap extends MetadataResource {
 
     public enum ConceptMapGroupUnmappedMode {

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/JsonParserDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/JsonParserDstu3Test.java
@@ -36,6 +36,8 @@ import java.util.UUID;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.StringContains;
+import org.hl7.fhir.dstu3.hapi.validation.DefaultProfileValidationSupport;
+import org.hl7.fhir.dstu3.hapi.validation.FhirInstanceValidator;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.dstu3.model.Address.AddressUse;
 import org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory;
@@ -71,6 +73,9 @@ import ca.uhn.fhir.parser.json.JsonLikeValue.ValueType;
 import ca.uhn.fhir.rest.server.Constants;
 import ca.uhn.fhir.util.TestUtil;
 import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.IValidationContext;
+import ca.uhn.fhir.validation.SingleValidationMessage;
+import ca.uhn.fhir.validation.ValidationContext;
 import ca.uhn.fhir.validation.ValidationResult;
 import net.sf.json.JSON;
 import net.sf.json.JSONSerializer;
@@ -83,6 +88,78 @@ public class JsonParserDstu3Test {
 	@After
 	public void after() {
 		ourCtx.setNarrativeGenerator(null);
+	}
+	
+	@Test
+	public void testActivityDefinitionElementsOrder() throws Exception {
+		final String origContent = "{\"resourceType\":\"ActivityDefinition\",\"id\":\"x1\",\"url\":\"http://testing.org\",\"status\":\"draft\",\"timingDateTime\":\"2011-02-03\"}";
+		final IParser parser = ourCtx.newJsonParser();
+		DefaultProfileValidationSupport validationSupport = new DefaultProfileValidationSupport();
+
+		// verify that InstanceValidator likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, origContent);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		ActivityDefinition fhirObj = parser.parseResource(ActivityDefinition.class, origContent);
+		String content = parser.encodeResourceToString(fhirObj);
+		ourLog.info("Serialized form: {}", content);
+
+		// verify that InstanceValidator still likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, content);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		// verify that the original and newly serialized match
+		Assert.assertEquals(origContent, content);
+	}
+	
+	@Test
+	public void testConceptMapElementsOrder() throws Exception {
+		final String origContent = "{\"resourceType\":\"ConceptMap\",\"id\":\"x1\",\"url\":\"http://testing.org\",\"status\":\"draft\",\"sourceUri\":\"http://y1\"}";
+		final IParser parser = ourCtx.newJsonParser();
+		DefaultProfileValidationSupport validationSupport = new DefaultProfileValidationSupport();
+
+		// verify that InstanceValidator likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, origContent);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		ConceptMap fhirObj = parser.parseResource(ConceptMap.class, origContent);
+		String content = parser.encodeResourceToString(fhirObj);
+		ourLog.info("Serialized form: {}", content);
+
+		// verify that InstanceValidator still likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, content);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		// verify that the original and newly serialized match
+		Assert.assertEquals(origContent, content);
 	}
 
 	/**

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/XmlParserDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/parser/XmlParserDstu3Test.java
@@ -34,6 +34,8 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.hamcrest.collection.IsEmptyCollection;
 import org.hamcrest.core.StringContains;
 import org.hamcrest.text.StringContainsInOrder;
+import org.hl7.fhir.dstu3.hapi.validation.DefaultProfileValidationSupport;
+import org.hl7.fhir.dstu3.hapi.validation.FhirInstanceValidator;
 import org.hl7.fhir.dstu3.model.*;
 import org.hl7.fhir.dstu3.model.Address.AddressUse;
 import org.hl7.fhir.dstu3.model.Address.AddressUseEnumFactory;
@@ -67,6 +69,10 @@ import ca.uhn.fhir.parser.PatientWithCustomCompositeExtension.FooParentExtension
 import ca.uhn.fhir.rest.client.IGenericClient;
 import ca.uhn.fhir.rest.server.Constants;
 import ca.uhn.fhir.util.TestUtil;
+import ca.uhn.fhir.validation.IValidationContext;
+import ca.uhn.fhir.validation.SingleValidationMessage;
+import ca.uhn.fhir.validation.ValidationContext;
+import ca.uhn.fhir.validation.ValidationResult;
 
 public class XmlParserDstu3Test {
 	private static FhirContext ourCtx = FhirContext.forDstu3();
@@ -78,6 +84,78 @@ public class XmlParserDstu3Test {
 			ourCtx = FhirContext.forDstu3();
 		}
 		ourCtx.setNarrativeGenerator(null);
+	}
+	
+	@Test
+	public void testActivityDefinitionElementsOrder() throws Exception {
+		final String origContent = "<ActivityDefinition xmlns=\"http://hl7.org/fhir\"><id value=\"x1\"/><url value=\"http://testing.org\"/><status value=\"draft\"/><timingDateTime value=\"2011-02-03\"/></ActivityDefinition>";
+		final IParser parser = ourCtx.newXmlParser();
+		DefaultProfileValidationSupport validationSupport = new DefaultProfileValidationSupport();
+
+		// verify that InstanceValidator likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, origContent);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		ActivityDefinition fhirObj = parser.parseResource(ActivityDefinition.class, origContent);
+		String content = parser.encodeResourceToString(fhirObj);
+		ourLog.info("Serialized form: {}", content);
+
+		// verify that InstanceValidator still likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, content);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		// verify that the original and newly serialized match
+		Assert.assertEquals(origContent, content);
+	}
+	
+	@Test
+	public void testConceptMapElementsOrder() throws Exception {
+		final String origContent = "<ConceptMap xmlns=\"http://hl7.org/fhir\"><id value=\"x1\"/><url value=\"http://testing.org\"/><status value=\"draft\"/><sourceUri value=\"http://url1\"/></ConceptMap>";
+		final IParser parser = ourCtx.newXmlParser();
+		DefaultProfileValidationSupport validationSupport = new DefaultProfileValidationSupport();
+
+		// verify that InstanceValidator likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, origContent);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		ConceptMap fhirObj = parser.parseResource(ConceptMap.class, origContent);
+		String content = parser.encodeResourceToString(fhirObj);
+		ourLog.info("Serialized form: {}", content);
+
+		// verify that InstanceValidator still likes the format
+		{
+			IValidationContext<IBaseResource> validationCtx = ValidationContext.forText(ourCtx, content);
+			new FhirInstanceValidator(validationSupport).validateResource(validationCtx);
+			ValidationResult result = validationCtx.toResult();
+			for (SingleValidationMessage msg : result.getMessages()) {
+				ourLog.info("{}", msg);
+			}
+			Assert.assertEquals(0, result.getMessages().size());
+		}
+
+		// verify that the original and newly serialized match
+		Assert.assertEquals(origContent, content);
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes #634.

The cause was the paths in the ChildOrder annotation on these resources used '[x]'. However, the forcedOrder logic in BaseRuntimeElementCompositeDefinition.scanCompositeElementForChildren() method didn't account for the '[x]'. This leads to e.g. in ConceptMap, the sourceUri/sourceReference element being written first before url element, leading to a validation failure later on if the serialized resource is validated.

I did a scan of the code and it seems like ChildOrder annotation is only used in the STU3 model classes. Moreover, it seems only ConceptMap and ActivityDefinition resources are the ones who have paths that have '[x]'.

Since the fix was made to generated code, I think a more permanent fix to this would be to update the FHIR code generator not to use '[x]' in ChildOrder annotation paths.