### PR TITLE
Fix typo in custom structures documentation

### DIFF
--- a/src/site/xdoc/doc_custom_structures.xml
+++ b/src/site/xdoc/doc_custom_structures.xml
@@ -12,7 +12,7 @@
 			<p>
 				Typically, when working with FHIR the right way to provide your
 				own extensions is to work with existing resource types and simply
-				ass your own extensions and/or constrain out fields you don't
+				add your own extensions and/or constrain out fields you don't
 				need.
 			</p>
 			<p>


### PR DESCRIPTION
Fix an unfortunate typo in [the documentation for creating custom structures](http://hapifhir.io/doc_custom_structures.html).