### PR TITLE
Fix questionnaire schematron for que-7

### DIFF
--- a/hapi-fhir-validation-resources-dstu3/src/main/resources/org/hl7/fhir/dstu3/model/schema/fhir-invariants.sch
+++ b/hapi-fhir-validation-resources-dstu3/src/main/resources/org/hl7/fhir/dstu3/model/schema/fhir-invariants.sch
@@ -4503,7 +4503,7 @@
       <sch:assert test="not((f:type/@value='group' and not(f:item)) or (f:type/@value='display' and f:item))">que-1: Group items must have nested items, display items cannot have nested items</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen">
-      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|self::f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
+      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen/f:answerAttachment">
       <sch:assert test="not(exists(f:data)) or exists(f:contentType)">att-1: It the Attachment has data, it SHALL have a contentType</sch:assert>

--- a/hapi-fhir-validation-resources-dstu3/src/main/resources/org/hl7/fhir/dstu3/model/schema/questionnaire.sch
+++ b/hapi-fhir-validation-resources-dstu3/src/main/resources/org/hl7/fhir/dstu3/model/schema/questionnaire.sch
@@ -76,7 +76,7 @@
       <sch:assert test="not((f:type/@value='group' and not(f:item)) or (f:type/@value='display' and f:item))">que-1: Group items must have nested items, display items cannot have nested items</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen">
-      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|self::f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
+      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen/f:answerAttachment">
       <sch:assert test="not(exists(f:data)) or exists(f:contentType)">att-1: It the Attachment has data, it SHALL have a contentType</sch:assert>

--- a/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/fhir-invariants.sch
+++ b/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/fhir-invariants.sch
@@ -5187,7 +5187,7 @@
       <sch:assert test="not(f:option) or not(count(f:*[starts-with(local-name(.), 'initial')]|)">que-11: If one or more option is present, initial[x] must be missing</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen">
-      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|self::f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
+      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen/f:answerAttachment">
       <sch:assert test="not(exists(f:data)) or exists(f:contentType)">att-1: If the Attachment has data, it SHALL have a contentType</sch:assert>

--- a/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/questionnaire.sch
+++ b/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/schema/questionnaire.sch
@@ -74,7 +74,7 @@
       <sch:assert test="not(f:option) or not(count(f:*[starts-with(local-name(.), 'initial')]|)">que-11: If one or more option is present, initial[x] must be missing</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen">
