### PR TITLE
Publish the jpaserver-example

### DIFF
--- a/hapi-fhir-jpaserver-example/pom.xml
+++ b/hapi-fhir-jpaserver-example/pom.xml
@@ -260,15 +260,6 @@
 				</configuration>
 			</plugin>
 
-			<!-- This plugin is just a part of the HAPI internal build process, you do not need to incude it in your own projects -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<configuration>
-					<skip>true</skip>
-				</configuration>
-			</plugin>
-
 			<!-- This is to run the integration tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/hapi-fhir-jpaserver-example/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfig.java
+++ b/hapi-fhir-jpaserver-example/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfig.java
@@ -8,11 +8,11 @@ import javax.sql.DataSource;
 import ca.uhn.fhir.jpa.search.LuceneSearchMappingFactory;
 import ca.uhn.fhir.jpa.util.DerbyTenSevenHapiFhirDialect;
 import org.apache.commons.dbcp2.BasicDataSource;
-import org.apache.commons.lang3.time.DateUtils;
-import org.hibernate.jpa.HibernatePersistenceProvider;
 import org.springframework.beans.factory.annotation.Autowire;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -28,8 +28,12 @@ import ca.uhn.fhir.rest.server.interceptor.ResponseHighlighterInterceptor;
  * This is the primary configuration file for the example server
  */
 @Configuration
+@PropertySource("classpath:server-config.properties")
 @EnableTransactionManagement()
 public class FhirServerConfig extends BaseJavaConfigDstu3 {
+
+	@Value("${cache.timeout}")
+	Long cacheTimeout;
 
 	/**
 	 * Configure FHIR properties around the the JPA server via this bean
@@ -38,6 +42,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	public DaoConfig daoConfig() {
 		DaoConfig retVal = new DaoConfig();
 		retVal.setAllowMultipleDelete(true);
+		retVal.setReuseCachedSearchResultsForMillis(cacheTimeout);
 		return retVal;
 	}
 

--- a/hapi-fhir-jpaserver-example/src/main/resources/server-config.properties
+++ b/hapi-fhir-jpaserver-example/src/main/resources/server-config.properties
@@ -1,0 +1,1 @@
+cache.timeout=60000


### PR DESCRIPTION
Solves https://github.com/jamesagnew/hapi-fhir/issues/948

I think it would be nice to publish the jpaserver-example to allow third party projects to easily spin up a FHIR Server as part of their integration tests.

I also externalized the caching timeout which is currently hard coded to 60s (I like to disable caching during my tests, even though it's possible to add the `Cache-Control: no-cache` HTTP header to every request).

Thanks!