### PR TITLE
Extension domains configuration for the fhr instance validator

### DIFF
--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/dstu3/hapi/validation/FhirInstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/dstu3/hapi/validation/FhirInstanceValidator.java
@@ -121,17 +121,13 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 	}
 
 	private String determineResourceName(Document theDocument) {
-		Element root = null;
-
 		NodeList list = theDocument.getChildNodes();
 		for (int i = 0; i < list.getLength(); i++) {
 			if (list.item(i) instanceof Element) {
-				root = (Element) list.item(i);
-				break;
+				return list.item(i).getLocalName();
 			}
 		}
-		root = theDocument.getDocumentElement();
-		return root.getLocalName();
+		return theDocument.getDocumentElement().getLocalName();
 	}
 
 	private ArrayList<String> determineIfProfilesSpecified(Document theDocument) {

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/dstu3/hapi/validation/FhirInstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/dstu3/hapi/validation/FhirInstanceValidator.java
@@ -173,7 +173,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 	 * guielines will be ignored.
 	 * </p>
 	 *
-	 * @see {@link #setBestPracticeWarningLevel(BestPracticeWarningLevel)}
+	 * @see #setBestPracticeWarningLevel(BestPracticeWarningLevel)
 	 */
 	public BestPracticeWarningLevel getBestPracticeWarningLevel() {
 		return myBestPracticeWarningLevel;
@@ -379,7 +379,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		private LoadingCache<ResourceKey, org.hl7.fhir.r4.model.Resource> myFetchResourceCache;
 		private org.hl7.fhir.r4.model.Parameters myExpansionProfile;
 
-		public WorkerContextWrapper(HapiWorkerContext theWorkerContext) {
+		WorkerContextWrapper(HapiWorkerContext theWorkerContext) {
 			myWrap = theWorkerContext;
 			myConverter = new VersionConvertor_30_40();
 
@@ -460,7 +460,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		}
 
 		@Override
-		public void cacheResource(org.hl7.fhir.r4.model.Resource res) throws FHIRException {
+		public void cacheResource(org.hl7.fhir.r4.model.Resource res) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -482,7 +482,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 
 		@Override
 		public ValueSetExpander.ValueSetExpansionOutcome expandVS(org.hl7.fhir.r4.model.ValueSet source, boolean cacheOk, boolean heiarchical) {
-			ValueSet convertedSource = null;
+			ValueSet convertedSource;
 			try {
 				convertedSource = VersionConvertor_30_40.convertValueSet(source);
 			} catch (FHIRException e) {
@@ -506,7 +506,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		}
 
 		@Override
-		public ValueSetExpander.ValueSetExpansionOutcome expandVS(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent binding, boolean cacheOk, boolean heiarchical) throws FHIRException {
+		public ValueSetExpander.ValueSetExpansionOutcome expandVS(org.hl7.fhir.r4.model.ElementDefinition.ElementDefinitionBindingComponent binding, boolean cacheOk, boolean heiarchical) {
 			throw new UnsupportedOperationException();
 		}
 
@@ -673,7 +673,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		}
 
 		@Override
-		public IResourceValidator newValidator() throws FHIRException {
+		public IResourceValidator newValidator() {
 			throw new UnsupportedOperationException();
 		}
 
@@ -698,7 +698,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		}
 
 		@Override
-		public boolean supportsSystem(String system) throws TerminologyServiceException {
+		public boolean supportsSystem(String system) {
 			return myWrap.supportsSystem(system);
 		}
 
@@ -715,6 +715,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		@Override
 		public ValidationResult validateCode(String system, String code, String display) {
 			org.hl7.fhir.dstu3.context.IWorkerContext.ValidationResult result = myWrap.validateCode(system, code, display);
+			// TODO: converted code might be null -> NPE
 			return convertValidationResult(result);
 		}
 
@@ -765,6 +766,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 				throw new InternalErrorException(e);
 			}
 
+			// TODO: converted code might be null -> NPE
 			org.hl7.fhir.dstu3.context.IWorkerContext.ValidationResult result = myWrap.validateCode(convertedCode, convertedVs);
 			return convertValidationResult(result);
 		}
@@ -785,6 +787,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 				throw new InternalErrorException(e);
 			}
 
+			// TODO: converted code might be null -> NPE
 			org.hl7.fhir.dstu3.context.IWorkerContext.ValidationResult result = myWrap.validateCode(convertedCode, convertedVs);
 			return convertValidationResult(result);
 		}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/dstu3/hapi/validation/FhirInstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/dstu3/hapi/validation/FhirInstanceValidator.java
@@ -60,6 +60,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 	private IValidationSupport myValidationSupport;
 	private boolean noTerminologyChecks = false;
 	private volatile WorkerContextWrapper myWrappedWorkerContext;
+	private List<String> extensionDomains = Collections.emptyList();
 
 	/**
 	 * Constructor
@@ -79,6 +80,44 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		myDocBuilderFactory = DocumentBuilderFactory.newInstance();
 		myDocBuilderFactory.setNamespaceAware(true);
 		myValidationSupport = theValidationSupport;
+	}
+
+	/**
+	 * Every element in a resource or data type includes an optional <it>extension</it> child element
+	 * which is identified by it's {@code url attribute}. There exists a number of predefined
+	 * extension urls or extension domains:<ul>
+	 *  <li>any url which contains {@code example.org}, {@code nema.org}, or {@code acme.com}.</li>
+	 *  <li>any url which starts with {@code http://hl7.org/fhir/StructureDefinition/}.</li>
+	 * </ul>
+	 * It is possible to extend this list of known extension by defining custom extensions:
+	 * Any url which starts which one of the elements in the list of custom extension domains is
+	 * considered as known.
+	 * <p>
+	 * Any unknown extension domain will result in an information message when validating a resource.
+	 * </p>
+	 */
+	public FhirInstanceValidator setCustomExtensionDomains(List<String> extensionDomains) {
+		this.extensionDomains = extensionDomains;
+		return this;
+	}
+
+	/**
+	 * Every element in a resource or data type includes an optional <it>extension</it> child element
+	 * which is identified by it's {@code url attribute}. There exists a number of predefined
+	 * extension urls or extension domains:<ul>
+	 *  <li>any url which contains {@code example.org}, {@code nema.org}, or {@code acme.com}.</li>
+	 *  <li>any url which starts with {@code http://hl7.org/fhir/StructureDefinition/}.</li>
+	 * </ul>
+	 * It is possible to extend this list of known extension by defining custom extensions:
+	 * Any url which starts which one of the elements in the list of custom extension domains is
+	 * considered as known.
+	 * <p>
+	 * Any unknown extension domain will result in an information message when validating a resource.
+	 * </p>
+	 */
+	public FhirInstanceValidator setCustomExtensionDomains(String... extensionDomains) {
+		this.extensionDomains = Arrays.asList(extensionDomains);
+		return this;
 	}
 
 	private String determineResourceName(Document theDocument) {
@@ -235,6 +274,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		v.setAnyExtensionsAllowed(isAnyExtensionsAllowed());
 		v.setResourceIdRule(IdStatus.OPTIONAL);
 		v.setNoTerminologyChecks(isNoTerminologyChecks());
+		v.addExtensionDomains(extensionDomains);
 
 		List<ValidationMessage> messages = new ArrayList<>();
 

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/hapi/validation/FhirInstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/hapi/validation/FhirInstanceValidator.java
@@ -32,6 +32,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -45,6 +46,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 	private DocumentBuilderFactory myDocBuilderFactory;
 	private boolean myNoTerminologyChecks;
 	private StructureDefinition myStructureDefintion;
+	private List<String> extensionDomains = Collections.emptyList();
 
 	private IValidationSupport myValidationSupport;
 
@@ -66,6 +68,44 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		myDocBuilderFactory = DocumentBuilderFactory.newInstance();
 		myDocBuilderFactory.setNamespaceAware(true);
 		myValidationSupport = theValidationSupport;
+	}
+
+	/**
+	 * Every element in a resource or data type includes an optional <it>extension</it> child element
+	 * which is identified by it's {@code url attribute}. There exists a number of predefined
+	 * extension urls or extension domains:<ul>
+	 *  <li>any url which contains {@code example.org}, {@code nema.org}, or {@code acme.com}.</li>
+	 *  <li>any url which starts with {@code http://hl7.org/fhir/StructureDefinition/}.</li>
+	 * </ul>
+	 * It is possible to extend this list of known extension by defining custom extensions:
+	 * Any url which starts which one of the elements in the list of custom extension domains is
+	 * considered as known.
+	 * <p>
+	 * Any unknown extension domain will result in an information message when validating a resource.
+	 * </p>
+	 */
+	public FhirInstanceValidator setCustomExtensionDomains(List<String> extensionDomains) {
+		this.extensionDomains = extensionDomains;
+		return this;
+	}
+
+	/**
+	 * Every element in a resource or data type includes an optional <it>extension</it> child element
+	 * which is identified by it's {@code url attribute}. There exists a number of predefined
+	 * extension urls or extension domains:<ul>
+	 *  <li>any url which contains {@code example.org}, {@code nema.org}, or {@code acme.com}.</li>
+	 *  <li>any url which starts with {@code http://hl7.org/fhir/StructureDefinition/}.</li>
+	 * </ul>
+	 * It is possible to extend this list of known extension by defining custom extensions:
+	 * Any url which starts which one of the elements in the list of custom extension domains is
+	 * considered as known.
+	 * <p>
+	 * Any unknown extension domain will result in an information message when validating a resource.
+	 * </p>
+	 */
+	public FhirInstanceValidator setCustomExtensionDomains(String... extensionDomains) {
+		this.extensionDomains = Arrays.asList(extensionDomains);
+		return this;
 	}
 
 	private String determineResourceName(Document theDocument) {
@@ -211,6 +251,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		v.setAnyExtensionsAllowed(isAnyExtensionsAllowed());
 		v.setResourceIdRule(IdStatus.OPTIONAL);
 		v.setNoTerminologyChecks(isNoTerminologyChecks());
+		v.addExtensionDomains(extensionDomains);
 
 		List<ValidationMessage> messages = new ArrayList<ValidationMessage>();
 

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/hapi/validation/FhirInstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/hapi/validation/FhirInstanceValidator.java
@@ -109,17 +109,13 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 	}
 
 	private String determineResourceName(Document theDocument) {
-		Element root = null;
-
 		NodeList list = theDocument.getChildNodes();
 		for (int i = 0; i < list.getLength(); i++) {
 			if (list.item(i) instanceof Element) {
-				root = (Element) list.item(i);
-				break;
+				return list.item(i).getLocalName();
 			}
 		}
-		root = theDocument.getDocumentElement();
-		return root.getLocalName();
+		return theDocument.getDocumentElement().getLocalName();
 	}
 
 	private ArrayList<String> determineIfProfilesSpecified(Document theDocument) {

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/hapi/validation/FhirInstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/hapi/validation/FhirInstanceValidator.java
@@ -156,8 +156,8 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 	 * reported at the ERROR level. If this setting is set to {@link BestPracticeWarningLevel#Ignore}, best practice
 	 * guielines will be ignored.
 	 * </p>
-	 *
-	 * @see {@link #setBestPracticeWarningLevel(BestPracticeWarningLevel)}
+	 * 
+	 * @see #setBestPracticeWarningLevel(BestPracticeWarningLevel)
 	 */
 	public BestPracticeWarningLevel getBestPracticeWarningLevel() {
 		return myBestPracticeWarningLevel;
@@ -249,7 +249,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		v.setNoTerminologyChecks(isNoTerminologyChecks());
 		v.addExtensionDomains(extensionDomains);
 
-		List<ValidationMessage> messages = new ArrayList<ValidationMessage>();
+		List<ValidationMessage> messages = new ArrayList<>();
 
 		if (theEncoding == EncodingEnum.XML) {
 			Document document;
@@ -349,7 +349,7 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 	public static class NullEvaluationContext implements IEvaluationContext {
 
 		@Override
-		public TypeDetails checkFunction(Object theAppContext, String theFunctionName, List<TypeDetails> theParameters) throws PathEngineException {
+		public TypeDetails checkFunction(Object theAppContext, String theFunctionName, List<TypeDetails> theParameters) {
 			return null;
 		}
 
@@ -364,12 +364,12 @@ public class FhirInstanceValidator extends BaseValidatorBridge implements IValid
 		}
 
 		@Override
-		public Base resolveConstant(Object theAppContext, String theName) throws PathEngineException {
+		public Base resolveConstant(Object theAppContext, String theName) {
 			return null;
 		}
 
 		@Override
-		public TypeDetails resolveConstantType(Object theAppContext, String theName) throws PathEngineException {
+		public TypeDetails resolveConstantType(Object theAppContext, String theName) {
 			return null;
 		}
 

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/validation/InstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/validation/InstanceValidator.java
@@ -1956,6 +1956,11 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     return extensionDomains;
   }
 
+  public InstanceValidator addExtensionDomains(List<String> extensionDomains) {
+    this.extensionDomains.addAll(extensionDomains);
+    return this;
+  }
+
   private Element getFromBundle(Element bundle, String ref, String fullUrl, List<ValidationMessage> errors, String path) {
     String targetUrl = null;
     String version = "";

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/validation/InstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/r4/validation/InstanceValidator.java
@@ -416,8 +416,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
   }
 
   private boolean allowUnknownExtension(String url) {
-    if (url.contains("example.org") || url.contains("acme.com") || url.contains("nema.org") || url.startsWith("http://hl7.org/fhir/tools/StructureDefinition/") || url.equals("http://hl7.org/fhir/StructureDefinition/structuredefinition-expression"))
-      // Added structuredefinition-expression explicitly because it wasn't defined in the version of the spec it needs to be used with
+    if (isPredefinedExtension(url))
       return true;
     for (String s : extensionDomains)
       if (url.startsWith(s))
@@ -426,13 +425,20 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
   }
 
   private boolean isKnownExtension(String url) {
-    // Added structuredefinition-expression and following extensions explicitly because they weren't defined in the version of the spec they need to be used with
-    if (url.contains("example.org") || url.contains("acme.com") || url.contains("nema.org") || url.startsWith("http://hl7.org/fhir/tools/StructureDefinition/") || url.equals("http://hl7.org/fhir/StructureDefinition/structuredefinition-expression") || url.equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION))
+    if (isPredefinedExtension(url))
       return true;
     for (String s : extensionDomains)
       if (url.startsWith(s))
         return true;
     return false;
+  }
+
+  private boolean isPredefinedExtension(String url) {
+    return url.contains("example.org")
+        || url.contains("acme.com")
+        || url.contains("nema.org")
+        || url.startsWith("http://hl7.org/fhir/StructureDefinition/")
+        || url.equals(VersionConvertorConstants.IG_DEPENDSON_PACKAGE_EXTENSION);
   }
 
   private void bpCheck(List<ValidationMessage> errors, IssueType invalid, int line, int col, String literalPath, boolean test, String message) {

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/QuestionnaireValidatorDstu3Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/dstu3/hapi/validation/QuestionnaireValidatorDstu3Test.java
@@ -1,0 +1,134 @@
+package org.hl7.fhir.dstu3.hapi.validation;
+
+import java.util.Collections;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.util.TestUtil;
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.ResultSeverityEnum;
+import ca.uhn.fhir.validation.ValidationResult;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.dstu3.hapi.ctx.IValidationSupport;
+import org.hl7.fhir.dstu3.model.CodeableConcept;
+import org.hl7.fhir.dstu3.model.Coding;
+import org.hl7.fhir.dstu3.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.dstu3.model.Questionnaire;
+import org.hl7.fhir.dstu3.model.Questionnaire.QuestionnaireItemType;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class QuestionnaireValidatorDstu3Test {
+	private static final Logger ourLog = LoggerFactory.getLogger(QuestionnaireValidatorDstu3Test.class);
+	private static DefaultProfileValidationSupport myDefaultValidationSupport = new DefaultProfileValidationSupport();
+	private static FhirContext ourCtx = FhirContext.forDstu3();
+	private FhirInstanceValidator myInstanceVal;
+	private FhirValidator myVal;
+
+	@Before
+	public void before() {
+		IValidationSupport myValSupport = mock(IValidationSupport.class);
+
+		myVal = ourCtx.newValidator();
+		myVal.setValidateAgainstStandardSchema(false);
+		myVal.setValidateAgainstStandardSchematron(false);
+
+		ValidationSupportChain validationSupport = new ValidationSupportChain(myValSupport, myDefaultValidationSupport);
+		myInstanceVal = new FhirInstanceValidator(validationSupport);
+
+		myVal.registerValidatorModule(myInstanceVal);
+	}
+
+	@Test
+	public void testQuestionnaireWithPredefinedExtensionDomainsForCoding() {
+		String[] extensionDomainsToTest = new String[] {
+			"http://example.org/questionnaire-color-control-1",
+			"https://example.org/questionnaire-color-control-2",
+			"http://acme.com/questionnaire-color-control-3",
+			"https://acme.com/questionnaire-color-control-4",
+			"http://nema.org/questionnaire-color-control-5",
+			"https://nema.org/questionnaire-color-control-6",
+			"http://hl7.org/fhir/StructureDefinition/questionnaire-scoreItem",
+			"http://hl7.org/fhir/StructureDefinition/structuredefinition-expression",
+		};
+		for (String extensionDomainToTest : extensionDomainsToTest) {
+			Questionnaire q = new Questionnaire();
+			q.setStatus(PublicationStatus.ACTIVE)
+				.addItem()
+				.setLinkId("link0")
+				.setType(QuestionnaireItemType.STRING)
+				.addExtension()
+				.setUrl(extensionDomainToTest)
+				.setValue(new Coding(null, "text-box", null));
+
+			ValidationResult errors = myVal.validateWithResult(q);
+			ourLog.info(errors.toString());
+			assertThat(errors.isSuccessful(), Matchers.is(true));
+			assertThat(errors.getMessages(), Matchers.empty());
+		}
+	}
+
+	@Test
+	public void testQuestionnaireWithPredefinedExtensionDomainsForCodeableConcept() {
+		String[] extensionDomainsToTest = new String[] {
+			"http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+		};
+		for (String extensionDomainToTest : extensionDomainsToTest) {
+			Questionnaire q = new Questionnaire();
+			q.setStatus(PublicationStatus.ACTIVE)
+				.addItem()
+				.setLinkId("link0")
+				.setType(QuestionnaireItemType.STRING)
+				.addExtension()
+				.setUrl(extensionDomainToTest)
+				.setValue(new CodeableConcept().addCoding(new Coding(null, "text-box", null)));
+
+			ValidationResult errors = myVal.validateWithResult(q);
+			ourLog.info(errors.toString());
+			assertThat(errors.isSuccessful(), Matchers.is(true));
+			assertThat(errors.getMessages(), Matchers.empty());
+		}
+	}
+
+	@Test
+	public void testQuestionnaireWithCustomExtensionDomain() {
+		Questionnaire q = new Questionnaire();
+		String extensionUrl = "http://my.own.domain/StructureDefinition/";
+		q.setStatus(PublicationStatus.ACTIVE)
+			.addItem()
+				.setLinkId("link0")
+				.setType(QuestionnaireItemType.STRING)
+				.addExtension()
+					.setUrl(extensionUrl + "questionnaire-itemControl")
+					.setValue(new Coding(null, "text-box", null));
+
+		ValidationResult errors = myVal.validateWithResult(q);
+
+		ourLog.info(errors.toString());
+		assertThat(errors.isSuccessful(), Matchers.is(true));
+		assertThat(errors.getMessages(), Matchers.hasSize(1));
+		assertEquals(errors.getMessages().get(0).getSeverity(), ResultSeverityEnum.INFORMATION);
+		assertThat(errors.getMessages().get(0).getMessage(), Matchers.startsWith("Unknown extension " + extensionUrl));
+
+		myInstanceVal.setCustomExtensionDomains(Collections.singletonList(extensionUrl));
+		errors = myVal.validateWithResult(q);
+
+		ourLog.info(errors.toString());
+		assertThat(errors.isSuccessful(), Matchers.is(true));
+		assertThat(errors.getMessages(), Matchers.empty());
+	}
+
+	@AfterClass
+	public static void afterClassClearContext() {
+		myDefaultValidationSupport.flush();
+		myDefaultValidationSupport = null;
+		TestUtil.clearAllStaticFieldsForUnitTest();
+	}
+}

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/QuestionnaireValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/QuestionnaireValidatorR4Test.java
@@ -1,0 +1,145 @@
+package org.hl7.fhir.r4.validation;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.util.TestUtil;
+import ca.uhn.fhir.validation.FhirValidator;
+import ca.uhn.fhir.validation.ResultSeverityEnum;
+import ca.uhn.fhir.validation.ValidationResult;
+
+import org.hamcrest.Matchers;
+import org.hl7.fhir.r4.hapi.ctx.DefaultProfileValidationSupport;
+import org.hl7.fhir.r4.hapi.ctx.IValidationSupport;
+import org.hl7.fhir.r4.hapi.validation.FhirInstanceValidator;
+import org.hl7.fhir.r4.hapi.validation.ValidationSupportChain;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.Enumerations.PublicationStatus;
+import org.hl7.fhir.r4.model.Narrative;
+import org.hl7.fhir.r4.model.Narrative.NarrativeStatus;
+import org.hl7.fhir.r4.model.Questionnaire;
+import org.hl7.fhir.r4.model.Questionnaire.QuestionnaireItemType;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class QuestionnaireValidatorR4Test {
+	private static final Logger ourLog = LoggerFactory.getLogger(QuestionnaireValidatorR4Test.class);
+	private static DefaultProfileValidationSupport myDefaultValidationSupport = new DefaultProfileValidationSupport();
+	private static FhirContext ourCtx = FhirContext.forR4();
+	private FhirInstanceValidator myInstanceVal;
+	private FhirValidator myVal;
+
+	@Before
+	public void before() {
+		IValidationSupport myValSupport = mock(IValidationSupport.class);
+
+		myVal = ourCtx.newValidator();
+		myVal.setValidateAgainstStandardSchema(false);
+		myVal.setValidateAgainstStandardSchematron(false);
+
+		ValidationSupportChain validationSupport = new ValidationSupportChain(myValSupport, myDefaultValidationSupport);
+		myInstanceVal = new FhirInstanceValidator(validationSupport);
+
+		myVal.registerValidatorModule(myInstanceVal);
+	}
+
+	@Test
+	public void testQuestionnaireWithPredefinedExtensionDomains() {
+		String[] extensionDomainsToTest = new String[] {
+			"http://example.org/questionnaire-color-control-1",
+			"https://example.org/questionnaire-color-control-2",
+			"http://acme.com/questionnaire-color-control-3",
+			"https://acme.com/questionnaire-color-control-4",
+			"http://nema.org/questionnaire-color-control-5",
+			"https://nema.org/questionnaire-color-control-6",
+			"http://hl7.org/fhir/StructureDefinition/questionnaire-scoreItem",
+			"http://hl7.org/fhir/StructureDefinition/structuredefinition-expression",
+
+		};
+		for (String extensionDomainToTest : extensionDomainsToTest) {
+			Questionnaire q = minimalValidQuestionnaire();
+			q.addItem()
+				.setLinkId("link0")
+				.setType(QuestionnaireItemType.STRING)
+				.addExtension()
+				.setUrl(extensionDomainToTest)
+				.setValue(new Coding(null, "text-box", null));
+
+			ValidationResult errors = myVal.validateWithResult(q);
+			ourLog.info(errors.toString());
+			assertThat(errors.isSuccessful(), Matchers.is(true));
+			assertThat(errors.getMessages(), Matchers.empty());
+		}
+	}
+
+	@Test
+	public void testQuestionnaireWithPredefinedExtensionDomainsForCodeableConcept() {
+		String[] extensionDomainsToTest = new String[] {
+			"http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+		};
+		for (String extensionDomainToTest : extensionDomainsToTest) {
+			Questionnaire q = minimalValidQuestionnaire();
+			q.addItem()
+				.setLinkId("link0")
+				.setType(QuestionnaireItemType.STRING)
+				.addExtension()
+				.setUrl(extensionDomainToTest)
+				.setValue(new CodeableConcept().addCoding(new Coding(null, "text-box", null)));
+
+			ValidationResult errors = myVal.validateWithResult(q);
+			ourLog.info(errors.toString());
+			assertThat(errors.isSuccessful(), Matchers.is(true));
+			assertThat(errors.getMessages(), Matchers.empty());
+		}
+	}
+
+	@Test
+	public void testQuestionnaireWithCustomExtensionDomain() {
+		String extensionUrl = "http://my.own.domain/StructureDefinition/";
+		Questionnaire q = minimalValidQuestionnaire();
+		q.addItem()
+			.setLinkId("link0")
+			.setType(QuestionnaireItemType.STRING)
+			.addExtension()
+			.setUrl(extensionUrl + "questionnaire-itemControl")
+			.setValue(new Coding(null, "text-box", null));
+
+		ValidationResult errors = myVal.validateWithResult(q);
+
+		ourLog.info(errors.toString());
+		assertThat(errors.isSuccessful(), Matchers.is(true));
+		assertThat(errors.getMessages(), Matchers.hasSize(1));
+		assertEquals(errors.getMessages().get(0).getSeverity(), ResultSeverityEnum.INFORMATION);
+		assertThat(errors.getMessages().get(0).getMessage(), Matchers.startsWith("Unknown extension " + extensionUrl));
+
+		myInstanceVal.setCustomExtensionDomains(extensionUrl);
+		errors = myVal.validateWithResult(q);
+
+		ourLog.info(errors.toString());
+		assertThat(errors.isSuccessful(), Matchers.is(true));
+		assertThat(errors.getMessages(), Matchers.empty());
+	}
+
+	private Questionnaire minimalValidQuestionnaire() {
+		Narrative n = new Narrative().setStatus(NarrativeStatus.GENERATED);
+		n.setDivAsString("simple example");
+		Questionnaire q = new Questionnaire();
+		q.setText(n);
+		q.setName("SomeName");
+		q.setStatus(PublicationStatus.ACTIVE);
+		return q;
+	}
+
+	@AfterClass
+	public static void afterClassClearContext() {
+		myDefaultValidationSupport.flush();
+		myDefaultValidationSupport = null;
+		TestUtil.clearAllStaticFieldsForUnitTest();
+	}
+}


### PR DESCRIPTION
Creating larger questionnaires with extension domains will currently produce lot's of information messages with regard `Unkown extensions` which might drown the more critical warnings and errors.
The `InstanceValidator` already has a data structure which is used for registering `extension domains`, but this data structure is not exposed to client code.

The first of patch for this branch add the necessary functionality for the `FhirInstanceValidator` in DSTU3 and R4 and the second patch add two tests.

The third and fourth patch are not really about this functionality and can in priniciple remove from this branch and/or moved in their own branches.
The third patch fixes and obvious bug when intialising the `FhirInstanceValidator` and the forth one tackles a variety of different less important issues.