### PR TITLE
Issue 430: Generate OperationDefinitions for named queries, fix minor…

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseMethodBinding.java
@@ -446,8 +446,7 @@ public abstract class BaseMethodBinding<T> {
 
 		if (returnTypeFromRp != null) {
 			if (returnTypeFromAnnotation != null && !isResourceInterface(returnTypeFromAnnotation)) {
-				if (!returnTypeFromRp.isAssignableFrom(returnTypeFromAnnotation)) {
-					//FIXME potential null access on retunrTypeFromMethod
+				if (returnTypeFromMethod != null && !returnTypeFromRp.isAssignableFrom(returnTypeFromMethod)) {
 					throw new ConfigurationException("Method '" + theMethod.getName() + "' in type " + theMethod.getDeclaringClass().getCanonicalName() + " returns type "
 							+ returnTypeFromMethod.getCanonicalName() + " - Must return " + returnTypeFromRp.getCanonicalName() + " (or a subclass of it) per IResourceProvider contract");
 				}
@@ -475,7 +474,7 @@ public abstract class BaseMethodBinding<T> {
 		if (read != null) {
 			return new ReadMethodBinding(returnType, theMethod, theContext, theProvider);
 		} else if (search != null) {
-			return new SearchMethodBinding(returnType, theMethod, theContext, theProvider);
+			return new SearchMethodBinding(returnType, returnTypeFromRp, theMethod, theContext, theProvider);
 		} else if (conformance != null) {
 			return new ConformanceMethodBinding(theMethod, theContext, theProvider);
 		} else if (create != null) {

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/BaseResourceReturningMethodBinding.java
@@ -77,7 +77,6 @@ public abstract class BaseResourceReturningMethodBinding extends BaseMethodBindi
 
 	private MethodReturnTypeEnum myMethodReturnType;
 	private String myResourceName;
-	private Class<? extends IBaseResource> myResourceType;
 
 	@SuppressWarnings("unchecked")
 	public BaseResourceReturningMethodBinding(Class<?> theReturnResourceType, Method theMethod, FhirContext theContext, Object theProvider) {
@@ -115,8 +114,8 @@ public abstract class BaseResourceReturningMethodBinding extends BaseMethodBindi
 				if (Modifier.isAbstract(theReturnResourceType.getModifiers()) || Modifier.isInterface(theReturnResourceType.getModifiers())) {
 					// If we're returning an abstract type, that's ok
 				} else {
-					myResourceType = (Class<? extends IResource>) theReturnResourceType;
-					myResourceName = theContext.getResourceDefinition(myResourceType).getName();
+          Class<? extends IResource> methodReturnTypeResourceType = (Class<? extends IResource>) theReturnResourceType;
+					myResourceName = theContext.getResourceDefinition(methodReturnTypeResourceType).getName();
 				}
 			}
 		}
@@ -369,7 +368,7 @@ public abstract class BaseResourceReturningMethodBinding extends BaseMethodBindi
 	/**
 	 * If the response is a bundle, this type will be placed in the root of the bundle (can be null)
 	 */
-	protected abstract BundleTypeEnum getResponseBundleType();
+  protected abstract BundleTypeEnum getResponseBundleType();
 
 	public abstract ReturnTypeEnum getReturnType();
 

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
@@ -33,7 +33,6 @@ import ca.uhn.fhir.context.ConfigurationException;
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.model.api.IResource;
 import ca.uhn.fhir.model.api.ResourceMetadataKeyEnum;
-import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.model.primitive.InstantDt;
 import ca.uhn.fhir.model.valueset.BundleTypeEnum;
 import ca.uhn.fhir.rest.annotation.*;

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/SearchMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/SearchMethodBinding.java
@@ -55,8 +55,9 @@ public class SearchMethodBinding extends BaseResourceReturningMethodBinding {
 	private Integer myIdParamIndex;
 	private String myQueryName;
 	private boolean myAllowUnknownParams;
+  private final String myResourceProviderResourceName;
 
-	public SearchMethodBinding(Class<? extends IBaseResource> theReturnResourceType, Method theMethod, FhirContext theContext, Object theProvider) {
+	public SearchMethodBinding(Class<? extends IBaseResource> theReturnResourceType, Class<? extends IBaseResource> theResourceProviderResourceType, Method theMethod, FhirContext theContext, Object theProvider) {
 		super(theReturnResourceType, theMethod, theContext, theProvider);
 		Search search = theMethod.getAnnotation(Search.class);
 		this.myQueryName = StringUtils.defaultIfBlank(search.queryName(), null);
@@ -101,12 +102,26 @@ public class SearchMethodBinding extends BaseResourceReturningMethodBinding {
 			String msg = theContext.getLocalizer().getMessage(getClass().getName() + ".idWithoutCompartment", theMethod.getName(), theMethod.getDeclaringClass());
 			throw new ConfigurationException(msg);
 		}
+    
+    if (theResourceProviderResourceType != null) {
+      this.myResourceProviderResourceName = theContext.getResourceDefinition(theResourceProviderResourceType).getName();
+    } else {
+      this.myResourceProviderResourceName = null;
+    }
 
 	}
 
 	public String getDescription() {
 		return myDescription;
 	}
+
+	public String getQueryName() {
+		return myQueryName;
+	}
+
+  public String getResourceProviderResourceName() {
+    return myResourceProviderResourceName;
+  }
 
 	@Override
 	public RestOperationTypeEnum getRestOperationType() {


### PR DESCRIPTION
… errors in generation of OperationDefinition for operations. Closes #430.

See https://github.com/jamesagnew/hapi-fhir/issues/430

This fixes the following issues:
* Generate OperationDefinition for named queries. Added tests for queries at type level and at server level.
* Fix potential NPE in BaseMethodBinding when the method return type is a raw typed collection.
* When an operation appears at system level with no IdType parameter, the generated definition specified that the operation could be invoked at both system and type level. 