### PR TITLE
Ja subscription debug logger

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionMatcherInterceptor.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/subscription/SubscriptionMatcherInterceptor.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.subscription;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.model.interceptor.api.Hook;
+import ca.uhn.fhir.jpa.model.interceptor.api.IInterceptorBroadcaster;
 import ca.uhn.fhir.jpa.model.interceptor.api.Interceptor;
 import ca.uhn.fhir.jpa.model.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.subscription.module.LinkedBlockingQueueSubscribableChannel;
@@ -97,8 +98,17 @@ public class SubscriptionMatcherInterceptor implements IResourceModifiedConsumer
 		submitResourceModified(theNewResource, ResourceModifiedMessage.OperationTypeEnum.UPDATE);
 	}
 
+	@Autowired
+	private IInterceptorBroadcaster myInterceptorBroadcaster;
+
 	private void submitResourceModified(IBaseResource theNewResource, ResourceModifiedMessage.OperationTypeEnum theOperationType) {
 		ResourceModifiedMessage msg = new ResourceModifiedMessage(myFhirContext, theNewResource, theOperationType);
+
+		// Interceptor call: SUBSCRIPTION_RESOURCE_MODIFIED
+		if (!myInterceptorBroadcaster.callHooks(Pointcut.SUBSCRIPTION_RESOURCE_MODIFIED, msg)) {
+			return;
+		}
+
 		submitResourceModified(msg);
 	}
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
@@ -15,10 +15,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Captor;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -46,10 +43,6 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 
 	@Autowired
 	StoppableSubscriptionDeliveringRestHookSubscriber myStoppableSubscriptionDeliveringRestHookSubscriber;
-	@Captor
-	private ArgumentCaptor<String> myMessageCaptor;
-	@Captor
-	private ArgumentCaptor<Object[]> myArgsCaptor;
 
 	@After
 	public void cleanupStoppableSubscriptionDeliveringRestHookSubscriber() {

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
@@ -252,68 +252,6 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 	}
 
 	@Test
-	public void testDebugLoggingInterceptor() throws Exception {
-		List<String> messages = new ArrayList<>();
-		Logger loggerMock = mock(Logger.class);
-		doAnswer(t->{
-			Object msg = t.getArguments()[0];
-			Object[] args = Arrays.copyOfRange(t.getArguments(), 1, t.getArguments().length);
-			String formattedMessage = MessageFormatter.arrayFormat((String) msg, args).getMessage();
-			messages.add(formattedMessage);
-			return null;
-		}).when(loggerMock).debug(any(), ArgumentMatchers.<Object[]>any());
-
-		SubscriptionDebugLogInterceptor interceptor = new SubscriptionDebugLogInterceptor();
-		myInterceptorRegistry.registerInterceptor(interceptor);
-		SubscriptionDebugLogInterceptor interceptor2 = new SubscriptionDebugLogInterceptor(loggerMock, Level.DEBUG);
-		myInterceptorRegistry.registerInterceptor(interceptor2);
-		try {
-
-			String payload = "application/json";
-
-			String code = "1000000050";
-			String criteria1 = "Observation?code=SNOMED-CT|" + code + "&_format=xml";
-			String criteria2 = "Observation?code=SNOMED-CT|" + code + "111&_format=xml";
-
-			Subscription subscription1 = createSubscription(criteria1, payload);
-			Subscription subscription2 = createSubscription(criteria2, payload);
-			waitForActivatedSubscriptionCount(2);
-
-			Observation observation1 = sendObservation(code, "SNOMED-CT");
-
-			// Should see 1 subscription notification
-			waitForQueueToDrain();
-			waitForSize(0, ourCreatedObservations);
-			waitForSize(1, ourUpdatedObservations);
-			assertEquals(Constants.CT_FHIR_JSON_NEW, ourContentTypes.get(0));
-
-			assertEquals("1", ourUpdatedObservations.get(0).getIdElement().getVersionIdPart());
-
-			Subscription subscriptionTemp = ourClient.read(Subscription.class, subscription2.getId());
-			Assert.assertNotNull(subscriptionTemp);
-
-			subscriptionTemp.setCriteria(criteria1);
-			ourClient.update().resource(subscriptionTemp).withId(subscriptionTemp.getIdElement()).execute();
-			waitForQueueToDrain();
-
-			sendObservation(code, "SNOMED-CT");
-			waitForQueueToDrain();
-
-			// Should see two subscription notifications
-			waitForSize(0, ourCreatedObservations);
-			waitForSize(3, ourUpdatedObservations);
-
-			ourLog.info("Messages:\n  " + messages.stream().collect(Collectors.joining("\n  ")));
-
-			assertThat(messages.get(messages.size()-1), matchesPattern("Finished delivery of resource Observation.*"));
-
-		} finally {
-			myInterceptorRegistry.unregisterInterceptor(interceptor);
-			myInterceptorRegistry.unregisterInterceptor(interceptor2);
-		}
-	}
-
-	@Test
 	public void testRestHookSubscriptionNoopUpdateDoesntTriggerNewDelivery() throws Exception {
 		String payload = "application/fhir+json";
 

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/resthook/RestHookTestR4Test.java
@@ -16,6 +16,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -25,6 +26,7 @@ import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -262,11 +264,11 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 		Logger loggerMock = mock(Logger.class);
 		doAnswer(t->{
 			Object msg = t.getArguments()[0];
-			Object[] args = (Object[]) t.getArguments()[1];
+			Object[] args = Arrays.copyOfRange(t.getArguments(), 1, t.getArguments().length);
 			String formattedMessage = MessageFormatter.arrayFormat((String) msg, args).getMessage();
 			messages.add(formattedMessage);
 			return null;
-		}).when(loggerMock).debug(any(), any(Object[].class));
+		}).when(loggerMock).debug(any(), ArgumentMatchers.<Object[]>any());
 
 		SubscriptionDebugLogInterceptor interceptor = new SubscriptionDebugLogInterceptor();
 		myInterceptorRegistry.registerInterceptor(interceptor);
