### PR TITLE
Fixed small log formatting error in ExceptionHandlingInterceptor.java

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/ExceptionHandlingInterceptor.java
@@ -140,7 +140,7 @@ public class ExceptionHandlingInterceptor extends InterceptorAdapter {
 					if (statusCode < 500) {
 						ourLog.warn("Failure during REST processing: {}", theException.toString());
 					} else {
-						ourLog.warn("Failure during REST processing: {}", theException);
+						ourLog.warn("Failure during REST processing", theException);
 					}
 					
 					BaseServerResponseException baseServerResponseException = (BaseServerResponseException) theException;


### PR DESCRIPTION
Hi,

Came across this small log formatting error in ExceptionHandlingInterceptor.java, and thought it should be fixed.

(formatting anchor is not needed when logging a throwable) 