### PR TITLE
Removed annoying stacktrace from logs for failed conformance statements.

### DIFF
--- a/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/BaseController.java
+++ b/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/BaseController.java
@@ -320,7 +320,7 @@ public class BaseController {
 		try {
 			conformance = (Conformance) client.conformance();
 		} catch (Exception e) {
-			ourLog.warn("Failed to load conformance statement, error was: " + e.toString());
+			ourLog.warn("Failed to load conformance statement, error was: {}", e.toString());
 			theModel.put("errorMsg", toDisplayError("Failed to load conformance statement, error was: " + e.toString(), e));
 			conformance = new Conformance();
 		}
@@ -380,7 +380,7 @@ public class BaseController {
 		try {
 			conformance = (ca.uhn.fhir.model.dstu2.resource.Conformance) client.conformance();
 		} catch (Exception e) {
-			ourLog.warn("Failed to load conformance statement, error was: " + e.toString());
+			ourLog.warn("Failed to load conformance statement, error was: {}", e.toString());
 			theModel.put("errorMsg", toDisplayError("Failed to load conformance statement, error was: " + e.toString(), e));
 			conformance = new ca.uhn.fhir.model.dstu2.resource.Conformance();
 		}
@@ -440,7 +440,7 @@ public class BaseController {
 		try {
 			capabilityStatement = client.fetchConformance().ofType(org.hl7.fhir.dstu3.model.CapabilityStatement.class).execute();
 		} catch (Exception ex) {
-			ourLog.warn("Failed to load conformance statement, error was: " + ex.toString());
+			ourLog.warn("Failed to load conformance statement, error was: {}", ex.toString());
 			theModel.put("errorMsg", toDisplayError("Failed to load conformance statement, error was: " + ex.toString(), ex));
 		}
 

--- a/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/BaseController.java
+++ b/hapi-fhir-testpage-overlay/src/main/java/ca/uhn/fhir/to/BaseController.java
@@ -320,7 +320,7 @@ public class BaseController {
 		try {
 			conformance = (Conformance) client.conformance();
 		} catch (Exception e) {
-			ourLog.warn("Failed to load conformance statement", e);
+			ourLog.warn("Failed to load conformance statement, error was: " + e.toString());
 			theModel.put("errorMsg", toDisplayError("Failed to load conformance statement, error was: " + e.toString(), e));
 			conformance = new Conformance();
 		}
@@ -380,7 +380,7 @@ public class BaseController {
 		try {
 			conformance = (ca.uhn.fhir.model.dstu2.resource.Conformance) client.conformance();
 		} catch (Exception e) {
-			ourLog.warn("Failed to load conformance statement", e);
+			ourLog.warn("Failed to load conformance statement, error was: " + e.toString());
 			theModel.put("errorMsg", toDisplayError("Failed to load conformance statement, error was: " + e.toString(), e));
 			conformance = new ca.uhn.fhir.model.dstu2.resource.Conformance();
 		}
@@ -440,7 +440,7 @@ public class BaseController {
 		try {
 			capabilityStatement = client.fetchConformance().ofType(org.hl7.fhir.dstu3.model.CapabilityStatement.class).execute();
 		} catch (Exception ex) {
-			ourLog.warn("Failed to load conformance statement", ex);
+			ourLog.warn("Failed to load conformance statement, error was: " + ex.toString());
 			theModel.put("errorMsg", toDisplayError("Failed to load conformance statement, error was: " + ex.toString(), ex));
 		}
 


### PR DESCRIPTION
Now logs won't fill up with unnecessary stacktraces when underprivileged anonymous users access testpage-overlay.