### PR TITLE
Allows the Cache-Control Header in CORS 

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
@@ -274,6 +274,7 @@ public class Constants {
 		corsAllowedHeaders.add("Content-Type");
 		corsAllowedHeaders.add("Origin");
 		corsAllowedHeaders.add("Prefer");
+		corsAllowedHeaders.add("X-FHIR-Starter");
 		corsAllowedHeaders.add("X-Requested-With");
 		CORS_ALLOWED_HEADERS = Collections.unmodifiableSet(corsAllowedHeaders);
 

--- a/hapi-fhir-jpaserver-example/src/main/webapp/WEB-INF/web.xml
+++ b/hapi-fhir-jpaserver-example/src/main/webapp/WEB-INF/web.xml
@@ -76,7 +76,7 @@
 		<init-param>
 			<description>A comma separated list of allowed headers when making a non simple CORS request.</description>
 			<param-name>cors.allowed.headers</param-name>
-			<param-value>X-FHIR-Starter,Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers,Prefer</param-value>
+			<param-value>Accept,Access-Control-Request-Headers,Access-Control-Request-Method,Cache-Control,Content-Type,Origin,Prefer,X-FHIR-Starter,X-Requested-With</param-value>
 		</init-param>
 		<init-param>
 			<description>A comma separated list non-standard response headers that will be exposed to XHR2 object.</description>


### PR DESCRIPTION
 for jpa-example-server & hapi CLI.
Useful if you have JS app which wants to receive live results.