### PR TITLE
Subscription startup side-effects

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/BaseConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/BaseConfig.java
@@ -8,6 +8,8 @@ import ca.uhn.fhir.jpa.search.IStaleSearchDeletingSvc;
 import ca.uhn.fhir.jpa.search.StaleSearchDeletingSvcImpl;
 import ca.uhn.fhir.jpa.search.reindex.IResourceReindexingSvc;
 import ca.uhn.fhir.jpa.search.reindex.ResourceReindexingSvcImpl;
+import ca.uhn.fhir.jpa.subscription.ISubscriptionTriggeringSvc;
+import ca.uhn.fhir.jpa.subscription.SubscriptionTriggeringSvcImpl;
 import ca.uhn.fhir.jpa.subscription.dbmatcher.CompositeInMemoryDaoSubscriptionMatcher;
 import ca.uhn.fhir.jpa.subscription.dbmatcher.DaoSubscriptionMatcher;
 import ca.uhn.fhir.jpa.subscription.module.cache.ISubscribableChannelFactory;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/BaseConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/config/BaseConfig.java
@@ -8,8 +8,6 @@ import ca.uhn.fhir.jpa.search.IStaleSearchDeletingSvc;
 import ca.uhn.fhir.jpa.search.StaleSearchDeletingSvcImpl;
 import ca.uhn.fhir.jpa.search.reindex.IResourceReindexingSvc;
 import ca.uhn.fhir.jpa.search.reindex.ResourceReindexingSvcImpl;
-import ca.uhn.fhir.jpa.subscription.ISubscriptionTriggeringSvc;
-import ca.uhn.fhir.jpa.subscription.SubscriptionTriggeringSvcImpl;
 import ca.uhn.fhir.jpa.subscription.dbmatcher.CompositeInMemoryDaoSubscriptionMatcher;
 import ca.uhn.fhir.jpa.subscription.dbmatcher.DaoSubscriptionMatcher;
 import ca.uhn.fhir.jpa.subscription.module.cache.ISubscribableChannelFactory;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/DaoConfig.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/DaoConfig.java
