### PR TITLE
 Added a client interceptor called AdditionalRequestHeadersInterceptor to add arbitrary HTTP headers to the client request

### DIFF
--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/AdditionalRequestHeadersInterceptor.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/AdditionalRequestHeadersInterceptor.java
@@ -35,7 +35,7 @@ public class AdditionalRequestHeadersInterceptor implements IClientInterceptor {
 	 * @param headerValue the value to add for the header
 	 * @throws NullPointerException if either parameter is {@code null}
 	 */
-	public void addHeaderValue(String headerName, String headerValue) throws NullPointerException {
+	public void addHeaderValue(String headerName, String headerValue) {
 		Objects.requireNonNull(headerName, "headerName cannot be null");
 		Objects.requireNonNull(headerValue, "headerValue cannot be null");
 
@@ -49,7 +49,7 @@ public class AdditionalRequestHeadersInterceptor implements IClientInterceptor {
 	 * @param headerValues the list of values to add for the header
 	 * @throws NullPointerException if either parameter is {@code null}
 	 */
-	public void addAllHeaderValues(String headerName, List<String> headerValues) throws NullPointerException {
+	public void addAllHeaderValues(String headerName, List<String> headerValues) {
 		Objects.requireNonNull(headerName, "headerName cannot be null");
 		Objects.requireNonNull(headerValues, "headerValues cannot be null");
 

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/AdditionalRequestHeadersInterceptor.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/AdditionalRequestHeadersInterceptor.java
@@ -1,0 +1,96 @@
+package ca.uhn.fhir.rest.client.interceptor;
+
+import ca.uhn.fhir.rest.client.api.IClientInterceptor;
+import ca.uhn.fhir.rest.client.api.IHttpRequest;
+import ca.uhn.fhir.rest.client.api.IHttpResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This interceptor adds arbitrary header values to requests made by the client.
+ */
+public class AdditionalRequestHeadersInterceptor implements IClientInterceptor {
+	private final Map<String, List<String>> additionalHttpHeaders = new HashMap<>();
+
+	public AdditionalRequestHeadersInterceptor() {
+		this(new HashMap<String, List<String>>());
+	}
+
+	public AdditionalRequestHeadersInterceptor(Map<String, List<String>> additionalHttpHeaders) {
+		super();
+		if (additionalHttpHeaders != null) {
+			this.additionalHttpHeaders.putAll(additionalHttpHeaders);
+		}
+	}
+
+	/**
+	 * Adds the given header value.
+	 * Note that {@code headerName} and {@code headerValue} cannot be null.
+	 * @param headerName the name of the header
+	 * @param headerValue the value to add for the header
+	 * @throws NullPointerException if either parameter is {@code null}
+	 */
+	public void addHeaderValue(String headerName, String headerValue) throws NullPointerException {
+		Objects.requireNonNull(headerName, "headerName cannot be null");
+		Objects.requireNonNull(headerValue, "headerValue cannot be null");
+
+		getHeaderValues(headerName).add(headerValue);
+	}
+
+	/**
+	 * Adds the list of header values for the given header.
+	 * Note that {@code headerName} and {@code headerValues} cannot be null.
+	 * @param headerName the name of the header
+	 * @param headerValues the list of values to add for the header
+	 * @throws NullPointerException if either parameter is {@code null}
+	 */
+	public void addAllHeaderValues(String headerName, List<String> headerValues) throws NullPointerException {
+		Objects.requireNonNull(headerName, "headerName cannot be null");
+		Objects.requireNonNull(headerValues, "headerValues cannot be null");
+
+		getHeaderValues(headerName).addAll(headerValues);
+	}
+
+	/**
+	 * Gets the header values list for a given header.
+	 * If the header doesn't have any values, an empty list will be returned.
+	 * @param headerName the name of the header
+	 * @return the list of values for the header
+	 */
+	private List<String> getHeaderValues(String headerName) {
+		if (additionalHttpHeaders.get(headerName) == null) {
+			additionalHttpHeaders.put(headerName, new ArrayList<String>());
+		}
+		return additionalHttpHeaders.get(headerName);
+	}
+
+	/**
+	 * Adds the additional header values to the HTTP request.
+	 * @param theRequest the HTTP request
+	 */
+	@Override
+	public void interceptRequest(IHttpRequest theRequest) {
+		for (Map.Entry<String, List<String>> header : additionalHttpHeaders.entrySet()) {
+			for (String headerValue : header.getValue()) {
+				if (headerValue != null) {
+					theRequest.addHeader(header.getKey(), headerValue);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Does nothing since this interceptor is not concerned with the response.
+	 * @param theResponse the HTTP response
+	 * @throws IOException
+	 */
+	@Override
+	public void interceptResponse(IHttpResponse theResponse) throws IOException {
+		// Do nothing. This interceptor is not concerned with the response.
+	}
+}


### PR DESCRIPTION
@jamesagnew Feel free to merge this in if you feel like it'll be useful. You recommended that I open a PR for this here: https://groups.google.com/forum/#!topic/hapi-fhir/tu4l1ltQXco

I did notice that HAPI FHIR already has an interceptor called `SimpleRequestHeaderInterceptor` that is intended to add a single HTTP header to the request so functionality-wise, there is _some_ slight overlap between the functionalities of the existing `SimpleRequestHeaderInterceptor` interceptor (which can add a single HTTP header) and the `AdditionalRequestHeadersInterceptor` interceptor (which can add multiple HTTP headers).