### PR TITLE
Fixes issue #768 to conditionally include stacktraces for DataFormatExceptions in OperationOutcomes when using AbstractJaxRsProviders

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/exceptions/InvalidRequestException.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/server/exceptions/InvalidRequestException.java
@@ -47,6 +47,10 @@ public class InvalidRequestException extends BaseServerResponseException {
 	public InvalidRequestException(String theMessage) {
 		super(STATUS_CODE, theMessage);
 	}
+
+	public InvalidRequestException(Throwable theCause) {
+		super(STATUS_CODE, theCause);
+	}
 	
 	/**
 	 * Constructor

--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProvider.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProvider.java
@@ -26,8 +26,6 @@ import java.util.Map.Entry;
 import javax.ws.rs.core.*;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.api.AddProfileTagEnum;
@@ -35,12 +33,9 @@ import ca.uhn.fhir.jaxrs.server.interceptor.JaxRsExceptionInterceptor;
 import ca.uhn.fhir.jaxrs.server.interceptor.JaxRsResponseException;
 import ca.uhn.fhir.jaxrs.server.util.JaxRsRequest;
 import ca.uhn.fhir.jaxrs.server.util.JaxRsRequest.Builder;
-import ca.uhn.fhir.parser.DataFormatException;
 import ca.uhn.fhir.rest.api.*;
 import ca.uhn.fhir.rest.server.*;
-import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import ca.uhn.fhir.rest.server.interceptor.IServerInterceptor;
-import ca.uhn.fhir.util.OperationOutcomeUtil;
 
 /**
  * This is the abstract superclass for all jaxrs providers. It contains some defaults implementing
@@ -77,13 +72,6 @@ public abstract class AbstractJaxRsProvider implements IRestfulServerDefaults {
 	 */
 	protected AbstractJaxRsProvider(final FhirContext ctx) {
 		CTX = ctx;
-	}
-
-	private IBaseOperationOutcome createOutcome(final DataFormatException theException) {
-		final IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(getFhirContext());
-		final String detailsValue = theException.getMessage() + (this.withStackTrace() ? "\n\n" + ExceptionUtils.getStackTrace(theException) : "");
-		OperationOutcomeUtil.addIssue(getFhirContext(), oo, ERROR, detailsValue, null, PROCESSING);
-		return oo;
 	}
 
 	/**
@@ -241,9 +229,6 @@ public abstract class AbstractJaxRsProvider implements IRestfulServerDefaults {
 			throws IOException {
 		if (theException instanceof JaxRsResponseException) {
 			return new JaxRsExceptionInterceptor().convertExceptionIntoResponse(theRequest, (JaxRsResponseException) theException);
-		} else if (theException instanceof DataFormatException) {
-			return new JaxRsExceptionInterceptor().convertExceptionIntoResponse(theRequest, new JaxRsResponseException(
-					new InvalidRequestException(theException.getMessage(), createOutcome((DataFormatException) theException))));
 		} else {
 			return new JaxRsExceptionInterceptor().convertExceptionIntoResponse(theRequest,
 					new JaxRsExceptionInterceptor().convertException(this, theException));

--- a/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProvider.java
+++ b/hapi-fhir-jaxrsserver-base/src/main/java/ca/uhn/fhir/jaxrs/server/AbstractJaxRsProvider.java
@@ -81,7 +81,7 @@ public abstract class AbstractJaxRsProvider implements IRestfulServerDefaults {
 
 	private IBaseOperationOutcome createOutcome(final DataFormatException theException) {
 		final IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(getFhirContext());
-		final String detailsValue = theException.getMessage() + "\n\n" + ExceptionUtils.getStackTrace(theException);
+		final String detailsValue = theException.getMessage() + (this.withStackTrace() ? "\n\n" + ExceptionUtils.getStackTrace(theException) : "");
 		OperationOutcomeUtil.addIssue(getFhirContext(), oo, ERROR, detailsValue, null, PROCESSING);
 		return oo;
 	}

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
@@ -32,6 +32,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import ca.uhn.fhir.parser.DataFormatException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome;
 
@@ -99,7 +101,10 @@ public class ExceptionHandlingInterceptor extends InterceptorAdapter {
 	@Override
 	public BaseServerResponseException preProcessOutgoingException(RequestDetails theRequestDetails, Throwable theException, HttpServletRequest theServletRequest) throws ServletException {
 		BaseServerResponseException retVal;
-		if (!(theException instanceof BaseServerResponseException)) {
+		if (theException instanceof DataFormatException) {
+			// Wrapping the DataFormatException as an InvalidRequestException so that it gets sent back to the client as a 400 response.
+			retVal = new InvalidRequestException(theException);
+		} else if (!(theException instanceof BaseServerResponseException)) {
 			retVal = new InternalErrorException(theException);
 		} else {
 			retVal = (BaseServerResponseException) theException;


### PR DESCRIPTION
When `DataFormatException`s are thrown when using `AbstractJaxRsProvider`s, the stacktrace will be included in the OperationOutcome details only if `AbstractJaxRsProvider#withStrackTrace()` is configured to return `true`.