-      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|self::f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
+      <sch:assert test="count(f:*[starts-with(local-name(.), 'answer')]|f:hasAnswer) = 1">que-7: enableWhen must contain either a 'answer' or a 'hasAnswer' element</sch:assert>
     </sch:rule>
     <sch:rule context="f:Questionnaire/f:item/f:enableWhen/f:answerAttachment">
       <sch:assert test="not(exists(f:data)) or exists(f:contentType)">att-1: If the Attachment has data, it SHALL have a contentType</sch:assert>

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/SchematronValidationDstu3QuestionnaireTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/SchematronValidationDstu3QuestionnaireTest.java
@@ -1,0 +1,127 @@
+package org.hl7.fhir.dstu3.hapi.validation;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.util.TestUtil;
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.ValidationResult;
+import org.hl7.fhir.dstu3.model.Enumerations;
+import org.hl7.fhir.dstu3.model.Questionnaire;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemEnableWhenComponent;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
+import org.hl7.fhir.dstu3.model.StringType;
+
+import org.hamcrest.Matchers;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchematronValidationDstu3QuestionnaireTest {
+	private static final Logger ourLog = LoggerFactory.getLogger(SchematronValidationDstu3QuestionnaireTest.class);
+
+	private static FhirContext ourCtx = FhirContext.forDstu3();
+
+	private static int linkIdCnt = 1;
+
+	@Test
+	public void enableWhenWithAnswer() {
+		Questionnaire resource = new Questionnaire();
+		resource.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		QuestionnaireItemComponent child1 = createItem(QuestionnaireItemType.GROUP);
+		resource.addItem(child1);
+
+		QuestionnaireItemEnableWhenComponent enableWhen = new QuestionnaireItemEnableWhenComponent();
+		enableWhen.setQuestion("q1");
+		enableWhen.setAnswer(new StringType("a value"));
+		child1.addEnableWhen(enableWhen);
+
+		QuestionnaireItemComponent child21 = createItem(QuestionnaireItemType.STRING);
+		child1.addItem(child21);
+
+		String inputXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(resource);
+		ourLog.info(inputXml);
+
+		ValidationResult result = validateSchematron(resource);
+		assertTrue(result.isSuccessful());
+	}
+
+	@Test
+	public void enableWhenWithHasAnswer() {
+		Questionnaire resource = new Questionnaire();
+		resource.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		QuestionnaireItemComponent child1 = createItem(QuestionnaireItemType.GROUP);
+		resource.addItem(child1);
+
+		QuestionnaireItemEnableWhenComponent enableWhen = new QuestionnaireItemEnableWhenComponent();
+		enableWhen.setQuestion("q1");
+		enableWhen.setHasAnswer(true);
+		child1.addEnableWhen(enableWhen);
+
+		QuestionnaireItemComponent child21 = createItem(QuestionnaireItemType.STRING);
+		child1.addItem(child21);
+
+		String inputXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(resource);
+		ourLog.info(inputXml);
+
+		ValidationResult result = validateSchematron(resource);
+		assertTrue(result.isSuccessful());
+	}
+
+	@Test
+	public void enableWhenWithHasAnswerAndAnswer() {
+		Questionnaire resource = new Questionnaire();
+		resource.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		QuestionnaireItemComponent child1 = createItem(QuestionnaireItemType.GROUP);
+		resource.addItem(child1);
+
+		QuestionnaireItemEnableWhenComponent enableWhen = new QuestionnaireItemEnableWhenComponent();
+		enableWhen.setQuestion("q1");
+		enableWhen.setAnswer(new StringType("a value"));
+		enableWhen.setHasAnswer(true);
+		child1.addEnableWhen(enableWhen);
+
+		QuestionnaireItemComponent child21 = createItem(QuestionnaireItemType.STRING);
+		child1.addItem(child21);
+
+		String inputXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(resource);
+		ourLog.info(inputXml);
+
+		ValidationResult result = validateSchematron(resource);
+		assertFalse(result.isSuccessful());
+		assertEquals(1, result.getMessages().size());
+		assertThat(result.getMessages().get(0).getMessage(), containsString("que-7"));
+	}
+
+	private QuestionnaireItemComponent createItem(QuestionnaireItemType type) {
+		QuestionnaireItemComponent item = new QuestionnaireItemComponent();
+		item.setLinkId("id-" + linkIdCnt++);
+		item.setType(type);
+		return item;
+	}
+
+	private ValidationResult validateSchematron(Questionnaire resource) {
+		FhirValidator val = ourCtx.newValidator();
+		val.setValidateAgainstStandardSchema(false);
+		val.setValidateAgainstStandardSchematron(true);
+		ValidationResult result = val.validateWithResult(resource);
+
+		String outcomeXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(result.toOperationOutcome());
+		ourLog.info(outcomeXml);
+		return result;
+	}
+
+	@AfterClass
+	public static void afterClassClearContext() {
+		TestUtil.clearAllStaticFieldsForUnitTest();
+	}
+}

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/SchematronValidationDstu3QuestionnaireTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/SchematronValidationDstu3QuestionnaireTest.java
@@ -17,7 +17,6 @@ import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemEnableWhenCompone
 import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
 import org.hl7.fhir.dstu3.model.StringType;
 
