### PR TITLE
Auth Interceptor - make sure Id has a type before trying to get its associated resource

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/RuleImplOp.java
@@ -225,7 +225,7 @@ class RuleImplOp extends BaseRule /* implements IAuthRule */ {
 					return null;
 				}
 			}
-			if (appliesToResourceId != null) {
+			if (appliesToResourceId != null && appliesToResourceId.hasResourceType()) {
 				Class<? extends IBaseResource> type = theRequestDetails.getServer().getFhirContext().getResourceDefinition(appliesToResourceId.getResourceType()).getImplementingClass();
 				if (myAppliesToTypes.contains(type) == false) {
 					return null;


### PR DESCRIPTION
I have an issue with the authorization rules engine where I would get a null pointer exception during rule validation where I have a transaction with multiple inserts using temporary keys to link them.

This pull request is the one line fix which seems to solve the issue.