### PR TITLE
Fix deleteByUrl to respect InCompartment Authorization

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -254,8 +254,8 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			ResourceTable entity = myEntityManager.find(ResourceTable.class, pid);
 			deletedResources.add(entity);
 
-			validateOkToDelete(deleteConflicts, entity);
 			T resourceToDelete = toResource(myResourceType, entity, false);
+			validateOkToDelete(deleteConflicts, entity);
 
 			// Notify interceptors
 			IdDt idToDelete = entity.getIdDt();
@@ -267,6 +267,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			// Perform delete
 			Date updateTime = new Date();
 			updateEntity(null, entity, updateTime, updateTime);
+	        resourceToDelete.setId(entity.getIdDt());
 
 			// Notify JPA interceptors
 			if (theRequestDetails != null) {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirResourceDao.java
@@ -255,6 +255,7 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			deletedResources.add(entity);
 
 			validateOkToDelete(deleteConflicts, entity);
+			T resourceToDelete = toResource(myResourceType, entity, false);
 
 			// Notify interceptors
 			IdDt idToDelete = entity.getIdDt();
@@ -268,7 +269,6 @@ public abstract class BaseHapiFhirResourceDao<T extends IBaseResource> extends B
 			updateEntity(null, entity, updateTime, updateTime);
 
 			// Notify JPA interceptors
-			T resourceToDelete = toResource(myResourceType, entity, false);
 			if (theRequestDetails != null) {
 				theRequestDetails.getRequestOperationCallback().resourceDeleted(resourceToDelete);
 				ActionRequestDetails requestDetails = new ActionRequestDetails(theRequestDetails, idToDelete.getResourceType(), idToDelete);

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/AuthorizationInterceptorResourceProviderDstu3Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/dstu3/AuthorizationInterceptorResourceProviderDstu3Test.java
@@ -84,7 +84,7 @@ public class AuthorizationInterceptorResourceProviderDstu3Test extends BaseResou
 	
 
 	/**
-	 * See #503
+	 * See #503 #751
 	 */
 	@Test
 	public void testDeleteIsAllowedForCompartment() {
@@ -98,6 +98,9 @@ public class AuthorizationInterceptorResourceProviderDstu3Test extends BaseResou
 		obsInCompartment.setStatus(ObservationStatus.FINAL);
 		obsInCompartment.getSubject().setReferenceElement(id.toUnqualifiedVersionless());
 		IIdType obsInCompartmentId = ourClient.create().resource(obsInCompartment).execute().getId().toUnqualifiedVersionless();
+		
+		// create a 2nd observation to be deleted by url Observation?patient=id
+        ourClient.create().resource(obsInCompartment).execute().getId().toUnqualifiedVersionless();
 		
 		Observation obsNotInCompartment = new Observation();
 		obsNotInCompartment.setStatus(ObservationStatus.FINAL);
@@ -115,6 +118,7 @@ public class AuthorizationInterceptorResourceProviderDstu3Test extends BaseResou
 		});
 		
 		ourClient.delete().resourceById(obsInCompartmentId.toUnqualifiedVersionless()).execute();
+		ourClient.delete().resourceConditionalByUrl("Observation?patient=" + id.toUnqualifiedVersionless()).execute();
 
 		try {
 			ourClient.delete().resourceById(obsNotInCompartmentId.toUnqualifiedVersionless()).execute();


### PR DESCRIPTION
Moved the assignment of the resource to delete before the actual delete as it will be used by the authorization to determine if this resource is in the compartment.