### PR TITLE
head operation should return 200OK response code instead of 400 BadRequest

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
@@ -23,25 +23,35 @@ package ca.uhn.fhir.rest.server.method;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
-import org.hl7.fhir.instance.model.api.*;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
 
 import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.api.IResource;
 import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
-import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.model.primitive.InstantDt;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
-import ca.uhn.fhir.rest.annotation.*;
-import ca.uhn.fhir.rest.api.*;
-import ca.uhn.fhir.rest.api.server.*;
+import ca.uhn.fhir.rest.annotation.Elements;
+import ca.uhn.fhir.rest.annotation.IdParam;
+import ca.uhn.fhir.rest.annotation.Read;
+import ca.uhn.fhir.rest.api.Constants;
+import ca.uhn.fhir.rest.api.RequestTypeEnum;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.api.server.IRestfulServer;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.param.ParameterUtil;
 import ca.uhn.fhir.rest.server.ETagSupportEnum;
-import ca.uhn.fhir.rest.server.exceptions.*;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
+import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
+import ca.uhn.fhir.rest.server.exceptions.NotModifiedException;
 import ca.uhn.fhir.util.DateUtils;
 
 public class ReadMethodBinding extends BaseResourceReturningMethodBinding {
@@ -122,8 +132,8 @@ public class ReadMethodBinding extends BaseResourceReturningMethodBinding {
 		if (isNotBlank(theRequest.getCompartmentName())) {
 			return false;
 		}
-		if (theRequest.getRequestType() != RequestTypeEnum.GET) {
-			ourLog.trace("Method {} doesn't match because request type is not GET: {}", theRequest.getId(), theRequest.getRequestType());
+		if (theRequest.getRequestType() != RequestTypeEnum.GET && theRequest.getRequestType() != RequestTypeEnum.HEAD ) {
+			ourLog.trace("Method {} doesn't match because request type is not GET or HEAD: {}", theRequest.getId(), theRequest.getRequestType());
 			return false;
 		}
 		if (Constants.PARAM_HISTORY.equals(theRequest.getOperation())) {

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/ServerFeaturesDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/rest/server/ServerFeaturesDstu2Test.java
@@ -132,7 +132,7 @@ public class ServerFeaturesDstu2Test {
 
 		ourLog.info(status.toString());
 		
-		assertEquals(400, status.getStatusLine().getStatusCode());
+		assertEquals(200, status.getStatusLine().getStatusCode());
 		assertThat(status.getFirstHeader("x-powered-by").getValue(), containsString("HAPI"));
 	}
 

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/interceptor/BanUnsupprtedHttpMethodsInterceptorDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/interceptor/BanUnsupprtedHttpMethodsInterceptorDstu3Test.java
@@ -54,19 +54,6 @@ public class BanUnsupprtedHttpMethodsInterceptorDstu3Test {
 			IOUtils.closeQuietly(status.getEntity().getContent());
 		}
 	}
-
-	@Test
-	public void testHeadJson() throws Exception {
-		HttpHead httpGet = new HttpHead("http://localhost:" + ourPort + "/Patient/123");
-		HttpResponse status = ourClient.execute(httpGet);
-		assertEquals(null, status.getEntity());
-
-		ourLog.info(status.toString());
-		
-		assertEquals(400, status.getStatusLine().getStatusCode());
-		assertThat(status.getFirstHeader("x-powered-by").getValue(), containsString("HAPI"));
-	}
-
 	
 	@Test
 	public void testHttpTrackNotEnabled() throws Exception {

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/interceptor/BanUnsupprtedHttpMethodsInterceptorDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/interceptor/BanUnsupprtedHttpMethodsInterceptorDstu3Test.java
@@ -55,6 +55,28 @@ public class BanUnsupprtedHttpMethodsInterceptorDstu3Test {
 		}
 	}
 	
+	@Test	
+	public void testHeadJsonWithInvalidPatient() throws Exception {	
+		HttpHead httpGet = new HttpHead("http://localhost:" + ourPort + "/Patient/123");	
+		HttpResponse status = ourClient.execute(httpGet);	
+		assertEquals(null, status.getEntity());	
+ 		ourLog.info(status.toString());	
+			
+		assertEquals(404, status.getStatusLine().getStatusCode());	
+		assertThat(status.getFirstHeader("x-powered-by").getValue(), containsString("HAPI"));	
+	}
+	
+	@Test	
+	public void testHeadJsonWithValidPatient() throws Exception {	
+		HttpHead httpGet = new HttpHead("http://localhost:" + ourPort + "/Patient/1");	
+		HttpResponse status = ourClient.execute(httpGet);	
+		assertEquals(null, status.getEntity());	
+ 		ourLog.info(status.toString());	
+			
+		assertEquals(200, status.getStatusLine().getStatusCode());	
+		assertThat(status.getFirstHeader("x-powered-by").getValue(), containsString("HAPI"));	
+	}
+	
 	@Test
 	public void testHttpTrackNotEnabled() throws Exception {
 		HttpRequestBase req = new HttpRequestBase() {


### PR DESCRIPTION
Hello,

Based on the FHIR specifications (http://hl7.org/fhir/2018May/http.html#head) :

"Anywhere that a GET request can be used, a HEAD request is also allowed. HEAD requests are treated as specified in HTTP: same response as a GET, but with no body."

Right now, the head operation returns 400 Bad Request with no body and it should return the code 200 OK (same as for a normal GET). 

The head operation works as excepted only for _history operations.