### PR TITLE
Fix #1096 : allow primitive values in castToInstant()

### DIFF
--- a/hapi-fhir-structures-dstu2.1/src/main/java/org/hl7/fhir/dstu2016may/model/Base.java
+++ b/hapi-fhir-structures-dstu2.1/src/main/java/org/hl7/fhir/dstu2016may/model/Base.java
@@ -270,6 +270,8 @@ private Map<String, Object> userData;
 	public InstantType castToInstant(Base b) throws FHIRException {
 		if (b instanceof InstantType)
 			return (InstantType) b;
+	  else if (b.hasPrimitiveValue())
+			return new InstantType(b.primitiveValue());
 		else
 			throw new FHIRException("Unable to convert a "+b.getClass().getName()+" to a Instant");
 	}

--- a/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/model/Base.java
+++ b/hapi-fhir-structures-dstu3/src/main/java/org/hl7/fhir/dstu3/model/Base.java
@@ -305,6 +305,8 @@ private Map<String, Object> userData;
 	public InstantType castToInstant(Base b) throws FHIRException {
 		if (b instanceof InstantType)
 			return (InstantType) b;
+      else if (b.hasPrimitiveValue())
+          return new InstantType(b.primitiveValue());
 		else
 			throw new FHIRException("Unable to convert a "+b.getClass().getName()+" to a Instant");
 	}

--- a/hapi-fhir-structures-r4/src/main/java/org/hl7/fhir/r4/model/Base.java
+++ b/hapi-fhir-structures-r4/src/main/java/org/hl7/fhir/r4/model/Base.java
@@ -318,6 +318,8 @@ private Map<String, Object> userData;
 	public InstantType castToInstant(Base b) throws FHIRException {
 		if (b instanceof InstantType)
 			return (InstantType) b;
+      else if (b.hasPrimitiveValue())
+          return new InstantType(b.primitiveValue());
 		else
 			throw new FHIRException("Unable to convert a "+b.getClass().getName()+" to a Instant");
 	}


### PR DESCRIPTION
Fix #1096 