-import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.slf4j.Logger;

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/SchematronValidationR4QuestionnaireTest.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/SchematronValidationR4QuestionnaireTest.java
@@ -1,0 +1,129 @@
+package org.hl7.fhir.r4.validation;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.util.TestUtil;
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.ValidationResult;
+
+import org.hl7.fhir.r4.model.Enumerations;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemEnableWhenComponent;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
+import org.hl7.fhir.r4.model.StringType;
+
+import org.junit.AfterClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Ignore("Requires a valid schematron file, e.g. bei merging pull request #869")
+public class SchematronValidationR4QuestionnaireTest {
+	private static final Logger ourLog = LoggerFactory.getLogger(SchematronValidationR4QuestionnaireTest.class);
+
+	private static FhirContext ourCtx = FhirContext.forR4();
+
+	private static int linkIdCnt = 1;
+
+	@Test
+	public void enableWhenWithAnswer() {
+		Questionnaire resource = new Questionnaire();
+		resource.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		QuestionnaireItemComponent child1 = createItem(QuestionnaireItemType.GROUP);
+		resource.addItem(child1);
+
+		QuestionnaireItemEnableWhenComponent enableWhen = new QuestionnaireItemEnableWhenComponent();
+		enableWhen.setQuestion("q1");
+		enableWhen.setAnswer(new StringType("a value"));
+		child1.addEnableWhen(enableWhen);
+
+		QuestionnaireItemComponent child21 = createItem(QuestionnaireItemType.STRING);
+		child1.addItem(child21);
+
+		String inputXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(resource);
+		ourLog.info(inputXml);
+
+		ValidationResult result = validateSchematron(resource);
+		assertTrue(result.isSuccessful());
+	}
+
+	@Test
+	public void enableWhenWithHasAnswer() {
+		Questionnaire resource = new Questionnaire();
+		resource.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		QuestionnaireItemComponent child1 = createItem(QuestionnaireItemType.GROUP);
+		resource.addItem(child1);
+
+		QuestionnaireItemEnableWhenComponent enableWhen = new QuestionnaireItemEnableWhenComponent();
+		enableWhen.setQuestion("q1");
+		enableWhen.setHasAnswer(true);
+		child1.addEnableWhen(enableWhen);
+
+		QuestionnaireItemComponent child21 = createItem(QuestionnaireItemType.STRING);
+		child1.addItem(child21);
+
+		String inputXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(resource);
+		ourLog.info(inputXml);
+
+		ValidationResult result = validateSchematron(resource);
+		assertTrue(result.isSuccessful());
+	}
+
+	@Test
+	public void enableWhenWithHasAnswerAndAnswer() {
+		Questionnaire resource = new Questionnaire();
+		resource.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+		QuestionnaireItemComponent child1 = createItem(QuestionnaireItemType.GROUP);
+		resource.addItem(child1);
+
+		QuestionnaireItemEnableWhenComponent enableWhen = new QuestionnaireItemEnableWhenComponent();
+		enableWhen.setQuestion("q1");
+		enableWhen.setAnswer(new StringType("a value"));
+		enableWhen.setHasAnswer(true);
+		child1.addEnableWhen(enableWhen);
+
+		QuestionnaireItemComponent child21 = createItem(QuestionnaireItemType.STRING);
+		child1.addItem(child21);
+
+		String inputXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(resource);
+		ourLog.info(inputXml);
+
+		ValidationResult result = validateSchematron(resource);
+		assertFalse(result.isSuccessful());
+		assertEquals(1, result.getMessages().size());
+		assertThat(result.getMessages().get(0).getMessage(), containsString("que-7"));
+	}
+
+	private QuestionnaireItemComponent createItem(QuestionnaireItemType type) {
+		QuestionnaireItemComponent item = new QuestionnaireItemComponent();
+		item.setLinkId("id-" + linkIdCnt++);
+		item.setType(type);
+		return item;
+	}
+
+	private ValidationResult validateSchematron(Questionnaire resource) {
+		FhirValidator val = ourCtx.newValidator();
+		val.setValidateAgainstStandardSchema(false);
+		val.setValidateAgainstStandardSchematron(true);
+		ValidationResult result = val.validateWithResult(resource);
+
+		String outcomeXml = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(result.toOperationOutcome());
+		ourLog.info(outcomeXml);
+		return result;
+	}
+
+	@AfterClass
+	public static void afterClassClearContext() {
+		TestUtil.clearAllStaticFieldsForUnitTest();
+	}
+}


### PR DESCRIPTION
Without this fix, the 'hasAnswer' element of a questionnaire item is ignored.
This in turn permits that one can have both an 'answer' and a 'hasAnswer' item.

A fix is applied for both DSTU3 and R4 and tests are provided.

The tests for R4 are currently ignored, since they require a valid schematron,
e.g. by merging #869