### PR TITLE
Fix problem with _include=MedicationRequest:medication

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ResourceReferenceInfo.java
@@ -101,9 +101,15 @@ public class ResourceReferenceInfo {
 			if (resourceDef != null) {
 				RuntimeSearchParam searchParamDef = resourceDef.getSearchParam(paramName);
 				if (searchParamDef!=null) {
-					if (searchParamDef.getPathsSplit().contains(myOwningResource + "." + myName)) {
-						return true;
+					final String myCompleteName = myOwningResource + "." + myName;
+					boolean matched = false;
+					for (String s : searchParamDef.getPathsSplit()) {
+						if (s.equals(myCompleteName) ||
+								       s.startsWith(myCompleteName + ".")) {
+							matched = true; break;
+						}
 					}
+					return matched;
 				}
 			}
 			return false;


### PR DESCRIPTION
A query for MedicationRequest that should include medication
did not work, because the SearchParamDefinition defined the
path as MedicationRequest.medication.as(Reference)

Enhanced the matchesInclude method to allow extra parts after
the search path