### PR TITLE
fix bugs with inverted test for If-Modified-Since (impl and tests)

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
@@ -161,7 +161,7 @@ public class ReadMethodBinding extends BaseResourceReturningMethodBinding {
 					ifNoneMatch = ParameterUtil.parseETagValue(ifNoneMatch);
 					if (responseResource.getIdElement() != null && responseResource.getIdElement().hasVersionIdPart()) {
 						if (responseResource.getIdElement().getVersionIdPart().equals(ifNoneMatch)) {
-							ourLog.debug("Returning HTTP 301 because request specified {}={}", Constants.HEADER_IF_NONE_MATCH, ifNoneMatch);
+							ourLog.debug("Returning HTTP 304 because request specified {}={}", Constants.HEADER_IF_NONE_MATCH, ifNoneMatch);
 							throw new NotModifiedException("Not Modified");
 						}
 					}
@@ -182,8 +182,8 @@ public class ReadMethodBinding extends BaseResourceReturningMethodBinding {
 					lastModified = responseResource.getMeta().getLastUpdated();
 				}
 				
-				if (lastModified != null && lastModified.getTime() > ifModifiedSinceDate.getTime()) {
-					ourLog.debug("Returning HTTP 301 because If-Modified-Since does not match");
+				if (lastModified != null && lastModified.getTime() <= ifModifiedSinceDate.getTime()) {
+					ourLog.debug("Returning HTTP 304 because If-Modified-Since does not match");
 					throw new NotModifiedException("Not Modified");
 				}
 			}

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/ReadDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/ReadDstu2Test.java
@@ -57,20 +57,38 @@ public class ReadDstu2Test {
 		CloseableHttpResponse status;
 		HttpGet httpGet;
 
+		// Fixture was last modified at 2012-01-01T12:12:12Z
+		// thus it has changed before the later time of 2012-01-01T13:00:00Z
+		// so we expect a 304
 		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
 		httpGet.addHeader(Constants.HEADER_IF_MODIFIED_SINCE, DateUtils.formatDate(new InstantDt("2012-01-01T13:00:00Z").getValue()));
 		status = ourClient.execute(httpGet);
 		try {
-			assertEquals(200, status.getStatusLine().getStatusCode());
+			assertEquals(304, status.getStatusLine().getStatusCode());
 		} finally {
 			IOUtils.closeQuietly(status);
 		}
 		
+		// Fixture was last modified at 2012-01-01T12:12:12Z
+		// thus it has changed at the same time of 2012-01-01T12:12:12Z
+		// so we expect a 304
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
+		httpGet.addHeader(Constants.HEADER_IF_MODIFIED_SINCE, DateUtils.formatDate(new InstantDt("2012-01-01T12:12:12Z").getValue()));
+		status = ourClient.execute(httpGet);
+		try {
+			assertEquals(304, status.getStatusLine().getStatusCode());
+		} finally {
+			IOUtils.closeQuietly(status);
+		}
+
+		// Fixture was last modified at 2012-01-01T12:12:12Z
+		// thus it has changed after the earlier time of 2012-01-01T10:00:00Z
+		// so we expect a 200
 		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
 		httpGet.addHeader(Constants.HEADER_IF_MODIFIED_SINCE, DateUtils.formatDate(new InstantDt("2012-01-01T10:00:00Z").getValue()));
 		status = ourClient.execute(httpGet);
 		try {
-			assertEquals(304, status.getStatusLine().getStatusCode());
+			assertEquals(200, status.getStatusLine().getStatusCode());
 		} finally {
 			IOUtils.closeQuietly(status);
 		}

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/ReadDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/ReadDstu3Test.java
@@ -69,20 +69,38 @@ public class ReadDstu3Test {
 		CloseableHttpResponse status;
 		HttpGet httpGet;
 
+		// Fixture was last modified at 2012-01-01T12:12:12Z
+		// thus it hasn't changed after the later time of 2012-01-01T13:00:00Z
+		// so we expect a 304 (Not Modified)
 		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
 		httpGet.addHeader(Constants.HEADER_IF_MODIFIED_SINCE, DateUtils.formatDate(new InstantDt("2012-01-01T13:00:00Z").getValue()));
 		status = ourClient.execute(httpGet);
 		try {
-			assertEquals(200, status.getStatusLine().getStatusCode());
+			assertEquals(304, status.getStatusLine().getStatusCode());
 		} finally {
 			IOUtils.closeQuietly(status);
 		}
-		
+
+		// Fixture was last modified at 2012-01-01T12:12:12Z
+		// thus it hasn't changed after the same time of 2012-01-01T12:12:12Z
+		// so we expect a 304 (Not Modified)
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
+		httpGet.addHeader(Constants.HEADER_IF_MODIFIED_SINCE, DateUtils.formatDate(new InstantDt("2012-01-01T12:12:12Z").getValue()));
+		status = ourClient.execute(httpGet);
+		try {
+			assertEquals(304, status.getStatusLine().getStatusCode());
+		} finally {
+			IOUtils.closeQuietly(status);
+		}
+
+		// Fixture was last modified at 2012-01-01T12:12:12Z
+		// thus it has changed after the earlier time of 2012-01-01T10:00:00Z
+		// so we expect a 200
 		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
 		httpGet.addHeader(Constants.HEADER_IF_MODIFIED_SINCE, DateUtils.formatDate(new InstantDt("2012-01-01T10:00:00Z").getValue()));
 		status = ourClient.execute(httpGet);
 		try {
-			assertEquals(304, status.getStatusLine().getStatusCode());
+			assertEquals(200, status.getStatusLine().getStatusCode());
 		} finally {
 			IOUtils.closeQuietly(status);
 		}


### PR DESCRIPTION
The implementation of support for If-Modified-Since and the corresponding unit tests are broken.

The implementation has the timestamp comparison test backwards and the unit tests have the wrong expectations.

Implementation updated to use correct test, and unit tests have been updated to 1. fix the expectations, and 2. also cover the case where the header timestamp is identical to the modified timestamp.
