### PR TITLE
Fixes Conformance providers in the hapi-fhir-jaxrsserver-example module to pass the server description, server name, and server version in the correct order

### DIFF
--- a/examples/src/main/java/example/JaxRsConformanceProvider.java
+++ b/examples/src/main/java/example/JaxRsConformanceProvider.java
@@ -27,7 +27,7 @@ public class JaxRsConformanceProvider extends AbstractJaxRsConformanceProvider {
   private JaxRsPatientRestProvider provider;
 
   public JaxRsConformanceProvider() {
-    super("My Server Version", "My Server Description", "My Server Name");
+    super("My Server Description", "My Server Name", "My Server Version");
   }
 
   @Override

--- a/hapi-fhir-jaxrsserver-example/src/main/java/ca/uhn/fhir/jaxrs/server/example/JaxRsConformanceProvider.java
+++ b/hapi-fhir-jaxrsserver-example/src/main/java/ca/uhn/fhir/jaxrs/server/example/JaxRsConformanceProvider.java
@@ -32,7 +32,7 @@ public class JaxRsConformanceProvider extends AbstractJaxRsConformanceProvider {
 	 * Standard Constructor
 	 */
 	public JaxRsConformanceProvider() {
-		super(SERVER_VERSION, SERVER_DESCRIPTION, SERVER_NAME);
+		super(SERVER_DESCRIPTION, SERVER_NAME, SERVER_VERSION);
 	}
 
 	@Override

--- a/hapi-fhir-jaxrsserver-example/src/main/java/ca/uhn/fhir/jaxrs/server/example/JaxRsConformanceProviderDstu3.java
+++ b/hapi-fhir-jaxrsserver-example/src/main/java/ca/uhn/fhir/jaxrs/server/example/JaxRsConformanceProviderDstu3.java
@@ -33,7 +33,7 @@ public class JaxRsConformanceProviderDstu3 extends AbstractJaxRsConformanceProvi
 	 * Standard Constructor
 	 */
 	public JaxRsConformanceProviderDstu3() {
-		super(FhirContext.forDstu3(), SERVER_VERSION, SERVER_DESCRIPTION, SERVER_NAME);
+		super(FhirContext.forDstu3(), SERVER_DESCRIPTION, SERVER_NAME, SERVER_VERSION);
 	}
 
 	@Override


### PR DESCRIPTION
I noticed when looking at the hapi-fhir-jaxrsserver-example that the server version, server name, and server description were being passed in the wrong order to the super constructor.