@@ -310,6 +312,7 @@ public class RestHookTestR4Test extends BaseSubscriptionsR4Test {
 
 			ourLog.info("Messages:\n  " + messages.stream().collect(Collectors.joining("\n  ")));
 
+			assertThat(messages.get(messages.size()-1), matchesPattern("Finished delivery of resource Observation.*"));
 
 		} finally {
 			myInterceptorRegistry.unregisterInterceptor(interceptor);

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
@@ -30,6 +30,48 @@ import java.util.List;
 public enum Pointcut {
 
 	/**
+	 * Invoked whenever a persisted resource has been modified and is being submitted to the
+	 * subscription processing pipeline. This method is called before the resource is placed
+	 * on any queues for processing and executes synchronously during the resource modification
+	 * operation itself, so it should return quickly.
+	 * <p>
+	 * Hooks may accept the following parameters:
+	 * <ul>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage - Hooks may modify this parameter. This will affect the checking process.</li>
+	 * </ul>
+	 * </p>
+	 * <p>
+	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * returns <code>false</code>, subscription processing will not proceed for the given resource;
+	 * </p>
+	 */
+	SUBSCRIPTION_RESOURCE_MODIFIED("ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage"),
+
+	/**
+	 * Inkoved any time that a resource is matched by an individual subscription, and
+	 * is about to be queued for delivery.
+	 * <p>
+	 * Hooks may make changes to the delivery payload, or make changes to the
+	 * canonical subscription such as adding headers, modifying the channel
+	 * endpoint, etc.
+	 * </p>
+	 * Hooks may accept the following parameters:
+	 * <ul>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription</li>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.matcher.SubscriptionMatchResult</li>
+	 * </ul>
+	 * <p>
+	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * returns <code>false</code>, delivery will be aborted.
+	 * </p>
+	 */
+	SUBSCRIPTION_RESOURCE_MATCHED("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription", "ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage", "ca.uhn.fhir.jpa.subscription.module.matcher.SubscriptionMatchResult"),
+
+
+	/**
 	 * Invoked immediately before the delivery of a subscription, and right before any channel-specific
 	 * hooks are invoked (e.g. {@link #SUBSCRIPTION_BEFORE_REST_HOOK_DELIVERY}.
 	 * <p>
@@ -249,7 +291,9 @@ public enum Pointcut {
 	 * Hooks should return <code>null</code>.
 	 * </p>
 	 */
-	OP_PRESTORAGE_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource");
+	OP_PRESTORAGE_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource"),
+
+	;
 
 
 	private final List<String> myParameterTypes;

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
@@ -9,9 +9,9 @@ package ca.uhn.fhir.jpa.model.interceptor.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,6 +30,43 @@ import java.util.List;
 public enum Pointcut {
 
 	/**
+	 * Invoked immediately before the delivery of a subscription, and right before any channel-specific
+	 * hooks are invoked (e.g. {@link #SUBSCRIPTION_BEFORE_REST_HOOK_DELIVERY}.
+	 * <p>
+	 * Hooks may make changes to the delivery payload, or make changes to the
+	 * canonical subscription such as adding headers, modifying the channel
+	 * endpoint, etc.
+	 * </p>
+	 * Hooks may accept the following parameters:
+	 * <ul>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription</li>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
+	 * </ul>
+	 * <p>
+	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * returns <code>false</code>, processing will be aborted.
+	 * </p>
+	 */
+	SUBSCRIPTION_BEFORE_DELIVERY("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription", "ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage"),
+
+	/**
+	 * Invoked immediately after the delivery of a subscription, and right before any channel-specific
+	 * hooks are invoked (e.g. {@link #SUBSCRIPTION_AFTER_REST_HOOK_DELIVERY}.
+	 * <p>
+	 * Hooks may accept the following parameters:
+	 * </p>
+	 * <ul>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription</li>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
+	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
+	 */
+	SUBSCRIPTION_AFTER_DELIVERY("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription", "ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage"),
+
+	/**
 	 * Invoked immediately after the delivery of a REST HOOK subscription.
 	 * <p>
 	 * When this hook is called, all processing is complete so this hook should not
@@ -40,6 +77,9 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription</li>
 	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
 	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
 	SUBSCRIPTION_AFTER_REST_HOOK_DELIVERY("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription", "ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage"),
 
@@ -55,17 +95,45 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription</li>
 	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
 	 * </ul>
+	 * <p>
+	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * returns <code>false</code>, processing will be aborted.
+	 * </p>
 	 */
 	SUBSCRIPTION_BEFORE_REST_HOOK_DELIVERY("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription", "ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage"),
 
 	/**
 	 * Invoked whenever a persisted resource (a resource that has just been stored in the
-	 * database via a create/update/patch/etc.) has been checked for whether any subscriptions
-	 * were triggered as a result of the operation
+	 * database via a create/update/patch/etc.) is about to be checked for whether any subscriptions
+	 * were triggered as a result of the operation.
+	 * <p>
 	 * Hooks may accept the following parameters:
 	 * <ul>
-	 * <li>ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage</li>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage - Hooks may modify this parameter. This will affect the checking process.</li>
 	 * </ul>
+	 * </p>
+	 * <p>
+	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * returns <code>false</code>, processing will be aborted.
+	 * </p>
+	 */
+	SUBSCRIPTION_BEFORE_PERSISTED_RESOURCE_CHECKED("ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage"),
+
+	/**
+	 * Invoked whenever a persisted resource (a resource that has just been stored in the
+	 * database via a create/update/patch/etc.) has been checked for whether any subscriptions
+	 * were triggered as a result of the operation.
+	 * <p>
+	 * Hooks may accept the following parameters:
+	 * <ul>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage - This parameter should not be modified as processing is complete when this hook is invoked.</li>
+	 * </ul>
+	 * </p>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
 	SUBSCRIPTION_AFTER_PERSISTED_RESOURCE_CHECKED("ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage"),
 
@@ -82,6 +150,9 @@ public enum Pointcut {
 	 * <ul>
 	 * <li>ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription</li>
 	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
 	SUBSCRIPTION_AFTER_ACTIVE_SUBSCRIPTION_REGISTERED("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription"),
 
@@ -97,6 +168,9 @@ public enum Pointcut {
 	 * <ul>
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource</li>
 	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
 	OP_PRESTORAGE_RESOURCE_CREATED("org.hl7.fhir.instance.model.api.IBaseResource"),
 
@@ -114,6 +188,9 @@ public enum Pointcut {
 	 * <ul>
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource</li>
 	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
 	OP_PRECOMMIT_RESOURCE_CREATED("org.hl7.fhir.instance.model.api.IBaseResource"),
 
@@ -127,6 +204,9 @@ public enum Pointcut {
 	 * <ul>
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource</li>
 	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
 	OP_PRECOMMIT_RESOURCE_DELETED("org.hl7.fhir.instance.model.api.IBaseResource"),
 
@@ -145,6 +225,9 @@ public enum Pointcut {
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource (previous contents)</li>
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource (new contents)</li>
 	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
 	OP_PRECOMMIT_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource"),
 
@@ -162,10 +245,12 @@ public enum Pointcut {
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource (previous contents)</li>
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource (new contents)</li>
 	 * </ul>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
 	 */
-	OP_PRESTORAGE_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource"),
+	OP_PRESTORAGE_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource");
 
-	;
 
 	private final List<String> myParameterTypes;
 
@@ -176,4 +261,4 @@ public enum Pointcut {
 	public List<String> getParameterTypes() {
 		return myParameterTypes;
 	}
-	}
+}

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
@@ -41,15 +41,15 @@ public enum Pointcut {
 	 * </ul>
 	 * </p>
 	 * <p>
-	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
-	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * Hooks may return <code>void</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>void</code> or <code>true</code>, processing will continue normally. If the method
 	 * returns <code>false</code>, subscription processing will not proceed for the given resource;
 	 * </p>
 	 */
 	SUBSCRIPTION_RESOURCE_MODIFIED("ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage"),
 
 	/**
-	 * Inkoved any time that a resource is matched by an individual subscription, and
+	 * Invoked any time that a resource is matched by an individual subscription, and
 	 * is about to be queued for delivery.
 	 * <p>
 	 * Hooks may make changes to the delivery payload, or make changes to the
@@ -63,8 +63,8 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.matcher.SubscriptionMatchResult</li>
 	 * </ul>
 	 * <p>
-	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
-	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * Hooks may return <code>void</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>void</code> or <code>true</code>, processing will continue normally. If the method
 	 * returns <code>false</code>, delivery will be aborted.
 	 * </p>
 	 */
@@ -81,7 +81,7 @@ public enum Pointcut {
 	 * </ul>
 	 * </p>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	SUBSCRIPTION_RESOURCE_DID_NOT_MATCH_ANY_SUBSCRIPTIONS("ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage"),
@@ -101,8 +101,8 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
 	 * </ul>
 	 * <p>
-	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
-	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * Hooks may return <code>void</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>void</code> or <code>true</code>, processing will continue normally. If the method
 	 * returns <code>false</code>, processing will be aborted.
 	 * </p>
 	 */
@@ -119,7 +119,7 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	SUBSCRIPTION_AFTER_DELIVERY("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription", "ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage"),
@@ -136,7 +136,7 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	SUBSCRIPTION_AFTER_REST_HOOK_DELIVERY("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription", "ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage"),
@@ -154,8 +154,8 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage</li>
 	 * </ul>
 	 * <p>
-	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
-	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * Hooks may return <code>void</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>void</code> or <code>true</code>, processing will continue normally. If the method
 	 * returns <code>false</code>, processing will be aborted.
 	 * </p>
 	 */
@@ -172,8 +172,8 @@ public enum Pointcut {
 	 * </ul>
 	 * </p>
 	 * <p>
-	 * Hooks may return <code>null</code> or may return a <code>boolean</code>. If the method returns
-	 * <code>null</code> or <code>true</code>, processing will continue normally. If the method
+	 * Hooks may return <code>void</code> or may return a <code>boolean</code>. If the method returns
+	 * <code>void</code> or <code>true</code>, processing will continue normally. If the method
 	 * returns <code>false</code>, processing will be aborted.
 	 * </p>
 	 */
@@ -190,7 +190,7 @@ public enum Pointcut {
 	 * </ul>
 	 * </p>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	SUBSCRIPTION_AFTER_PERSISTED_RESOURCE_CHECKED("ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage"),
@@ -209,7 +209,7 @@ public enum Pointcut {
 	 * <li>ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	SUBSCRIPTION_AFTER_ACTIVE_SUBSCRIPTION_REGISTERED("ca.uhn.fhir.jpa.subscription.module.CanonicalSubscription"),
@@ -227,7 +227,7 @@ public enum Pointcut {
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	OP_PRESTORAGE_RESOURCE_CREATED("org.hl7.fhir.instance.model.api.IBaseResource"),
@@ -247,7 +247,7 @@ public enum Pointcut {
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	OP_PRECOMMIT_RESOURCE_CREATED("org.hl7.fhir.instance.model.api.IBaseResource"),
@@ -263,7 +263,7 @@ public enum Pointcut {
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	OP_PRECOMMIT_RESOURCE_DELETED("org.hl7.fhir.instance.model.api.IBaseResource"),
@@ -284,7 +284,7 @@ public enum Pointcut {
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource (new contents)</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	OP_PRECOMMIT_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource"),
@@ -304,7 +304,7 @@ public enum Pointcut {
 	 * <li>org.hl7.fhir.instance.model.api.IBaseResource (new contents)</li>
 	 * </ul>
 	 * <p>
-	 * Hooks should return <code>null</code>.
+	 * Hooks should return <code>void</code>.
 	 * </p>
 	 */
 	OP_PRESTORAGE_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource"),

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/interceptor/api/Pointcut.java
@@ -72,6 +72,22 @@ public enum Pointcut {
 
 
 	/**
+	 * Invoked whenever a persisted resource was checked against all active subscriptions, and did not
+	 * match any.
+	 * <p>
+	 * Hooks may accept the following parameters:
+	 * <ul>
+	 * <li>ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage - Hooks should not modify this parameter as changes will not have any effect.</li>
+	 * </ul>
+	 * </p>
+	 * <p>
+	 * Hooks should return <code>null</code>.
+	 * </p>
+	 */
+	SUBSCRIPTION_RESOURCE_DID_NOT_MATCH_ANY_SUBSCRIPTIONS("ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage"),
+
+
+	/**
 	 * Invoked immediately before the delivery of a subscription, and right before any channel-specific
 	 * hooks are invoked (e.g. {@link #SUBSCRIPTION_BEFORE_REST_HOOK_DELIVERY}.
 	 * <p>
@@ -294,7 +310,6 @@ public enum Pointcut {
 	OP_PRESTORAGE_RESOURCE_UPDATED("org.hl7.fhir.instance.model.api.IBaseResource", "org.hl7.fhir.instance.model.api.IBaseResource"),
 
 	;
-
 
 	private final List<String> myParameterTypes;
 

--- a/hapi-fhir-jpaserver-subscription/pom.xml
+++ b/hapi-fhir-jpaserver-subscription/pom.xml
@@ -97,6 +97,16 @@
 			<artifactId>jetty-servlet</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<pluginManagement>

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/ResourceModifiedMessage.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/ResourceModifiedMessage.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.subscription.module;
  */
 
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.subscription.module.subscriber.BaseResourceMessage;
 import ca.uhn.fhir.jpa.subscription.module.subscriber.IResourceMessage;
 import ca.uhn.fhir.util.ResourceReferenceInfo;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -37,7 +38,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(creatorVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
-public class ResourceModifiedMessage implements IResourceMessage {
+public class ResourceModifiedMessage extends BaseResourceMessage implements IResourceMessage {
 
 	@JsonProperty("resourceId")
 	private String myId;

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/interceptor/SubscriptionDebugLogInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/interceptor/SubscriptionDebugLogInterceptor.java
@@ -55,7 +55,7 @@ public class SubscriptionDebugLogInterceptor {
 	@Hook(Pointcut.SUBSCRIPTION_RESOURCE_MODIFIED)
 	public void step10_resourceModified(ResourceModifiedMessage theMessage) {
 		String value = Long.toString(System.currentTimeMillis());
-		theMessage.setAdditionalProperty(SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK, value);
+		theMessage.setAttribute(SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK, value);
 		log("SUBS10","Resource {} was submitted to the processing pipeline", theMessage.getPayloadId(), theMessage.getOperationType());
 	}
 
@@ -82,7 +82,7 @@ public class SubscriptionDebugLogInterceptor {
 	@Hook(Pointcut.SUBSCRIPTION_AFTER_DELIVERY)
 	public void step50_afterDelivery(ResourceDeliveryMessage theMessage) {
 		String processingTime = theMessage
-			.getAdditionalProperty(SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK)
+			.getAttribute(SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK)
 			.map(Long::parseLong)
 			.map(Date::new)
 			.map(start -> new StopWatch(start).toString())

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/interceptor/SubscriptionDebugLogInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/interceptor/SubscriptionDebugLogInterceptor.java
@@ -70,16 +70,12 @@ public class SubscriptionDebugLogInterceptor {
 
 	@Hook(Pointcut.SUBSCRIPTION_AFTER_DELIVERY)
 	public void step05_afterDelivery(ResourceDeliveryMessage theMessage) {
-		Date precheckTime = theMessage
+		String processingTime = theMessage
 			.getAdditionalProperty(SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK)
 			.map(Long::parseLong)
-			.map(t -> new Date(t))
-			.orElse(null);
-
-		String processingTime = "(unknown)";
-		if (precheckTime != null) {
-			processingTime = new StopWatch(precheckTime).toString();
-		}
+			.map(Date::new)
+			.map(t->new StopWatch(t).toString())
+			.orElse("(unknown)");
 
 		log("Finished delivery of resource {} for subscription {} to channel of type {} - Total processing time: {}", theMessage.getPayloadId(), theMessage.getSubscription().getIdElementString(), theMessage.getSubscription().getChannelType(), processingTime);
 	}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/interceptor/SubscriptionDebugLogInterceptor.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/interceptor/SubscriptionDebugLogInterceptor.java
@@ -1,0 +1,91 @@
+package ca.uhn.fhir.jpa.subscription.module.interceptor;
+
+import ca.uhn.fhir.jpa.model.interceptor.api.Hook;
+import ca.uhn.fhir.jpa.model.interceptor.api.Interceptor;
+import ca.uhn.fhir.jpa.model.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.subscription.module.ResourceModifiedMessage;
+import ca.uhn.fhir.jpa.subscription.module.subscriber.ResourceDeliveryMessage;
+import ca.uhn.fhir.util.StopWatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import java.util.Date;
+
+/**
+ * This interceptor can be used for troubleshooting subscription processing. It provides very
+ * detailed logging about the subscription processing pipeline.
+ */
+@Interceptor
+public class SubscriptionDebugLogInterceptor {
+
+	private static final Logger DEFAULT_LOGGER = LoggerFactory.getLogger(SubscriptionDebugLogInterceptor.class);
+	private static final String SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK = "SubscriptionDebugLogInterceptor_precheck";
+	private final Logger myLogger;
+	private final Level myLevel;
+
+	/**
+	 * Constructor that logs at INFO level to the logger <code>ca.uhn.fhir.jpa.subscription.module.interceptor.SubscriptionDebugLogInterceptor</code>
+	 */
+	public SubscriptionDebugLogInterceptor() {
+		this(DEFAULT_LOGGER, Level.INFO);
+	}
+
+	/**
+	 * Constructor using a specific logger
+	 */
+	public SubscriptionDebugLogInterceptor(Logger theLog, Level theLevel) {
+		myLogger = theLog;
+		myLevel = theLevel;
+	}
+
+	@Hook(Pointcut.SUBSCRIPTION_BEFORE_PERSISTED_RESOURCE_CHECKED)
+	public void checkMessage(ResourceModifiedMessage theMessage) {
+		String value = Long.toString(System.currentTimeMillis());
+		theMessage.setAdditionalProperty(SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK, value);
+
+		log("About to check {} for subscription matches", theMessage.getPayloadId());
+	}
+
+	@Hook(Pointcut.SUBSCRIPTION_BEFORE_DELIVERY)
+	public void beforeDelivery(ResourceDeliveryMessage theMessage) {
+		log("About to deliver resource {} for subscription {} to channel of type {}", theMessage.getPayloadId(), theMessage.getSubscription().getIdElementString(), theMessage.getSubscription().getChannelType());
+	}
+
+	@Hook(Pointcut.SUBSCRIPTION_AFTER_DELIVERY)
+	public void afterDelivery(ResourceDeliveryMessage theMessage) {
+		Date precheckTime = theMessage
+			.getAdditionalProperty(SUBSCRIPTION_DEBUG_LOG_INTERCEPTOR_PRECHECK)
+			.map(Long::parseLong)
+			.map(t -> new Date(t))
+			.orElse(null);
+
+		String processingTime = "(unknown)";
+		if (precheckTime != null) {
+			processingTime = new StopWatch(precheckTime).toString();
+		}
+
+		log("Finished delivery of resource {} for subscription {} to channel of type {} - Total processing time: {}", theMessage.getPayloadId(), theMessage.getSubscription().getIdElementString(), theMessage.getSubscription().getChannelType(), processingTime);
+	}
+
+	private void log(String theMessage, Object... theArguments) {
+		switch (myLevel) {
+			case ERROR:
+				myLogger.error(theMessage, theArguments);
+				break;
+			case WARN:
+				myLogger.warn(theMessage, theArguments);
+				break;
+			case INFO:
+				myLogger.info(theMessage, theArguments);
+				break;
+			case DEBUG:
+				myLogger.debug(theMessage, theArguments);
+				break;
+			case TRACE:
+				myLogger.trace(theMessage, theArguments);
+				break;
+		}
+	}
+
+}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/BaseResourceMessage.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/BaseResourceMessage.java
@@ -1,5 +1,7 @@
 package ca.uhn.fhir.jpa.subscription.module.subscriber;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang3.Validate;
 
@@ -8,60 +10,71 @@ import java.util.Map;
 import java.util.Optional;
 
 @SuppressWarnings("WeakerAccess")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonAutoDetect(creatorVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
 public abstract class BaseResourceMessage implements IResourceMessage {
-	@JsonProperty("additionalProperties")
-	private Map<String, String> myAdditionalProperties;
+
+	@JsonProperty("attributes")
+	private Map<String, String> myAttributes;
 
 	/**
-	 * Returns an additional property stored in this message.
+	 * Returns an attribute stored in this message.
 	 * <p>
-	 * Additional properties are just a spot for user data of any kind to be
+	 * Attributes are just a spot for user data of any kind to be
 	 * added to the message for pasing along the subscription processing
 	 * pipeline (typically by interceptors). Values will be carried from the beginning to the end.
 	 * </p>
+	 * <p>
+	 * Note that messages are designed to be passed into queueing systems
+	 * and serialized as JSON. As a result, only strings are currently allowed
+	 * as values.
+	 * </p>
 	 */
-	public Optional<String> getAdditionalProperty(String theKey) {
+	public Optional<String> getAttribute(String theKey) {
 		Validate.notBlank(theKey);
-		if (myAdditionalProperties == null) {
+		if (myAttributes == null) {
 			return Optional.empty();
 		}
-		return Optional.ofNullable(myAdditionalProperties.get(theKey));
+		return Optional.ofNullable(myAttributes.get(theKey));
 	}
 
 	/**
-	 * Sets an additional property stored in this message.
+	 * Sets an attribute stored in this message.
 	 * <p>
-	 * Additional properties are just a spot for user data of any kind to be
-	 * added to the message for pasing along the subscription processing
+	 * Attributes are just a spot for user data of any kind to be
+	 * added to the message for passing along the subscription processing
 	 * pipeline (typically by interceptors). Values will be carried from the beginning to the end.
+	 * </p>
+	 * <p>
+	 * Note that messages are designed to be passed into queueing systems
+	 * and serialized as JSON. As a result, only strings are currently allowed
+	 * as values.
 	 * </p>
 	 *
 	 * @param theKey   The key (must not be null or blank)
 	 * @param theValue The value (must not be null)
 	 */
-	public void setAdditionalProperty(String theKey, String theValue) {
+	public void setAttribute(String theKey, String theValue) {
 		Validate.notBlank(theKey);
 		Validate.notNull(theValue);
-		if (myAdditionalProperties == null) {
-			myAdditionalProperties = new HashMap<>();
+		if (myAttributes == null) {
+			myAttributes = new HashMap<>();
 		}
-		myAdditionalProperties.put(theKey, theValue);
+		myAttributes.put(theKey, theValue);
 	}
 
 	/**
-	 * Copies any additional properties forward.
-	 * <p>
-	 * Additional properties are just a spot for user data of any kind to be
-	 * added to the message for pasing along the subscription processing
-	 * pipeline (typically by interceptors). Values will be carried from the beginning to the end.
-	 * </p>
+	 * Copies any attributes from the given message into this messsage.
+	 *
+	 * @see #setAttribute(String, String)
+	 * @see #getAttribute(String)
 	 */
 	public void copyAdditionalPropertiesFrom(BaseResourceMessage theMsg) {
-		if (theMsg.myAdditionalProperties != null) {
-			if (myAdditionalProperties == null) {
-				myAdditionalProperties = new HashMap<>();
+		if (theMsg.myAttributes != null) {
+			if (myAttributes == null) {
+				myAttributes = new HashMap<>();
 			}
-			myAdditionalProperties.putAll(theMsg.myAdditionalProperties);
+			myAttributes.putAll(theMsg.myAttributes);
 		}
 	}
 }

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/BaseResourceMessage.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/BaseResourceMessage.java
@@ -1,0 +1,67 @@
+package ca.uhn.fhir.jpa.subscription.module.subscriber;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.Validate;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@SuppressWarnings("WeakerAccess")
+public abstract class BaseResourceMessage implements IResourceMessage {
+	@JsonProperty("additionalProperties")
+	private Map<String, String> myAdditionalProperties;
+
+	/**
+	 * Returns an additional property stored in this message.
+	 * <p>
+	 * Additional properties are just a spot for user data of any kind to be
+	 * added to the message for pasing along the subscription processing
+	 * pipeline (typically by interceptors). Values will be carried from the beginning to the end.
+	 * </p>
+	 */
+	public Optional<String> getAdditionalProperty(String theKey) {
+		Validate.notBlank(theKey);
+		if (myAdditionalProperties == null) {
+			return Optional.empty();
+		}
+		return Optional.ofNullable(myAdditionalProperties.get(theKey));
+	}
+
+	/**
+	 * Sets an additional property stored in this message.
+	 * <p>
+	 * Additional properties are just a spot for user data of any kind to be
+	 * added to the message for pasing along the subscription processing
+	 * pipeline (typically by interceptors). Values will be carried from the beginning to the end.
+	 * </p>
+	 *
+	 * @param theKey   The key (must not be null or blank)
+	 * @param theValue The value (must not be null)
+	 */
+	public void setAdditionalProperty(String theKey, String theValue) {
+		Validate.notBlank(theKey);
+		Validate.notNull(theValue);
+		if (myAdditionalProperties == null) {
+			myAdditionalProperties = new HashMap<>();
+		}
+		myAdditionalProperties.put(theKey, theValue);
+	}
+
+	/**
+	 * Copies any additional properties forward.
+	 * <p>
+	 * Additional properties are just a spot for user data of any kind to be
+	 * added to the message for pasing along the subscription processing
+	 * pipeline (typically by interceptors). Values will be carried from the beginning to the end.
+	 * </p>
+	 */
+	public void copyAdditionalPropertiesFrom(BaseResourceMessage theMsg) {
+		if (theMsg.myAdditionalProperties != null) {
+			if (myAdditionalProperties == null) {
+				myAdditionalProperties = new HashMap<>();
+			}
+			myAdditionalProperties.putAll(theMsg.myAdditionalProperties);
+		}
+	}
+}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/ResourceDeliveryMessage.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/ResourceDeliveryMessage.java
@@ -9,9 +9,9 @@ package ca.uhn.fhir.jpa.subscription.module.subscriber;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,15 +28,21 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
+import org.apache.commons.lang3.Validate;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.IIdType;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @SuppressWarnings("WeakerAccess")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(creatorVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE)
-public class ResourceDeliveryMessage implements IResourceMessage {
+public class ResourceDeliveryMessage extends BaseResourceMessage implements IResourceMessage {
 
 	@JsonIgnore
 	private transient CanonicalSubscription mySubscription;

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriber.java
@@ -104,6 +104,7 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 		Collection<ActiveSubscription> subscriptions = mySubscriptionRegistry.getAll();
 
 		ourLog.trace("Testing {} subscriptions for applicability", subscriptions.size());
+		boolean resourceMatched = false;
 
 		for (ActiveSubscription nextActiveSubscription : subscriptions) {
 
@@ -148,10 +149,16 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 			ResourceDeliveryJsonMessage wrappedMsg = new ResourceDeliveryJsonMessage(deliveryMsg);
 			MessageChannel deliveryChannel = nextActiveSubscription.getSubscribableChannel();
 			if (deliveryChannel != null) {
+				resourceMatched = true;
 				deliveryChannel.send(wrappedMsg);
 			} else {
 				ourLog.warn("Do not have delivery channel for subscription {}", nextActiveSubscription.getIdElement(myFhirContext));
 			}
+		}
+
+		if (!resourceMatched) {
+			// Interceptor call: SUBSCRIPTION_RESOURCE_MATCHED
+			myInterceptorBroadcaster.callHooks(Pointcut.SUBSCRIPTION_RESOURCE_DID_NOT_MATCH_ANY_SUBSCRIPTIONS, theMsg);
 		}
 	}
 

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriber.java
@@ -72,9 +72,16 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 	}
 
 	public void matchActiveSubscriptionsAndDeliver(ResourceModifiedMessage theMsg) {
+
+		// Interceptor call: SUBSCRIPTION_BEFORE_PERSISTED_RESOURCE_CHECKED
+		if (!myInterceptorBroadcaster.callHooks(Pointcut.SUBSCRIPTION_BEFORE_PERSISTED_RESOURCE_CHECKED, theMsg)) {
+			return;
+		}
+
 		try {
 			doMatchActiveSubscriptionsAndDeliver(theMsg);
 		} finally {
+			// Interceptor call: SUBSCRIPTION_AFTER_PERSISTED_RESOURCE_CHECKED
 			myInterceptorBroadcaster.callHooks(Pointcut.SUBSCRIPTION_AFTER_PERSISTED_RESOURCE_CHECKED, theMsg);
 		}
 	}
@@ -128,6 +135,7 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 			deliveryMsg.setPayload(myFhirContext, payload);
 			deliveryMsg.setSubscription(nextActiveSubscription.getSubscription());
 			deliveryMsg.setOperationType(theMsg.getOperationType());
+			deliveryMsg.copyAdditionalPropertiesFrom(theMsg);
 			if (payload == null) {
 				deliveryMsg.setPayloadId(theMsg.getId(myFhirContext));
 			}

--- a/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriber.java
+++ b/hapi-fhir-jpaserver-subscription/src/main/java/ca/uhn/fhir/jpa/subscription/module/subscriber/SubscriptionMatchingSubscriber.java
@@ -140,6 +140,11 @@ public class SubscriptionMatchingSubscriber implements MessageHandler {
 				deliveryMsg.setPayloadId(theMsg.getId(myFhirContext));
 			}
 
+			// Interceptor call: SUBSCRIPTION_RESOURCE_MATCHED
+			if (!myInterceptorBroadcaster.callHooks(Pointcut.SUBSCRIPTION_RESOURCE_MATCHED, deliveryMsg, nextActiveSubscription.getSubscription(), matchResult)) {
+				return;
+			}
+
 			ResourceDeliveryJsonMessage wrappedMsg = new ResourceDeliveryJsonMessage(deliveryMsg);
 			MessageChannel deliveryChannel = nextActiveSubscription.getSubscribableChannel();
 			if (deliveryChannel != null) {

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/ResourceDeliveryMessageTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/ResourceDeliveryMessageTest.java
@@ -1,0 +1,25 @@
+package ca.uhn.fhir.jpa.subscription.module.subscriber;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ResourceDeliveryMessageTest {
+
+	@Test
+	public void testAdditionalProperties() throws IOException {
+		ResourceDeliveryMessage msg = new ResourceDeliveryMessage();
+		msg.setAdditionalProperty("foo1", "bar");
+		msg.setAdditionalProperty("foo2", "baz");
+		String encoded = new ObjectMapper().writeValueAsString(msg);
+
+		msg = new ObjectMapper().readValue(encoded, ResourceDeliveryMessage.class);
+		assertEquals("bar", msg.getAdditionalProperty("foo1").get());
+		assertEquals("baz", msg.getAdditionalProperty("foo2").get());
+		assertEquals(false, msg.getAdditionalProperty("foo3").isPresent());
+	}
+
+}

--- a/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/ResourceDeliveryMessageTest.java
+++ b/hapi-fhir-jpaserver-subscription/src/test/java/ca/uhn/fhir/jpa/subscription/module/subscriber/ResourceDeliveryMessageTest.java
@@ -12,14 +12,14 @@ public class ResourceDeliveryMessageTest {
 	@Test
 	public void testAdditionalProperties() throws IOException {
 		ResourceDeliveryMessage msg = new ResourceDeliveryMessage();
-		msg.setAdditionalProperty("foo1", "bar");
-		msg.setAdditionalProperty("foo2", "baz");
+		msg.setAttribute("foo1", "bar");
+		msg.setAttribute("foo2", "baz");
 		String encoded = new ObjectMapper().writeValueAsString(msg);
 
 		msg = new ObjectMapper().readValue(encoded, ResourceDeliveryMessage.class);
-		assertEquals("bar", msg.getAdditionalProperty("foo1").get());
-		assertEquals("baz", msg.getAdditionalProperty("foo2").get());
-		assertEquals(false, msg.getAdditionalProperty("foo3").isPresent());
+		assertEquals("bar", msg.getAttribute("foo1").get());
+		assertEquals("baz", msg.getAttribute("foo2").get());
+		assertEquals(false, msg.getAttribute("foo3").isPresent());
 	}
 
 }


### PR DESCRIPTION
This PR adds a new interceptor that outputs detailed information about the subscription processing pipeline. 

As a part of this change, I also added several new pointcuts to the subscription pipeline, and a spot in the JSON objects that are queued for storing user data (so that interceptors can add their own data to the messages).

Example output from a unit test:

```
  [SUBS10] Resource Subscription/1/_history/1 was submitted to the processing pipeline
  [SUBS20] Checking resource Subscription/1/_history/1 (op=CREATE) for matching subscriptions
  [SUBS35] Resource Subscription/1/_history/1 did not match any subscriptions
  [SUBS10] Resource Subscription/2/_history/1 was submitted to the processing pipeline
  [SUBS20] Checking resource Subscription/2/_history/1 (op=CREATE) for matching subscriptions
  [SUBS35] Resource Subscription/2/_history/1 did not match any subscriptions
  [SUBS10] Resource Subscription/1/_history/2 was submitted to the processing pipeline
  [SUBS20] Checking resource Subscription/1/_history/2 (op=UPDATE) for matching subscriptions
  [SUBS35] Resource Subscription/1/_history/2 did not match any subscriptions
  [SUBS10] Resource Subscription/2/_history/2 was submitted to the processing pipeline
  [SUBS20] Checking resource Subscription/2/_history/2 (op=UPDATE) for matching subscriptions
  [SUBS35] Resource Subscription/2/_history/2 did not match any subscriptions
  [SUBS10] Resource Observation/3/_history/1 was submitted to the processing pipeline
  [SUBS20] Checking resource Observation/3/_history/1 (op=CREATE) for matching subscriptions
  [SUBS30] Resource Observation/3/_history/1 matched by subscription Subscription/1 (memory match=true)
  [SUBS40] Delivering resource Observation/3/_history/1 for subscription Subscription/1 to channel of type RESTHOOK to endpoint http://localhost:37475/fhir/context
  [SUBS50] Finished delivery of resource Observation/3/_history/1 for subscription Subscription/1 to channel of type RESTHOOK - Total processing time: 31ms
  [SUBS10] Resource Subscription/2/_history/3 was submitted to the processing pipeline
  [SUBS20] Checking resource Subscription/2/_history/3 (op=UPDATE) for matching subscriptions
  [SUBS35] Resource Subscription/2/_history/3 did not match any subscriptions
  [SUBS10] Resource Observation/4/_history/1 was submitted to the processing pipeline
  [SUBS20] Checking resource Observation/4/_history/1 (op=CREATE) for matching subscriptions
  [SUBS30] Resource Observation/4/_history/1 matched by subscription Subscription/1 (memory match=true)
  [SUBS40] Delivering resource Observation/4/_history/1 for subscription Subscription/1 to channel of type RESTHOOK to endpoint http://localhost:37475/fhir/context
  [SUBS50] Finished delivery of resource Observation/4/_history/1 for subscription Subscription/1 to channel of type RESTHOOK - Total processing time: 17ms
  [SUBS30] Resource Observation/4/_history/1 matched by subscription Subscription/2 (memory match=true)
  [SUBS40] Delivering resource Observation/4/_history/1 for subscription Subscription/2 to channel of type RESTHOOK to endpoint http://localhost:37475/fhir/context
  [SUBS50] Finished delivery of resource Observation/4/_history/1 for subscription Subscription/2 to channel of type RESTHOOK - Total processing time: 25ms
```