@@ -143,7 +143,6 @@ public class DaoConfig {
 	private boolean myDisableHashBasedSearches;
 	private boolean myEnableInMemorySubscriptionMatching = true;
 	private ClientIdStrategyEnum myResourceClientIdStrategy = ClientIdStrategyEnum.ALPHANUMERIC;
-	private boolean mySubscriptionMatchingEnabled = true;
 
 	/**
 	 * Constructor
@@ -530,7 +529,7 @@ public class DaoConfig {
 	 * This may be used to optionally register server interceptors directly against the DAOs.
 	 */
 	public void setInterceptors(IServerInterceptor... theInterceptor) {
-		setInterceptors(new ArrayList<IServerInterceptor>());
+		setInterceptors(new ArrayList<>());
 		if (theInterceptor != null && theInterceptor.length != 0) {
 			getInterceptors().addAll(Arrays.asList(theInterceptor));
 		}
@@ -1308,8 +1307,7 @@ public class DaoConfig {
 	public void setSearchPreFetchThresholds(List<Integer> thePreFetchThresholds) {
 		Validate.isTrue(thePreFetchThresholds.size() > 0, "thePreFetchThresholds must not be empty");
 		int last = 0;
-		for (Integer nextInteger : thePreFetchThresholds) {
-			int nextInt = nextInteger.intValue();
+		for (Integer nextInt : thePreFetchThresholds) {
 			Validate.isTrue(nextInt > 0 || nextInt == -1, nextInt + " is not a valid prefetch threshold");
 			Validate.isTrue(nextInt != last, "Prefetch thresholds must be sequential");
 			Validate.isTrue(nextInt > last || nextInt == -1, "Prefetch thresholds must be sequential");
@@ -1398,7 +1396,7 @@ public class DaoConfig {
 	 */
 
 	public boolean isSubscriptionMatchingEnabled() {
-		return mySubscriptionMatchingEnabled;
+		return myModelConfig.isSubscriptionMatchingEnabled();
 	}
 
 	/**
@@ -1407,9 +1405,8 @@ public class DaoConfig {
 	 * @since 3.7.0
 	 */
 
-
 	public void setSubscriptionMatchingEnabled(boolean theSubscriptionMatchingEnabled) {
-		mySubscriptionMatchingEnabled = theSubscriptionMatchingEnabled;
+		myModelConfig.setSubscriptionMatchingEnabled(theSubscriptionMatchingEnabled);
 	}
 
 	public ModelConfig getModelConfig() {

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/IResourceModifiedConsumer.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/IResourceModifiedConsumer.java
@@ -1,0 +1,7 @@
+package ca.uhn.fhir.jpa.subscription;
+
+import ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage;
+
+public interface IResourceModifiedConsumer {
+	void submitResourceModified(ResourceModifiedMessage theMsg);
+}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionMatcherInterceptor.java
@@ -9,6 +9,7 @@ import ca.uhn.fhir.jpa.subscription.module.subscriber.SubscriptionMatchingSubscr
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.interceptor.ServerOperationInterceptorAdapter;
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,12 +43,12 @@ import javax.annotation.PreDestroy;
 
 @Component
 @Lazy
-public class SubscriptionMatcherInterceptor extends ServerOperationInterceptorAdapter {
+public class SubscriptionMatcherInterceptor extends ServerOperationInterceptorAdapter implements IResourceModifiedConsumer {
 	private Logger ourLog = LoggerFactory.getLogger(SubscriptionMatcherInterceptor.class);
 
-	public static final String SUBSCRIPTION_MATCHING_CHANNEL_NAME = "subscription-matching";
-	public static final String SUBSCRIPTION_STATUS = "Subscription.status";
-	public static final String SUBSCRIPTION_TYPE = "Subscription.channel.type";
+	private static final String SUBSCRIPTION_MATCHING_CHANNEL_NAME = "subscription-matching";
+	static final String SUBSCRIPTION_STATUS = "Subscription.status";
+	static final String SUBSCRIPTION_TYPE = "Subscription.channel.type";
 	private SubscribableChannel myProcessingChannel;
 
 	@Autowired
@@ -64,7 +65,6 @@ public class SubscriptionMatcherInterceptor extends ServerOperationInterceptorAd
 		super();
 	}
 
-	@PostConstruct
 	public void start() {
 		if (myProcessingChannel == null) {
 			myProcessingChannel = mySubscriptionChannelFactory.newMatchingChannel(SUBSCRIPTION_MATCHING_CHANNEL_NAME);
@@ -77,7 +77,10 @@ public class SubscriptionMatcherInterceptor extends ServerOperationInterceptorAd
 	@SuppressWarnings("unused")
 	@PreDestroy
 	public void preDestroy() {
-		myProcessingChannel.unsubscribe(mySubscriptionMatchingSubscriber);
+
+		if (myProcessingChannel != null) {
+			myProcessingChannel.unsubscribe(mySubscriptionMatchingSubscriber);
+		}
 	}
 
 	@Override
@@ -100,8 +103,9 @@ public class SubscriptionMatcherInterceptor extends ServerOperationInterceptorAd
 		submitResourceModified(msg);
 	}
 
-	protected void sendToProcessingChannel(final ResourceModifiedMessage theMessage) {
+	private void sendToProcessingChannel(final ResourceModifiedMessage theMessage) {
 		ourLog.trace("Sending resource modified message to processing channel");
+		Validate.notNull(myProcessingChannel, "A SubscriptionMatcherInterceptor has been registered without calling start() on it.");
 		myProcessingChannel.send(new ResourceModifiedJsonMessage(theMessage));
 	}
 
@@ -117,7 +121,7 @@ public class SubscriptionMatcherInterceptor extends ServerOperationInterceptorAd
 	}
 
 	@VisibleForTesting
-	public LinkedBlockingQueueSubscribableChannel getProcessingChannelForUnitTest() {
+	LinkedBlockingQueueSubscribableChannel getProcessingChannelForUnitTest() {
 		return (LinkedBlockingQueueSubscribableChannel) myProcessingChannel;
 	}
 }

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionMatcherInterceptor.java
@@ -18,7 +18,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 /*-

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionTriggeringSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionTriggeringSvcImpl.java
@@ -55,15 +55,15 @@ import org.hl7.fhir.instance.model.api.IIdType;
 import org.hl7.fhir.instance.model.api.IPrimitiveType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
 

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionTriggeringSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionTriggeringSvcImpl.java
@@ -72,10 +72,10 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @Service
-public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc, ApplicationContextAware {
+public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc {
 	private static final Logger ourLog = LoggerFactory.getLogger(SubscriptionTriggeringProvider.class);
 
-	public static final int DEFAULT_MAX_SUBMIT = 10000;
+	private static final int DEFAULT_MAX_SUBMIT = 10000;
 
 	@Autowired
 	private FhirContext myFhirContext;
@@ -88,11 +88,10 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 	@Autowired
 	private MatchUrlService myMatchUrlService;
 	@Autowired
-	private SubscriptionMatcherInterceptor mySubscriptionMatcherInterceptor;
+	private IResourceModifiedConsumer myResourceModifiedConsumer;
 
 	private final List<SubscriptionTriggeringJobDetails> myActiveJobs = new ArrayList<>();
 	private int myMaxSubmitPerPass = DEFAULT_MAX_SUBMIT;
-	private ApplicationContext myAppCtx;
 	private ExecutorService myExecutorService;
 
 	@Override
@@ -105,7 +104,7 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 		if (theSubscriptionId != null) {
 			IFhirResourceDao<?> subscriptionDao = myDaoRegistry.getSubscriptionDao();
 			IIdType subscriptionId = theSubscriptionId;
-			if (subscriptionId.hasResourceType() == false) {
+			if (!subscriptionId.hasResourceType()) {
 				subscriptionId = subscriptionId.withResourceType(ResourceTypeEnum.SUBSCRIPTION.getCode());
 			}
 			subscriptionDao.read(subscriptionId);
@@ -128,7 +127,7 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 
 		// Search URLs must be valid
 		for (StringParam next : searchUrls) {
-			if (next.getValue().contains("?") == false) {
+			if (!next.getValue().contains("?")) {
 				throw new InvalidRequestException("Search URL is not valid (must be in the form \"[resource type]?[optional params]\")");
 			}
 		}
@@ -163,7 +162,7 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 				return;
 			}
 
-			String activeJobIds = myActiveJobs.stream().map(t -> t.getJobId()).collect(Collectors.joining(", "));
+			String activeJobIds = myActiveJobs.stream().map(SubscriptionTriggeringJobDetails::getJobId).collect(Collectors.joining(", "));
 			ourLog.info("Starting pass: currently have {} active job IDs: {}", myActiveJobs.size(), activeJobIds);
 
 			SubscriptionTriggeringJobDetails activeJob = myActiveJobs.get(0);
@@ -290,7 +289,7 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 
 	private Future<Void> submitResource(String theSubscriptionId, String theResourceIdToTrigger) {
 		org.hl7.fhir.r4.model.IdType resourceId = new org.hl7.fhir.r4.model.IdType(theResourceIdToTrigger);
-		IFhirResourceDao<? extends IBaseResource> dao = myDaoRegistry.getResourceDao(resourceId.getResourceType());
+		IFhirResourceDao dao = myDaoRegistry.getResourceDao(resourceId.getResourceType());
 		IBaseResource resourceToTrigger = dao.read(resourceId);
 
 		return submitResource(theSubscriptionId, resourceToTrigger);
@@ -306,7 +305,7 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 		return myExecutorService.submit(() -> {
 			for (int i = 0; ; i++) {
 				try {
-						mySubscriptionMatcherInterceptor.submitResourceModified(msg);
+						myResourceModifiedConsumer.submitResourceModified(msg);
 					break;
 				} catch (Exception e) {
 					if (i >= 3) {
@@ -329,11 +328,6 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 		}
 	}
 
-	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		myAppCtx = applicationContext;
-	}
-
 	/**
 	 * Sets the maximum number of resources that will be submitted in a single pass
 	 */
@@ -346,7 +340,6 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 		myMaxSubmitPerPass = maxSubmitPerPass;
 	}
 
-	@SuppressWarnings("unchecked")
 	@PostConstruct
 	public void start() {
 		LinkedBlockingQueue<Runnable> executorQueue = new LinkedBlockingQueue<>(1000);
@@ -393,67 +386,67 @@ public class SubscriptionTriggeringSvcImpl implements ISubscriptionTriggeringSvc
 		private String myCurrentSearchResourceType;
 		private int myCurrentSearchLastUploadedIndex;
 
-		public Integer getCurrentSearchCount() {
+		Integer getCurrentSearchCount() {
 			return myCurrentSearchCount;
 		}
 
-		public void setCurrentSearchCount(Integer theCurrentSearchCount) {
+		void setCurrentSearchCount(Integer theCurrentSearchCount) {
 			myCurrentSearchCount = theCurrentSearchCount;
 		}
 
-		public String getCurrentSearchResourceType() {
+		String getCurrentSearchResourceType() {
 			return myCurrentSearchResourceType;
 		}
 
-		public void setCurrentSearchResourceType(String theCurrentSearchResourceType) {
+		void setCurrentSearchResourceType(String theCurrentSearchResourceType) {
 			myCurrentSearchResourceType = theCurrentSearchResourceType;
 		}
 
-		public String getJobId() {
+		String getJobId() {
 			return myJobId;
 		}
 
-		public void setJobId(String theJobId) {
+		void setJobId(String theJobId) {
 			myJobId = theJobId;
 		}
 
-		public String getSubscriptionId() {
+		String getSubscriptionId() {
 			return mySubscriptionId;
 		}
 
-		public void setSubscriptionId(String theSubscriptionId) {
+		void setSubscriptionId(String theSubscriptionId) {
 			mySubscriptionId = theSubscriptionId;
 		}
 
-		public List<String> getRemainingResourceIds() {
+		List<String> getRemainingResourceIds() {
 			return myRemainingResourceIds;
 		}
 
-		public void setRemainingResourceIds(List<String> theRemainingResourceIds) {
+		void setRemainingResourceIds(List<String> theRemainingResourceIds) {
 			myRemainingResourceIds = theRemainingResourceIds;
 		}
 
-		public List<String> getRemainingSearchUrls() {
+		List<String> getRemainingSearchUrls() {
 			return myRemainingSearchUrls;
 		}
 
-		public void setRemainingSearchUrls(List<String> theRemainingSearchUrls) {
+		void setRemainingSearchUrls(List<String> theRemainingSearchUrls) {
 			myRemainingSearchUrls = theRemainingSearchUrls;
 		}
 
-		public String getCurrentSearchUuid() {
+		String getCurrentSearchUuid() {
 			return myCurrentSearchUuid;
 		}
 
-		public void setCurrentSearchUuid(String theCurrentSearchUuid) {
+		void setCurrentSearchUuid(String theCurrentSearchUuid) {
 			myCurrentSearchUuid = theCurrentSearchUuid;
 		}
 
-		public int getCurrentSearchLastUploadedIndex() {
+		int getCurrentSearchLastUploadedIndex() {
 			return myCurrentSearchLastUploadedIndex;
 		}
 
-		public void setCurrentSearchLastUploadedIndex(int theCurrentSearchLastUploadedIndex) {
+		void setCurrentSearchLastUploadedIndex(int theCurrentSearchLastUploadedIndex) {
 			myCurrentSearchLastUploadedIndex = theCurrentSearchLastUploadedIndex;
 		}
 	}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/BaseResourceProviderR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/provider/r4/BaseResourceProviderR4Test.java
@@ -59,14 +59,14 @@ public abstract class BaseResourceProviderR4Test extends BaseJpaR4Test {
 	protected static RestfulServer ourRestServer;
 	protected static String ourServerBase;
 	protected static SearchParamRegistryR4 ourSearchParamRegistry;
-	protected static DatabaseBackedPagingProvider ourPagingProvider;
+	private static DatabaseBackedPagingProvider ourPagingProvider;
 	protected static ISearchDao mySearchEntityDao;
 	protected static ISearchCoordinatorSvc mySearchCoordinatorSvc;
-	protected static GenericWebApplicationContext ourWebApplicationContext;
-	protected static SubscriptionMatcherInterceptor ourSubscriptionMatcherInterceptor;
+	private static GenericWebApplicationContext ourWebApplicationContext;
+	private static SubscriptionMatcherInterceptor ourSubscriptionMatcherInterceptor;
 	private static Server ourServer;
 	protected IGenericClient ourClient;
-	protected ResourceCountCache ourResourceCountsCache;
+	ResourceCountCache ourResourceCountsCache;
 	private TerminologyUploaderProviderR4 myTerminologyUploaderProvider;
 	private Object ourGraphQLProvider;
 	private boolean ourRestHookSubscriptionInterceptorRequested;
@@ -162,6 +162,7 @@ public abstract class BaseResourceProviderR4Test extends BaseJpaR4Test {
 			mySearchEntityDao = wac.getBean(ISearchDao.class);
 			ourSearchParamRegistry = wac.getBean(SearchParamRegistryR4.class);
 			ourSubscriptionMatcherInterceptor = wac.getBean(SubscriptionMatcherInterceptor.class);
+			ourSubscriptionMatcherInterceptor.start();
 
 			myFhirCtx.getRestfulClientFactory().setSocketTimeout(5000000);
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ModelConfig.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ModelConfig.java
@@ -40,7 +40,7 @@ public class ModelConfig {
 	 * <li><code>"http://hl7.org/fhir/StructureDefinition/*"</code></li>
 	 * </ul>
 	 */
-	public static final Set<String> DEFAULT_LOGICAL_BASE_URLS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
+	public static final Set<String> DEFAULT_LOGICAL_BASE_URLS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
 		"http://hl7.org/fhir/ValueSet/*",
 		"http://hl7.org/fhir/CodeSystem/*",
 		"http://hl7.org/fhir/valueset-*",
@@ -57,6 +57,7 @@ public class ModelConfig {
 	private boolean myDefaultSearchParamsCanBeOverridden = false;
 	private Set<Subscription.SubscriptionChannelType> mySupportedSubscriptionTypes = new HashSet<>();
 	private String myEmailFromAddress = "noreply@unknown.com";
+	private boolean mySubscriptionMatchingEnabled = true;
 
 	/**
 	 * If set to {@code true} the default search params (i.e. the search parameters that are
@@ -225,7 +226,7 @@ public class ModelConfig {
 			}
 		}
 
-		HashSet<String> treatBaseUrlsAsLocal = new HashSet<String>();
+		HashSet<String> treatBaseUrlsAsLocal = new HashSet<>();
 		for (String next : ObjectUtils.defaultIfNull(theTreatBaseUrlsAsLocal, new HashSet<String>())) {
 			while (next.endsWith("/")) {
 				next = next.substring(0, next.length() - 1);
@@ -318,6 +319,27 @@ public class ModelConfig {
 	 */
 	public Set<Subscription.SubscriptionChannelType> getSupportedSubscriptionTypes() {
 		return Collections.unmodifiableSet(mySupportedSubscriptionTypes);
+	}
+
+	/**
+	 * If set to <code>true</code> (default is true) the server will match incoming resources against active subscriptions
+	 * and send them to the subscription channel.  If set to <code>false</code> no matching or sending occurs.
+	 * @since 3.7.0
+	 */
+
+	public boolean isSubscriptionMatchingEnabled() {
+		return mySubscriptionMatchingEnabled;
+	}
+
+	/**
+	 * If set to <code>true</code> (default is true) the server will match incoming resources against active subscriptions
+	 * and send them to the subscription channel.  If set to <code>false</code> no matching or sending occurs.
+	 * @since 3.7.0
+	 */
+
+
+	public void setSubscriptionMatchingEnabled(boolean theSubscriptionMatchingEnabled) {
+		mySubscriptionMatchingEnabled = theSubscriptionMatchingEnabled;
 	}
 
 	@VisibleForTesting

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
@@ -112,8 +112,6 @@ public class FhirAutoConfiguration {
 
 		private final IPagingProvider pagingProvider;
 
-		private final List<IServerInterceptor> interceptors;
-
 		private final List<FhirRestfulServerCustomizer> customizers;
 
 		public FhirRestfulServerConfiguration(
@@ -127,7 +125,6 @@ public class FhirAutoConfiguration {
 			this.fhirContext = fhirContext;
 			this.resourceProviders = resourceProviders.getIfAvailable();
 			this.pagingProvider = pagingProvider.getIfAvailable();
-			this.interceptors = interceptors.getIfAvailable();
 			this.customizers = customizers.getIfAvailable();
 		}
 
@@ -154,7 +151,6 @@ public class FhirAutoConfiguration {
 			setFhirContext(this.fhirContext);
 			setResourceProviders(this.resourceProviders);
 			setPagingProvider(this.pagingProvider);
-			setInterceptors(this.interceptors);
 
 			setServerAddressStrategy(new HardcodedServerAddressStrategy(this.properties.getServer().getPath()));
 

--- a/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
+++ b/hapi-fhir-spring-boot/hapi-fhir-spring-boot-autoconfigure/src/main/java/ca/uhn/fhir/spring/boot/autoconfigure/FhirAutoConfiguration.java
@@ -23,7 +23,6 @@ package ca.uhn.fhir.spring.boot.autoconfigure;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jaxrs.server.AbstractJaxRsProvider;
-import ca.uhn.fhir.jpa.config.BaseConfig;
 import ca.uhn.fhir.jpa.config.BaseJavaConfigDstu2;
 import ca.uhn.fhir.jpa.config.BaseJavaConfigDstu3;
 import ca.uhn.fhir.jpa.config.BaseJavaConfigR4;
@@ -31,7 +30,6 @@ import ca.uhn.fhir.jpa.dao.DaoConfig;
 import ca.uhn.fhir.jpa.model.entity.ModelConfig;
 import ca.uhn.fhir.jpa.provider.BaseJpaProvider;
 import ca.uhn.fhir.jpa.provider.BaseJpaSystemProvider;
-import ca.uhn.fhir.model.dstu2.resource.AuditEvent;
 import ca.uhn.fhir.okhttp.client.OkHttpRestfulClientFactory;
 import ca.uhn.fhir.rest.client.apache.ApacheRestfulClientFactory;
 import ca.uhn.fhir.rest.client.api.IClientInterceptor;
@@ -61,11 +59,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
-import org.springframework.core.task.AsyncTaskExecutor;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ConcurrentTaskScheduler;
-import org.springframework.scheduling.concurrent.ScheduledExecutorFactoryBean;
 import org.springframework.util.CollectionUtils;
 
 import javax.servlet.ServletException;


### PR DESCRIPTION
- Changed SubscriptionMatchingIntercepter so that you must call start() on it to start the subscription matching jms channel (before it auto-started in `@PostConstruct`)
- SubscriptionTriggeringSvcImpl now depends on an IResourceModifiedConsumer as opposed to explicitly using a SubscriptionMatcherInterceptor to send subscriptions.  This allows users to create their own interceptors that send resources to a standalone subscription matching server.
