### PR TITLE
Fix methods that check for names in lists

### DIFF
--- a/hapi-fhir-structures-dstu3/src/test/java/org/hl7/fhir/dstu3/model/HumanNameDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/org/hl7/fhir/dstu3/model/HumanNameDstu3Test.java
@@ -1,0 +1,29 @@
+package org.hl7.fhir.dstu3.model;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HumanNameDstu3Test {
+	@Ignore("Issue #865")
+	@Test
+	public void hasGivenFindsParameter() {
+		HumanName humanName = new HumanName().addGiven("test");
+		assertTrue(humanName.hasGiven("test"));
+	}
+
+	@Ignore("Issue #865")
+	@Test
+	public void hasPrefixFindsParameter() {
+		HumanName humanName = new HumanName().addPrefix("test");
+		assertTrue(humanName.hasPrefix("test"));
+	}
+
+	@Ignore("Issue #865")
+	@Test
+	public void hasSuffixFindsParameter() {
+		HumanName humanName = new HumanName().addSuffix("test");
+		assertTrue(humanName.hasSuffix("test"));
+	}
+}


### PR DESCRIPTION
Prefixes, given names, and suffixes can all have multiple entries, and so are kept in a list. The `hasPrefix(String)` and its sibling methods are conveniences for checking that these lists contain the given element. Add tests around those three methods to ensure that the list checking code is correct.

Issue #865 `HumanName#hasGiven(String)` can never return true