### PR TITLE
Avoid unecessary reference to javassist.

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ReflectionUtil.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/util/ReflectionUtil.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.Validate;
 
 import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.support.IContextValidationSupport;
-import javassist.Modifier;
 
 public class ReflectionUtil {
 


### PR DESCRIPTION
By accident I've found that hapi-fhir-base pulls in javassist without need. This might help (a little) with #826. :-)