### PR TITLE
issue-1128: update versions in dependencies so that mvn clean package…

### DIFF
--- a/hapi-fhir-tutorial/simple-server/pom.xml
+++ b/hapi-fhir-tutorial/simple-server/pom.xml
@@ -14,7 +14,7 @@
 	
 	<groupId>ca.uhn.hapi.example</groupId>
 	<artifactId>hapi-fhir-example-simple-server</artifactId>
-	<version>0.7</version>
+	<version>0.8</version>
 	<packaging>war</packaging>
 
 	<name>HAPI FHIR Example - Simple Server</name>
@@ -35,12 +35,12 @@
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-base</artifactId>
-			<version>1.2-SNAPSHOT</version>
+			<version>1.6</version>
 		</dependency>
 		<dependency>
 			<groupId>ca.uhn.hapi.fhir</groupId>
 			<artifactId>hapi-fhir-structures-dstu</artifactId>
-			<version>1.2-SNAPSHOT</version>
+			<version>1.6</version>
 		</dependency>
 
 		<!-- 


### PR DESCRIPTION
# About
Fix #1128 by updating the POM so that the test server can be run.

# Test Steps
1. `cd hapi-fhir-tutorial/simple-server/`
2. `mvn clean package` now works
3. `mvn jetty:run` launches the test server
4. Open browser and goto http://localhost:8080/example04 creates a patient
5. Open browser and goto http://localhost:8080/example04/Patient/1 will fetch the Patient Resource and download it.

