### PR TITLE
Fix for rest-hook subscriptions are not becoming active #675

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/RestHookSubscriptionDstu2Interceptor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/RestHookSubscriptionDstu2Interceptor.java
@@ -334,8 +334,9 @@ public class RestHookSubscriptionDstu2Interceptor extends BaseRestHookSubscripti
 			Subscription subscription = (Subscription) theResource;
 			if (subscription.getChannel() != null
 					&& subscription.getChannel().getTypeElement().getValueAsEnum() == SubscriptionChannelTypeEnum.REST_HOOK
-					&& subscription.getStatusElement().getValueAsEnum() == SubscriptionStatusEnum.ACTIVE) {
+					&& subscription.getStatusElement().getValueAsEnum() == SubscriptionStatusEnum.REQUESTED) {
 				removeLocalSubscription(subscription.getIdElement().getIdPart());
+				subscription.setStatus(SubscriptionStatusEnum.ACTIVE);
 				myRestHookSubscriptions.add(subscription);
 				ourLog.info("Subscription was added. Id: " + subscription.getId());
 			}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/RestHookSubscriptionDstu3Interceptor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/interceptor/RestHookSubscriptionDstu3Interceptor.java
@@ -325,8 +325,9 @@ public class RestHookSubscriptionDstu3Interceptor extends BaseRestHookSubscripti
 			Subscription subscription = (Subscription) theResource;
 			if (subscription.getChannel() != null
 					&& subscription.getChannel().getType() == Subscription.SubscriptionChannelType.RESTHOOK
-					&& subscription.getStatus() == Subscription.SubscriptionStatus.ACTIVE) {
+					&& subscription.getStatus() == Subscription.SubscriptionStatus.REQUESTED) {
 				removeLocalSubscription(subscription.getIdElement().getIdPart());
+				subscription.setStatus(Subscription.SubscriptionStatus.ACTIVE);
 				myRestHookSubscriptions.add(subscription);
 				ourLog.info("Subscription was added, id: {} - Have {}", subscription.getIdElement().getIdPart(), myRestHookSubscriptions.size());
 			}


### PR DESCRIPTION
Currently you cannot create rest hook subscriptions, because they must start off with a Requested state.  However the current code looks for new rest hook subscriptions in the Active state.  Changed the if statement to look for the Requested state.  Then changed the subscription state to Active.  