### PR TITLE
Fix NullPointerExceptions in DateRangeRaram

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
@@ -256,7 +256,7 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 	}
 
 	public Date getLowerBoundAsInstant() {
-		if (myLowerBound == null) {
+		if (myLowerBound == null || myLowerBound.getValue() == null) {
 			return null;
 		}
 		Date retVal = myLowerBound.getValue();
@@ -303,7 +303,7 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 	}
 
 	public Date getUpperBoundAsInstant() {
-		if (myUpperBound == null) {
+		if (myUpperBound == null || myUpperBound.getValue() == null) {
 			return null;
 		}
 		Date retVal = myUpperBound.getValue();

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
@@ -1,0 +1,67 @@
+package ca.uhn.fhir.rest.param;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.QualifiedParamList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class DateRangeParamTest {
+	private FhirContext fhirContext;
+
+	@Before
+	public void initMockContext() {
+		fhirContext = Mockito.mock(FhirContext.class);
+	}
+
+	/** Can happen e.g. when the query parameter for {@code _lastUpdated} is left empty. */
+	@Test
+	public void testParamWithoutPrefixAndWithoutValue() {
+		QualifiedParamList qualifiedParamList = new QualifiedParamList(1);
+		qualifiedParamList.add("");
+
+		List<QualifiedParamList> params = new ArrayList<>(1);
+		params.add(qualifiedParamList);
+		DateRangeParam dateRangeParam = new DateRangeParam();
+		dateRangeParam.setValuesAsQueryTokens(fhirContext, "_lastUpdated", params);
+
+		assertTrue(dateRangeParam.isEmpty());
+	}
+
+	/** Can happen e.g. when the query parameter for {@code _lastUpdated} is given as {@code lt} without any value. */
+	@Test
+	public void testUpperBoundWithPrefixWithoutValue() {
+		QualifiedParamList qualifiedParamList = new QualifiedParamList(1);
+		qualifiedParamList.add("lt");
+
+		List<QualifiedParamList> params = new ArrayList<>(1);
+		params.add(qualifiedParamList);
+		DateRangeParam dateRangeParam = new DateRangeParam();
+		dateRangeParam.setValuesAsQueryTokens(fhirContext, "_lastUpdated", params);
+
+		assertTrue(dateRangeParam.isEmpty());
+	}
+
+	/** Can happen e.g. when the query parameter for {@code _lastUpdated} is given as {@code gt} without any value. */
+	@Test
+	public void testLowerBoundWithPrefixWithoutValue() {
+		QualifiedParamList qualifiedParamList = new QualifiedParamList(1);
+		qualifiedParamList.add("gt");
+
+		List<QualifiedParamList> params = new ArrayList<>(1);
+		params.add(qualifiedParamList);
+		DateRangeParam dateRangeParam = new DateRangeParam();
+		dateRangeParam.setValuesAsQueryTokens(fhirContext, "_lastUpdated", params);
+
+		assertTrue(dateRangeParam.isEmpty());
+	}
+}


### PR DESCRIPTION
There a possible `NullPointerExceptions` in the `DateRangeParam` class which can be triggered e.g. when a search query for `_lastUpdated` is not properly filled (examples include `"", "lt", "gt"`).
The patch consits of two commits. The first adds adds junits tests which demonstrate the problem.
The second commit proposes a solution.