### PR TITLE
Minor improvement to VersionConverter_10_30, converts DiagnosticReport `request` and `basedOn`

### DIFF
--- a/hapi-fhir-converter/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_30.java
+++ b/hapi-fhir-converter/src/main/java/org/hl7/fhir/convertors/VersionConvertor_10_30.java
@@ -5784,8 +5784,8 @@ public class VersionConvertor_10_30 {
     tgt.setEffective(convertType(src.getEffective()));
     tgt.setIssued(src.getIssued());
 //    tgt.setPerformer(convertReference(src.getPerformer()));
-//    for (org.hl7.fhir.instance.model.Reference t : src.getRequest())
-//      tgt.addRequest(convertReference(t));
+    for (org.hl7.fhir.instance.model.Reference t : src.getRequest())
+      tgt.addBasedOn(convertReference(t));
     for (org.hl7.fhir.instance.model.Reference t : src.getSpecimen())
       tgt.addSpecimen(convertReference(t));
     for (org.hl7.fhir.instance.model.Reference t : src.getResult())
@@ -5817,8 +5817,8 @@ public class VersionConvertor_10_30 {
     tgt.setEffective(convertType(src.getEffective()));
     tgt.setIssued(src.getIssued());
 //    tgt.setPerformer(convertReference(src.getPerformer()));
-//    for (org.hl7.fhir.dstu3.model.Reference t : src.getRequest())
-//      tgt.addRequest(convertReference(t));
+    for (org.hl7.fhir.dstu3.model.Reference t : src.getBasedOn())
+      tgt.addRequest(convertReference(t));
     for (org.hl7.fhir.dstu3.model.Reference t : src.getSpecimen())
       tgt.addSpecimen(convertReference(t));
     for (org.hl7.fhir.dstu3.model.Reference t : src.getResult())


### PR DESCRIPTION
Modify DiagnosticReport converter to handle request <-> basedOn difference between 1.0.2 and 3.0.0