### PR TITLE
Conformance Statement -> Capability Statement

### DIFF
--- a/src/site/xdoc/doc_rest_server.xml
+++ b/src/site/xdoc/doc_rest_server.xml
@@ -204,7 +204,8 @@
 		
 			<p>
 				The HAPI FHIR RESTful Server will automatically export a 
-				<a href="http://hl7.org/implement/standards/fhir/conformance.html">conformance statement</a>, 
+				<a href="http://hl7.org/implement/standards/fhir/capabilitystatement.html">capability statement</a> (or a
+				<a href="https://www.hl7.org/fhir/DSTU2/conformance.html">conformance statement</a> for DSTU2 and prior), 
 				as required by the
 				<a href="http://hl7.org/implement/standards/fhir/http.html#conformance">FHIR Specification</a>.
 			</p>


### PR DESCRIPTION
Removed broken link to old conformance.html with link to capabilitysatement.html. Hope this is true that HAPI exports a capability statement now as of STU3?

Note - there are still references to Conformance Statement elsewhere within the documentation (such as doc_rest_operations.xml), but they contained coding / server behavior assertions that I was not comfortable modifying.