### PR TITLE
Allow to set additional Http headers directly on the IClientExecutable

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IClientExecutable.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/gclient/IClientExecutable.java
@@ -89,6 +89,21 @@ public interface IClientExecutable<T extends IClientExecutable<?, Y>, Y> {
 	T encodedXml();
 
 	/**
+	 * Set a HTTP header not explicitly defined in FHIR but commonly used in real-world scenarios. One
+	 * important example is to set the Authorization header (e.g. Basic Auth or OAuth2-based Bearer auth),
+	 * which tends to be cumbersome using {@link ca.uhn.fhir.rest.client.api.IClientInterceptor IClientInterceptors},
+	 * particularly when REST clients shall be reused and are thus supposed to remain stateless.
+	 * <p>It is the responsibility of the caller to care for proper encoding of the header value, e.g.
+	 * using Base64.</p>
+	 * <p>This is a short-cut alternative to using a corresponding client interceptor</p>
+	 *
+	 * @param theHeaderName header name
+	 * @param theHeaderValue header value
+	 * @return
+	 */
+	T withAdditionalHeader(String theHeaderName, String theHeaderValue);
+
+	/**
 	 * Actually execute the client operation
 	 */
 	Y execute();

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -118,7 +118,7 @@ public abstract class BaseClient implements IRestfulClient {
 	public <T extends IBaseResource> T fetchResourceFromUrl(Class<T> theResourceType, String theUrl) {
 		BaseHttpClientInvocation clientInvocation = new HttpGetClientInvocation(getFhirContext(), theUrl);
 		ResourceResponseHandler<T> binding = new ResourceResponseHandler<T>(theResourceType);
-		return invokeClient(getFhirContext(), binding, clientInvocation, null, false, false, null, null, null, null);
+		return invokeClient(getFhirContext(), binding, clientInvocation, null, false, false, null, null, null, null, null);
 	}
 
 	void forceConformanceCheck() {
@@ -203,11 +203,12 @@ public abstract class BaseClient implements IRestfulClient {
 	}
 
 	<T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation, boolean theLogRequestAndResponse) {
-		return invokeClient(theContext, binding, clientInvocation, null, null, theLogRequestAndResponse, null, null, null, null);
+		return invokeClient(theContext, binding, clientInvocation, null, null, theLogRequestAndResponse, null, null, null, null, null);
 	}
 
 	<T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation, EncodingEnum theEncoding, Boolean thePrettyPrint,
-							 boolean theLogRequestAndResponse, SummaryEnum theSummaryMode, Set<String> theSubsetElements, CacheControlDirective theCacheControlDirective, String theCustomAcceptHeader) {
+							 boolean theLogRequestAndResponse, SummaryEnum theSummaryMode, Set<String> theSubsetElements, CacheControlDirective theCacheControlDirective, String theCustomAcceptHeader,
+							 Map<String, List<String>> theCustomHeaders) {
 
 		if (!myDontValidateConformance) {
 			myFactory.validateServerBaseIfConfiguredToDoSo(myUrlBase, myClient, this);
@@ -265,6 +266,14 @@ public abstract class BaseClient implements IRestfulClient {
 				}
 				if (b.length() > 0) {
 					httpRequest.addHeader(Constants.HEADER_CACHE_CONTROL, b.toString());
+				}
+			}
+
+			if (theCustomHeaders != null) {
+				for (Map.Entry<String, List<String>> customHeader: theCustomHeaders.entrySet()) {
+					for (String value: customHeader.getValue()) {
+						httpRequest.addHeader(customHeader.getKey(), value);
+					}
 				}
 			}
 

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/AdditionalRequestHeadersInterceptor.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/AdditionalRequestHeadersInterceptor.java
@@ -33,12 +33,15 @@ import java.util.Objects;
 
 /**
  * This interceptor adds arbitrary header values to requests made by the client.
+ *
+ * This is now also possible directly on the Fluent Client API by calling
+ * {@link ca.uhn.fhir.rest.gclient.IClientExecutable#withAdditionalHeader(String, String)}
  */
 public class AdditionalRequestHeadersInterceptor implements IClientInterceptor {
 	private final Map<String, List<String>> additionalHttpHeaders = new HashMap<>();
 
 	public AdditionalRequestHeadersInterceptor() {
-		this(new HashMap<String, List<String>>());
+		this(new HashMap<>());
 	}
 
 	public AdditionalRequestHeadersInterceptor(Map<String, List<String>> additionalHttpHeaders) {
@@ -84,7 +87,7 @@ public class AdditionalRequestHeadersInterceptor implements IClientInterceptor {
 	 */
 	private List<String> getHeaderValues(String headerName) {
 		if (additionalHttpHeaders.get(headerName) == null) {
-			additionalHttpHeaders.put(headerName, new ArrayList<String>());
+			additionalHttpHeaders.put(headerName, new ArrayList<>());
 		}
 		return additionalHttpHeaders.get(headerName);
 	}


### PR DESCRIPTION
I'd like to propose an extension to the IClientExecutable interface that allows to set arbitrary HTTP headers. This is an alternative to using AdditionalRequestHeadersInterceptor, with one important difference: it makes the client stateless so it can even be reused with header values like OAuth2 tokens that change with every request. 
And I think it's simply more straightforward to use.