### PR TITLE
equals() and hashCode() for DateRangeParam and DateParam

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/BaseParamWithPrefix.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/BaseParamWithPrefix.java
@@ -107,5 +107,4 @@ public abstract class BaseParamWithPrefix<T extends BaseParam> extends BaseParam
 		myPrefix = thePrefix;
 		return (T) this;
 	}
-
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateParam.java
@@ -20,21 +20,26 @@ package ca.uhn.fhir.rest.param;
  * #L%
  */
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
-import java.util.*;
-
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.model.api.IQueryParameterOr;
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import ca.uhn.fhir.model.primitive.BaseDateTimeDt;
+import ca.uhn.fhir.model.primitive.DateDt;
+import ca.uhn.fhir.model.primitive.DateTimeDt;
+import ca.uhn.fhir.model.primitive.InstantDt;
+import ca.uhn.fhir.rest.api.QualifiedParamList;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.util.ValidateUtil;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.model.api.IQueryParameterOr;
-import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
-import ca.uhn.fhir.model.primitive.*;
-import ca.uhn.fhir.rest.api.QualifiedParamList;
-import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
-import ca.uhn.fhir.util.ValidateUtil;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class DateParam extends BaseParamWithPrefix<DateParam> implements /*IQueryParameterType , */IQueryParameterOr<DateParam> {
 
@@ -222,6 +227,20 @@ public class DateParam extends BaseParamWithPrefix<DateParam> implements /*IQuer
 		
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof DateParam)) {
+			return false;
+		}
+		DateParam other = (DateParam) obj;
+		return	Objects.equals(getValue(), other.getValue()) &&
+					Objects.equals(getPrefix(), other.getPrefix());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getValue(), getPrefix());
+	}
 
 	@Override
 	public String toString() {
@@ -241,8 +260,5 @@ public class DateParam extends BaseParamWithPrefix<DateParam> implements /*IQuer
 		protected boolean isPrecisionAllowed(TemporalPrecisionEnum thePrecision) {
 			return true;
 		}
-
 	}
-
-
 }

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateParam.java
@@ -229,6 +229,9 @@ public class DateParam extends BaseParamWithPrefix<DateParam> implements /*IQuer
 
 	@Override
 	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
 		if (!(obj instanceof DateParam)) {
 			return false;
 		}

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
@@ -414,6 +414,24 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 	}
 
 	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		}
+		if (!(obj instanceof DateRangeParam)) {
+			return false;
+		}
+		DateRangeParam other = (DateRangeParam) obj;
+		return	Objects.equals(myLowerBound, other.myLowerBound) &&
+					Objects.equals(myUpperBound, other.myUpperBound);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(myLowerBound, myUpperBound);
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder b = new StringBuilder();
 		b.append(getClass().getSimpleName());
@@ -484,7 +502,5 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 				throw new DataFormatException("Upper bound comparator must be < or <=, can not be " + myUpperBound.getPrefix().getValue());
 			}
 		}
-
 	}
-
 }

--- a/hapi-fhir-structures-dstu2/pom.xml
+++ b/hapi-fhir-structures-dstu2/pom.xml
@@ -172,7 +172,11 @@
 			<artifactId>guava</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava-testlib</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/param/DateParamTest.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/param/DateParamTest.java
@@ -2,21 +2,19 @@ package ca.uhn.fhir.rest.param;
 
 import ca.uhn.fhir.model.primitive.DateTimeDt;
 import ca.uhn.fhir.model.primitive.InstantDt;
+import com.google.common.testing.EqualsTester;
 import org.junit.Test;
 
 import java.util.Date;
-import java.util.List;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import static ca.uhn.fhir.rest.param.ParamPrefixEnum.APPROXIMATE;
 import static ca.uhn.fhir.rest.param.ParamPrefixEnum.EQUAL;
 import static ca.uhn.fhir.rest.param.ParamPrefixEnum.NOT_EQUAL;
-import static com.google.common.collect.Lists.newArrayList;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
@@ -115,24 +113,18 @@ public class DateParamTest {
 
 	@Test()
 	public void testEqualsAndHashCode() {
-		List<DateParam> uniqueSamples = newArrayList(
-			new DateParam(),
-			new DateParam(NOT_EQUAL, new Date()),
-			new DateParam(EQUAL, new Date().getTime()),
-			new DateParam(APPROXIMATE, "2017-10-17T11:11:11.111-11:11"));
-		DateParam previous = null;
-		for (DateParam current : uniqueSamples) {
-			ourLog.info("Equals test samples: [previous=" + previous + ", current=" + current + "]");
-			assertThat(current, is(equalTo(copyOf(current))));
-			assertThat(current.hashCode(), is(equalTo(copyOf(current).hashCode())));
-
-			assertThat(current, is(not(equalTo(previous))));
-			assertThat(current.hashCode(), is(not(equalTo(previous != null ? previous.hashCode() : null))));
-			previous = current;
-		}
-	}
-
-	private DateParam copyOf(DateParam param) {
-		return new DateParam(param.getPrefix(), param.getValue());
+		Date now = new Date();
+		Date later = new Date(now.getTime() + SECONDS.toMillis(666));
+		new EqualsTester()
+			.addEqualityGroup(new DateParam(),
+				               new DateParam(null))
+			.addEqualityGroup(new DateParam(NOT_EQUAL, now),
+				               new DateParam(NOT_EQUAL, now.getTime()))
+			.addEqualityGroup(new DateParam(EQUAL, now),
+				               new DateParam(EQUAL, now.getTime()))
+			.addEqualityGroup(new DateParam(EQUAL, later),
+				               new DateParam(EQUAL, later.getTime()))
+			.addEqualityGroup(new DateParam(APPROXIMATE, "2011-11-11T11:11:11.111-11:11"))
+			.testEquals();
 	}
 }

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/param/DateParamTest.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/param/DateParamTest.java
@@ -1,17 +1,24 @@
 package ca.uhn.fhir.rest.param;
 
-import static org.hamcrest.Matchers.endsWith;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
-import java.util.Date;
-import java.util.TimeZone;
-
-import org.junit.Test;
-
 import ca.uhn.fhir.model.primitive.DateTimeDt;
 import ca.uhn.fhir.model.primitive.InstantDt;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.APPROXIMATE;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.EQUAL;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.NOT_EQUAL;
+import static com.google.common.collect.Lists.newArrayList;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class DateParamTest {
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(DateParamTest.class);
@@ -105,6 +112,27 @@ public class DateParamTest {
 		assertEquals(ParamPrefixEnum.LESSTHAN, new DateParam("lt2012").getPrefix());
 		assertEquals(ParamPrefixEnum.LESSTHAN_OR_EQUALS, new DateParam("le2012").getPrefix());
 	}
-	
 
+	@Test()
+	public void testEqualsAndHashCode() {
+		List<DateParam> uniqueSamples = newArrayList(
+			new DateParam(),
+			new DateParam(NOT_EQUAL, new Date()),
+			new DateParam(EQUAL, new Date().getTime()),
+			new DateParam(APPROXIMATE, "2017-10-17T11:11:11.111-11:11"));
+		DateParam previous = null;
+		for (DateParam current : uniqueSamples) {
+			ourLog.info("Equals test samples: [previous=" + previous + ", current=" + current + "]");
+			assertThat(current, is(equalTo(copyOf(current))));
+			assertThat(current.hashCode(), is(equalTo(copyOf(current).hashCode())));
+
+			assertThat(current, is(not(equalTo(previous))));
+			assertThat(current.hashCode(), is(not(equalTo(previous != null ? previous.hashCode() : null))));
+			previous = current;
+		}
+	}
+
+	private DateParam copyOf(DateParam param) {
+		return new DateParam(param.getPrefix(), param.getValue());
+	}
 }

--- a/hapi-fhir-structures-dstu3/pom.xml
+++ b/hapi-fhir-structures-dstu3/pom.xml
@@ -261,7 +261,11 @@
 			<artifactId>guava</artifactId>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava-testlib</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
@@ -1,12 +1,28 @@
 package ca.uhn.fhir.rest.param;
 
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.APPROXIMATE;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.EQUAL;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.GREATERTHAN;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.GREATERTHAN_OR_EQUALS;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.LESSTHAN;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.LESSTHAN_OR_EQUALS;
+import static ca.uhn.fhir.rest.param.ParamPrefixEnum.NOT_EQUAL;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 
+import com.google.common.testing.EqualsTester;
 import org.junit.AfterClass;
 import org.junit.Test;
 
@@ -183,7 +199,26 @@ public class DateRangeParamTest {
 	public static void afterClassClearContext() {
 		TestUtil.clearAllStaticFieldsForUnitTest();
 	}
-	
+
+	@Test()
+	public void testEqualsAndHashCode() {
+		Date lowerBound = new Date(currentTimeMillis());
+		Date upperBound = new Date(lowerBound.getTime() + SECONDS.toMillis(1));
+		new EqualsTester()
+			.addEqualityGroup(new DateRangeParam(),
+				               new DateRangeParam((Date) null, (Date) null))
+			.addEqualityGroup(new DateRangeParam(lowerBound, upperBound),
+								   new DateRangeParam(new DateParam(GREATERTHAN_OR_EQUALS, lowerBound), new DateParam(LESSTHAN_OR_EQUALS, upperBound)))
+			.addEqualityGroup(new DateRangeParam(new DateParam(EQUAL, lowerBound)),
+				               new DateRangeParam(new DateParam(null, lowerBound)),
+								   new DateRangeParam(new DateParam(EQUAL, lowerBound), new DateParam(EQUAL, lowerBound)))
+			.addEqualityGroup(new DateRangeParam(lowerBound, null),
+				               new DateRangeParam(new DateParam(GREATERTHAN_OR_EQUALS, lowerBound), null))
+			.addEqualityGroup(new DateRangeParam(null, upperBound),
+				               new DateRangeParam(null, new DateParam(LESSTHAN_OR_EQUALS, upperBound)))
+			.testEquals();
+	}
+
 	private static DateRangeParam create(String theLower, String theUpper) throws InvalidRequestException {
 		DateRangeParam p = new DateRangeParam();
 		List<QualifiedParamList> tokens = new ArrayList<QualifiedParamList>();
@@ -202,5 +237,4 @@ public class DateRangeParamTest {
 	public static Date parseM1(String theString) throws ParseException {
 		return new Date(ourFmt.parse(theString).getTime() - 1L);
 	}
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,11 @@
 				<version>23.0</version>
 			</dependency>
 			<dependency>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava-testlib</artifactId>
+				<version>23.0</version>
+			</dependency>
+			<dependency>
 				<groupId>com.phloc</groupId>
 				<artifactId>phloc-schematron</artifactId>
 				<version>${phloc_schematron_version}</version>


### PR DESCRIPTION
- added guava-testlib as test dependency to modules hapi-fhir-structures-dstu2 and hapi-fhir-structures-dstu3
- added DateRangeParam.equals(Object) and DateRangeParam.hashCode()
- added DateParam.equals(Object) and DateParam.hashCode()
