### PR TITLE
Two typos in the InstanceValidator

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/validation/InstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/validation/InstanceValidator.java
@@ -2286,7 +2286,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
    *          - the candidate that might be in the slice
    * @param path
    *          - for reporting any errors. the XPath for the element
-   * @param slice
+   * @param slicer
    *          - the definition of how slicing is determined
    * @param ed
    *          - the slice for which to test membership


### PR DESCRIPTION
After the rebase the title is no longer true - there is only one typo left: a wrong javadoc parameter name.