### PR TITLE
Implemented graphql reference lookup

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/graphql/JpaStorageServices.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/graphql/JpaStorageServices.java
@@ -126,7 +126,11 @@ public class JpaStorageServices extends BaseHapiFhirDao<IBaseResource> implement
 
 	@Override
 	public ReferenceResolution lookup(Object appInfo, Resource context, Reference reference) throws FHIRException {
-		return null;
+		IIdType refId = getContext().getVersion().newIdType();
+		refId.setValue(reference.getReference());
+		IFhirResourceDao<? extends IBaseResource> dao = getDao(refId.getResourceType());
+		BaseHasResource id = dao.readEntity(refId);
+		return new ReferenceResolution(context, (Resource) toResource(id, false));
 	}
 
 	@Transactional(propagation = Propagation.NEVER)

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/graphql/JpaStorageServicesTest.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/graphql/JpaStorageServicesTest.java
@@ -1,0 +1,44 @@
+package ca.uhn.fhir.jpa.graphql;
+
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.hl7.fhir.r4.model.Patient;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.utils.GraphQLEngine.IGraphQLStorageServices;
+import org.hl7.fhir.r4.utils.GraphQLEngine.IGraphQLStorageServices.ReferenceResolution;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import ca.uhn.fhir.jpa.provider.r4.BaseResourceProviderR4Test;
+
+public class JpaStorageServicesTest extends BaseResourceProviderR4Test {
+	private IIdType myPatientId;
+
+	@Override
+	@Before
+	public void before() throws Exception {
+		super.before();
+
+		Patient p = new Patient();
+		p.setId("PT-ONEVERSION");
+		p.addName().setFamily("FAM");
+		myPatientId = myPatientDao.update(p).getId().toVersionless();
+	}
+	
+	public IGraphQLStorageServices storageServices() {
+		return this.myAppCtx.getBean(IGraphQLStorageServices.class);
+	}
+	
+	@Test
+	public void testLookupById() {
+		Patient result = (Patient) storageServices().lookup(null, myPatientId.getResourceType(), myPatientId.getIdPart());
+		Assert.assertNotNull(result);
+		Assert.assertEquals("FAM", result.getName().get(0).getFamily());
+	}
+
+	@Test
+	public void testLookupByReference() {
+		ReferenceResolution result = storageServices().lookup(null, null, new Reference(myPatientId));
+		Assert.assertNotNull(result);
+	}
+}


### PR DESCRIPTION
In my efforts to enable GraphQL in `hapi-fhir-jpaserver-example` I found that this method needed an implementation.

For example, you can start with an "Observation" entity, following the "subject" (patient) reference to get the patient's birth date.

http://localhost:8080/hapi-fhir-jpaserver-example/baseR4/Observation/2/$graphql?query={status%20subject{resource{birthDate}}}

```
{
  "status":"registered",
  "subject":{
    "resource":{
      "birthDate":"1924-10-10"
    }
  }
}
```

I'm new to this project, so I apologize for any stylistic oversights.  Feedback welcome.