### PR TITLE
Subscriptions are not enabled in JPA Server Example 3.7.0.

### DIFF
--- a/hapi-fhir-jpaserver-example/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfig.java
+++ b/hapi-fhir-jpaserver-example/src/main/java/ca/uhn/fhir/jpa/demo/FhirServerConfig.java
@@ -11,6 +11,7 @@ import ca.uhn.fhir.jpa.util.DerbyTenSevenHapiFhirDialect;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.lang3.time.DateUtils;
 import org.hibernate.jpa.HibernatePersistenceProvider;
+import org.hl7.fhir.instance.model.Subscription;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowire;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,10 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	public DaoConfig daoConfig() {
 		DaoConfig retVal = new DaoConfig();
 		retVal.setAllowMultipleDelete(true);
+		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.WEBSOCKET);
+		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.RESTHOOK);
+		retVal.addSupportedSubscriptionType(Subscription.SubscriptionChannelType.EMAIL);
+		retVal.setSubscriptionMatchingEnabled(true);
 		return retVal;
 	}
 
@@ -54,7 +59,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	/**
 	 * The following bean configures the database connection. The 'url' property value of "jdbc:derby:directory:jpaserver_derby_files;create=true" indicates that the server should save resources in a
 	 * directory called "jpaserver_derby_files".
-	 * 
+	 *
 	 * A URL to a remote database could also be placed here, along with login credentials and other properties supported by BasicDataSource.
 	 */
 	@Bean(destroyMethod = "close")


### PR DESCRIPTION
Unlike in JPA Server Example 3.6.0 and previous versions, subscriptions are not enabled in JPA Server Example 3.7.0 (after the change of subscription handling). This pull request enables the same subscription types that were also enabled in JPA Server Example 3.6.0. 