### PR TITLE
Fixes #705 - Client correctly validates the server's conformance statement FHIR version

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirVersionEnum.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirVersionEnum.java
@@ -42,7 +42,7 @@ public enum FhirVersionEnum {
 
 	DSTU2_1("org.hl7.fhir.dstu2016may.hapi.ctx.FhirDstu2_1", null, true, new Version("1.4.0")),
 
-	DSTU3("org.hl7.fhir.dstu3.hapi.ctx.FhirDstu3", null, true, new Dstu3Version());
+	DSTU3("org.hl7.fhir.dstu3.hapi.ctx.FhirDstu3", null, true, new Version("3.0.1"));
 
 	private final FhirVersionEnum myEquivalent;
 	private final boolean myIsRi;
@@ -136,26 +136,6 @@ public enum FhirVersionEnum {
 
 	private interface IVersionProvider {
 		String provideVersion();
-	}
-
-	private static class Dstu3Version implements IVersionProvider {
-
-		public Dstu3Version() {
-			try {
-				Class<?> c = Class.forName("org.hl7.fhir.dstu3.model.Constants");
-				myVersion = (String) c.getDeclaredField("VERSION").get(null);
-			} catch (Exception e) {
-				myVersion = "UNKNOWN";
-			}
-		}
-
-		private String myVersion;
-
-		@Override
-		public String provideVersion() {
-			return myVersion;
-		}
-
 	}
 
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/RestfulClientFactory.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/RestfulClientFactory.java
@@ -329,6 +329,8 @@ public abstract class RestfulClientFactory implements IRestfulClientFactory {
 				serverFhirVersionEnum = FhirVersionEnum.DSTU1;
 			} else if (serverFhirVersionString.equals(FhirVersionEnum.DSTU2.getFhirVersionString())) {
 				serverFhirVersionEnum = FhirVersionEnum.DSTU2;
+			} else if (serverFhirVersionString.equals(FhirVersionEnum.DSTU2_1.getFhirVersionString())) {
+				serverFhirVersionEnum = FhirVersionEnum.DSTU2_1;
 			} else if (serverFhirVersionString.equals(FhirVersionEnum.DSTU3.getFhirVersionString())) {
 				serverFhirVersionEnum = FhirVersionEnum.DSTU3;
 			} else {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/RestfulClientFactory.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/client/RestfulClientFactory.java
@@ -325,13 +325,12 @@ public abstract class RestfulClientFactory implements IRestfulClientFactory {
 		if (StringUtils.isBlank(serverFhirVersionString)) {
 			// we'll be lenient and accept this
 		} else {
-			//FIXME null access on serverFhirVersionString
-			if (serverFhirVersionString.startsWith("0.80") || serverFhirVersionString.startsWith("0.0.8")) {
+			if (serverFhirVersionString.equals(FhirVersionEnum.DSTU1.getFhirVersionString())) {
 				serverFhirVersionEnum = FhirVersionEnum.DSTU1;
-			} else if (serverFhirVersionString.startsWith("0.4")) {
+			} else if (serverFhirVersionString.equals(FhirVersionEnum.DSTU2.getFhirVersionString())) {
 				serverFhirVersionEnum = FhirVersionEnum.DSTU2;
-			} else if (serverFhirVersionString.startsWith("0.5")) {
-				serverFhirVersionEnum = FhirVersionEnum.DSTU2;
+			} else if (serverFhirVersionString.equals(FhirVersionEnum.DSTU3.getFhirVersionString())) {
+				serverFhirVersionEnum = FhirVersionEnum.DSTU3;
 			} else {
 				// we'll be lenient and accept this
 				ourLog.debug("Server conformance statement indicates unknown FHIR version: {}", serverFhirVersionString);

--- a/hapi-fhir-structures-dstu/src/main/java/ca/uhn/fhir/rest/server/provider/ServerConformanceProvider.java
+++ b/hapi-fhir-structures-dstu/src/main/java/ca/uhn/fhir/rest/server/provider/ServerConformanceProvider.java
@@ -31,6 +31,7 @@ import java.util.TreeSet;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -125,7 +126,7 @@ public class ServerConformanceProvider implements IServerConformanceProvider<Con
 
 		retVal.setPublisher(myPublisher);
 		retVal.setDate(conformanceDate());
-		retVal.setFhirVersion("0.0.82-3059"); // TODO: pull from model
+		retVal.setFhirVersion(FhirVersionEnum.DSTU1.getFhirVersionString());
 		retVal.setAcceptUnknown(false); // TODO: make this configurable - this is a fairly big effort since the parser needs to be modified to actually allow it
 		
 		retVal.getImplementation().setDescription(myServerConfiguration.getImplementationDescription());

--- a/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/rest/client/ClientServerValidationDstu1Test.java
+++ b/hapi-fhir-structures-dstu/src/test/java/ca/uhn/fhir/rest/client/ClientServerValidationDstu1Test.java
@@ -52,7 +52,7 @@ public class ClientServerValidationDstu1Test {
 	@Test
 	public void testServerReturnsAppropriateVersionDstu() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.0.8");
+		conf.setFhirVersion("0.0.82");
 		final String confResource = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -89,7 +89,7 @@ public class ClientServerValidationDstu1Test {
 	@Test
 	public void testServerReturnsWrongVersionDstu() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.4.0");
+		conf.setFhirVersion("1.0.2");
 		String msg = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -105,7 +105,7 @@ public class ClientServerValidationDstu1Test {
 			myCtx.newRestfulGenericClient("http://foo").read(new UriDt("http://foo/Patient/1"));
 			fail();
 		} catch (FhirClientInappropriateForServerException e) {
-			assertThat(e.toString(), containsString("The server at base URL \"http://foo/metadata\" returned a conformance statement indicating that it supports FHIR version \"0.4.0\" which corresponds to DSTU2, but this client is configured to use DSTU1 (via the FhirContext)"));
+			assertThat(e.toString(), containsString("The server at base URL \"http://foo/metadata\" returned a conformance statement indicating that it supports FHIR version \"1.0.2\" which corresponds to DSTU2, but this client is configured to use DSTU1 (via the FhirContext)"));
 		}
 	}
 

--- a/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/rest/server/provider/dstu2/ServerConformanceProvider.java
+++ b/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/rest/server/provider/dstu2/ServerConformanceProvider.java
@@ -38,6 +38,7 @@ import java.util.TreeSet;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -196,7 +197,7 @@ public class ServerConformanceProvider implements IServerConformanceProvider<Con
 
 		retVal.setPublisher(myPublisher);
 		retVal.setDate(conformanceDate());
-		retVal.setFhirVersion("1.0.2"); // TODO: pull from model
+		retVal.setFhirVersion(FhirVersionEnum.DSTU2.getFhirVersionString());
 		retVal.setAcceptUnknown(UnknownContentCodeEnum.UNKNOWN_EXTENSIONS); // TODO: make this configurable - this is a fairly big effort since the parser
 		// needs to be modified to actually allow it
 

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/client/ClientServerValidationDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/client/ClientServerValidationDstu2Test.java
@@ -70,7 +70,7 @@ public class ClientServerValidationDstu2Test {
 	@Test
 	public void testClientUsesInterceptors() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.5.0");
+		conf.setFhirVersion("1.0.2");
 		final String confResource = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -112,7 +112,7 @@ public class ClientServerValidationDstu2Test {
 	@Test
 	public void testForceConformanceCheck() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.5.0");
+		conf.setFhirVersion("1.0.2");
 		final String confResource = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -181,47 +181,9 @@ public class ClientServerValidationDstu2Test {
 	}
 
 	@Test
-	public void testServerReturnsAppropriateVersionForDstu2_040() throws Exception {
+	public void testServerReturnsAppropriateVersionForDstu2() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.5.0");
-		final String confResource = myCtx.newXmlParser().encodeResourceToString(conf);
-
-		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
-
-		when(myHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
-		when(myHttpResponse.getEntity().getContentType()).thenReturn(new BasicHeader("content-type", Constants.CT_FHIR_XML + "; charset=UTF-8"));
-		when(myHttpResponse.getEntity().getContent()).thenAnswer(new Answer<InputStream>() {
-			@Override
-			public InputStream answer(InvocationOnMock theInvocation) throws Throwable {
-				if (myFirstResponse) {
-					myFirstResponse = false;
-					return new ReaderInputStream(new StringReader(confResource), Charset.forName("UTF-8"));
-				} else {
-					return new ReaderInputStream(new StringReader(myCtx.newXmlParser().encodeResourceToString(new Patient())), Charset.forName("UTF-8"));
-				}
-			}
-		});
-
-		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
-
-		myCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.ONCE);
-		IGenericClient client = myCtx.newRestfulGenericClient("http://foo");
-
-		// don't load the conformance until the first time the client is actually used
-		assertTrue(myFirstResponse);
-		client.read(new UriDt("http://foo/Patient/123"));
-		assertFalse(myFirstResponse);
-		myCtx.newRestfulGenericClient("http://foo").read(new UriDt("http://foo/Patient/123"));
-		myCtx.newRestfulGenericClient("http://foo").read(new UriDt("http://foo/Patient/123"));
-
-		// Conformance only loaded once, then 3 reads
-		verify(myHttpClient, times(4)).execute(Matchers.any(HttpUriRequest.class));
-	}
-
-	@Test
-	public void testServerReturnsAppropriateVersionForDstu2_050() throws Exception {
-		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.5.0");
+		conf.setFhirVersion("1.0.2");
 		final String confResource = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -259,7 +221,7 @@ public class ClientServerValidationDstu2Test {
 	@Test
 	public void testServerReturnsWrongVersionForDstu2() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.80");
+		conf.setFhirVersion("0.0.82");
 		String msg = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -276,7 +238,7 @@ public class ClientServerValidationDstu2Test {
 			fail();
 		} catch (FhirClientInappropriateForServerException e) {
 			String out = e.toString();
-			String want = "The server at base URL \"http://foo/metadata\" returned a conformance statement indicating that it supports FHIR version \"0.80\" which corresponds to DSTU1, but this client is configured to use DSTU2 (via the FhirContext)";
+			String want = "The server at base URL \"http://foo/metadata\" returned a conformance statement indicating that it supports FHIR version \"0.0.82\" which corresponds to DSTU1, but this client is configured to use DSTU2 (via the FhirContext)";
 			ourLog.info(out);
 			ourLog.info(want);
 			assertThat(out, containsString(want));

--- a/hapi-fhir-structures-hl7org-dstu2/src/main/java/org/hl7/fhir/instance/conf/ServerConformanceProvider.java
+++ b/hapi-fhir-structures-hl7org-dstu2/src/main/java/org/hl7/fhir/instance/conf/ServerConformanceProvider.java
@@ -43,6 +43,7 @@ import java.util.jar.Manifest;
 
 import javax.servlet.http.HttpServletRequest;
 
+import ca.uhn.fhir.context.FhirVersionEnum;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.Conformance;
 import org.hl7.fhir.instance.model.Conformance.ConditionalDeleteStatus;
@@ -192,7 +193,7 @@ public class ServerConformanceProvider implements IServerConformanceProvider<Con
 
     retVal.setPublisher(myPublisher);
     retVal.setDate(conformanceDate());
-    retVal.setFhirVersion("1.0.2"); // TODO: pull from model
+    retVal.setFhirVersion(FhirVersionEnum.DSTU2_HL7ORG.getFhirVersionString());
     retVal.setAcceptUnknown(UnknownContentCode.EXTENSIONS); // TODO: make this configurable - this is a fairly big effort since the parser
     // needs to be modified to actually allow it
 

--- a/hapi-fhir-structures-hl7org-dstu2/src/test/java/ca/uhn/fhir/rest/client/ClientServerValidationTestHl7OrgDstu2.java
+++ b/hapi-fhir-structures-hl7org-dstu2/src/test/java/ca/uhn/fhir/rest/client/ClientServerValidationTestHl7OrgDstu2.java
@@ -56,46 +56,9 @@ public class ClientServerValidationTestHl7OrgDstu2 {
 	}
 
 	@Test
-	public void testServerReturnsAppropriateVersionForDstu2_040() throws Exception {
+	public void testServerReturnsAppropriateVersionForDstu2() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.5.0");
-		final String confResource = myCtx.newXmlParser().encodeResourceToString(conf);
-
-		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
-
-		when(myHttpResponse.getStatusLine()).thenReturn(new BasicStatusLine(new ProtocolVersion("HTTP", 1, 1), 200, "OK"));
-		when(myHttpResponse.getEntity().getContentType()).thenReturn(new BasicHeader("content-type", Constants.CT_FHIR_XML + "; charset=UTF-8"));
-		when(myHttpResponse.getEntity().getContent()).thenAnswer(new Answer<InputStream>() {
-			@Override
-			public InputStream answer(InvocationOnMock theInvocation) throws Throwable {
-				if (myFirstResponse) {
-					myFirstResponse=false;
-					return new ReaderInputStream(new StringReader(confResource), Charset.forName("UTF-8"));
-				} else {
-					return new ReaderInputStream(new StringReader(myCtx.newXmlParser().encodeResourceToString(new Patient())), Charset.forName("UTF-8"));
-				}
-			}});
-
-		when(myHttpClient.execute(capt.capture())).thenReturn(myHttpResponse);
-
-		myCtx.getRestfulClientFactory().setServerValidationModeEnum(ServerValidationModeEnum.ONCE);
-		IGenericClient client = myCtx.newRestfulGenericClient("http://foo");
-		
-		// don't load the conformance until the first time the client is actually used 
-		assertTrue(myFirstResponse); 
-		client.read(new UriDt("http://foo/Patient/123"));
-		assertFalse(myFirstResponse);
-		myCtx.newRestfulGenericClient("http://foo").read(new UriDt("http://foo/Patient/123"));
-		myCtx.newRestfulGenericClient("http://foo").read(new UriDt("http://foo/Patient/123"));
-
-		// Conformance only loaded once, then 3 reads
-		verify(myHttpClient, times(4)).execute(Matchers.any(HttpUriRequest.class));
-	}
-
-	@Test
-	public void testServerReturnsAppropriateVersionForDstu2_050() throws Exception {
-		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.5.0");
+		conf.setFhirVersion("1.0.2");
 		final String confResource = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -132,7 +95,7 @@ public class ClientServerValidationTestHl7OrgDstu2 {
 	@Test
 	public void testServerReturnsWrongVersionForDstu2() throws Exception {
 		Conformance conf = new Conformance();
-		conf.setFhirVersion("0.80");
+		conf.setFhirVersion("0.0.82");
 		String msg = myCtx.newXmlParser().encodeResourceToString(conf);
 
 		ArgumentCaptor<HttpUriRequest> capt = ArgumentCaptor.forClass(HttpUriRequest.class);
@@ -149,7 +112,7 @@ public class ClientServerValidationTestHl7OrgDstu2 {
 			fail();
 		} catch (FhirClientInappropriateForServerException e) {
 			String out = e.toString();
-			String want = "The server at base URL \"http://foo/metadata\" returned a conformance statement indicating that it supports FHIR version \"0.80\" which corresponds to DSTU1, but this client is configured to use DSTU2_HL7ORG (via the FhirContext)";
+			String want = "The server at base URL \"http://foo/metadata\" returned a conformance statement indicating that it supports FHIR version \"0.0.82\" which corresponds to DSTU1, but this client is configured to use DSTU2_HL7ORG (via the FhirContext)";
 			ourLog.info(out);
 			ourLog.info(want);
 			assertThat(out, containsString(want));


### PR DESCRIPTION
Fixed #705 by changing the FHIR version string comparisons that the client side code does when validating the server's conformance statement.