### PR TITLE
Support parsing a QuestionnaireResponse's answer.valueReference

### DIFF
--- a/hapi-fhir-structures-hl7org-dstu2/src/main/java/org/hl7/fhir/instance/model/QuestionnaireResponse.java
+++ b/hapi-fhir-structures-hl7org-dstu2/src/main/java/org/hl7/fhir/instance/model/QuestionnaireResponse.java
@@ -831,7 +831,7 @@ public class QuestionnaireResponse extends DomainResource {
         /**
          * The answer (or one of the answers) provided by the respondent to the question.
          */
-        @Child(name = "value", type = {BooleanType.class, DecimalType.class, IntegerType.class, DateType.class, DateTimeType.class, InstantType.class, TimeType.class, StringType.class, UriType.class, Attachment.class, Coding.class, Quantity.class}, order=1, min=0, max=1, modifier=false, summary=false)
+        @Child(name = "value", type = {BooleanType.class, DecimalType.class, IntegerType.class, DateType.class, DateTimeType.class, InstantType.class, TimeType.class, StringType.class, UriType.class, Attachment.class, Coding.class, Quantity.class, Reference.class}, order=1, min=0, max=1, modifier=false, summary=false)
         @Description(shortDefinition="Single-valued answer to the question", formalDefinition="The answer (or one of the answers) provided by the respondent to the question." )
         protected Type value;
 

--- a/hapi-fhir-structures-hl7org-dstu2/src/test/java/ca/uhn/fhir/parser/JsonParserHl7OrgDstu2Test.java
+++ b/hapi-fhir-structures-hl7org-dstu2/src/test/java/ca/uhn/fhir/parser/JsonParserHl7OrgDstu2Test.java
@@ -12,6 +12,7 @@ import org.apache.commons.io.IOUtils;
 import org.hamcrest.core.IsNot;
 import org.hamcrest.core.StringContains;
 import org.hamcrest.text.StringContainsInOrder;
+import org.hl7.fhir.exceptions.FHIRException;
 import org.hl7.fhir.instance.model.*;
 import org.hl7.fhir.instance.model.Address.AddressUse;
 import org.hl7.fhir.instance.model.Address.AddressUseEnumFactory;
@@ -20,6 +21,7 @@ import org.hl7.fhir.instance.model.Conformance.UnknownContentCode;
 import org.hl7.fhir.instance.model.Identifier.IdentifierUse;
 import org.hl7.fhir.instance.model.Narrative.NarrativeStatus;
 import org.hl7.fhir.instance.model.Patient.ContactComponent;
+import org.hl7.fhir.instance.model.QuestionnaireResponse.QuestionAnswerComponent;
 import org.hl7.fhir.instance.model.ValueSet.ConceptDefinitionComponent;
 import org.hl7.fhir.instance.model.ValueSet.ValueSetCodeSystemComponent;
 import org.hl7.fhir.instance.model.api.IBaseResource;
@@ -1260,6 +1262,17 @@ public class JsonParserHl7OrgDstu2Test {
 		Assert.assertEquals(1, extlst.size());
 		Assert.assertEquals(refVal, ((Reference) extlst.get(0).getValue()).getReference());
 	}
+
+  @Test
+  public void testParseQuestionnaireResponseAnswerWithValueReference() throws FHIRException {
+    String response = "{\"resourceType\":\"QuestionnaireResponse\",\"group\":{\"question\":[{\"answer\": [{\"valueReference\": {\"reference\": \"Observation/testid\"}}]}]}}";
+    QuestionnaireResponse r = ourCtx.newJsonParser().parseResource(QuestionnaireResponse.class, response);
+
+    QuestionAnswerComponent answer = r.getGroup().getQuestion().get(0).getAnswer().get(0);
+    assertNotNull(answer);
+    assertNotNull(answer.getValueReference());
+    assertEquals("Observation/testid", answer.getValueReference().getReference());
+  }
 
   @ResourceDef(name = "Patient")
   public static class MyPatientWithOneDeclaredAddressExtension extends Patient {


### PR DESCRIPTION
This addresses bug #979, and adds a test for it.