### PR TITLE
Allow slotting in own IMessageResolver

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative/BaseThymeleafNarrativeGenerator.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative/BaseThymeleafNarrativeGenerator.java
@@ -34,6 +34,7 @@ import org.thymeleaf.cache.ICacheEntryValidity;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.context.ITemplateContext;
 import org.thymeleaf.engine.AttributeName;
+import org.thymeleaf.messageresolver.IMessageResolver;
 import org.thymeleaf.model.IProcessableElementTag;
 import org.thymeleaf.processor.IProcessor;
 import org.thymeleaf.processor.element.AbstractAttributeTagProcessor;
@@ -64,6 +65,8 @@ public abstract class BaseThymeleafNarrativeGenerator implements INarrativeGener
 	private volatile boolean myInitialized;
 	private HashMap<String, String> myNameToNarrativeTemplate;
 	private TemplateEngine myProfileTemplateEngine;
+
+	private IMessageResolver resolver;
 
 	/**
 	 * Constructor
@@ -166,9 +169,19 @@ public abstract class BaseThymeleafNarrativeGenerator implements INarrativeGener
 
 			};
 			myProfileTemplateEngine.setDialect(dialect);
+			if (this.resolver != null) {
+				myProfileTemplateEngine.setMessageResolver(this.resolver);
+			}
 		}
 
 		myInitialized = true;
+	}
+
+	public void setMessageResolver(IMessageResolver resolver) {
+		this.resolver = resolver;
+		if (myProfileTemplateEngine != null && resolver != null) {
+			myProfileTemplateEngine.setMessageResolver(resolver);
+		}
 	}
 
 	/**

--- a/hapi-fhir-structures-dstu3/src/test/resources/TestPatient.html
+++ b/hapi-fhir-structures-dstu3/src/test/resources/TestPatient.html
@@ -1,0 +1,4 @@
+<div>
+  <p th:text="#{some_text}">Some Text</p>
+  <p th:text="#{other_text}">Some Text</p>
+</div>

--- a/hapi-fhir-structures-dstu3/src/test/resources/testnarrative.properties
+++ b/hapi-fhir-structures-dstu3/src/test/resources/testnarrative.properties
@@ -1,0 +1,2 @@
+patient.class=org.hl7.fhir.dstu3.model.Patient
+patient.narrative=classpath:/TestPatient.html


### PR DESCRIPTION
This is useful in case we want to define our own way of translating
the codes in the thymeleaf templates.

(Note see also https://github.com/jamesagnew/hapi-fhir/pull/876, where you asked for a unit test. This commit is the same as that one, but includes the unit test, and rebased to the master branch. So that other pull request is no longer necessary.)