### PR TITLE
Fixes issue #878 where resources in a bundle are updated even when no…

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/BaseHapiFhirDao.java
@@ -129,7 +129,7 @@ public abstract class BaseHapiFhirDao<T extends IBaseResource> implements IDao {
 
 		HashSet<String> excludeElementsInEncoded = new HashSet<String>();
 		excludeElementsInEncoded.add("id");
-		excludeElementsInEncoded.add("meta");
+		excludeElementsInEncoded.add("*.meta");
 		EXCLUDE_ELEMENTS_IN_ENCODED = Collections.unmodifiableSet(excludeElementsInEncoded);
 	}
 


### PR DESCRIPTION
… data changes.

It looks like the issue is being caused by a misconfigured element exclusion list that is passed to the parser. "meta" was being passed in but the parser actually looks for "<resource_type>.meta" or "*.meta" when checking if it should serialize the meta block (see "shouldEncodeResourceMeta" in BaseParser.java). Updating the meta element to *.meta so the meta block will be excluded for all resource types resolves the issue.