### PR TITLE
avoid potential short circuit during saveDeferred processing of uploaded (e.g. LOINC) terminology

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseHapiTerminologySvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/BaseHapiTerminologySvcImpl.java
@@ -850,15 +850,16 @@ public abstract class BaseHapiTerminologySvcImpl implements IHapiTerminologySvc,
 			return;
 		} else if (myDeferredConcepts.isEmpty() && myConceptLinksToSaveLater.isEmpty()) {
 			processReindexing();
-			return;
 		}
 
 		TransactionTemplate tt = new TransactionTemplate(myTransactionMgr);
 		tt.setPropagationBehavior(TransactionTemplate.PROPAGATION_REQUIRES_NEW);
-		tt.execute(t -> {
-			processDeferredConcepts();
-			return null;
-		});
+		if(!myDeferredConcepts.isEmpty() || !myConceptLinksToSaveLater.isEmpty()) {
+			tt.execute(t -> {
+				processDeferredConcepts();
+				return null;
+			});
+		}
 
 		if (myDeferredValueSets.size() > 0) {
 			tt.execute(t -> {


### PR DESCRIPTION
The BaseHapiTerminologySvcImpl saveDeferred method's early return when myDeferredConcepts and myConceptLinksToSaveLater are both empty has the potential to cause some value sets and concept maps to not be saved.

Prior to making the change illustrated by this PR, testing of upload-terminology for LOINC 2.64 indicated 270 deferred ValueSet resources were not saved.  Some of the not-saved value sets were:  LL736-0, LL999-4, loinc-document-ontology, top-2000-lab-observations-us, and loinc-universal-order-set-vs.