### PR TITLE
Issue 1268: Fix date range missing STARTS_AFTER and ENDS_BEFORE handling

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/DateRangeParam.java
@@ -167,6 +167,7 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 			switch (theParsed.getPrefix()) {
 				case GREATERTHAN:
 				case GREATERTHAN_OR_EQUALS:
+				case STARTS_AFTER:
 					if (myLowerBound != null) {
 						throw new InvalidRequestException("Can not have multiple date range parameters for the same param that specify a lower bound");
 					}
@@ -174,6 +175,7 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 					break;
 				case LESSTHAN:
 				case LESSTHAN_OR_EQUALS:
+				case ENDS_BEFORE:
 					if (myUpperBound != null) {
 						throw new InvalidRequestException("Can not have multiple date range parameters for the same param that specify an upper bound");
 					}
@@ -327,12 +329,10 @@ public class DateRangeParam implements IQueryParameterAnd<DateParam> {
 			switch (myUpperBound.getPrefix()) {
 				case LESSTHAN:
 				case ENDS_BEFORE:
-					retVal = new Date(retVal.getTime() - 1L);
+					retVal = myUpperBound.getPrecision().add(retVal, -1);
 					break;
 				case EQUAL:
 				case LESSTHAN_OR_EQUALS:
-					retVal = myUpperBound.getPrecision().add(retVal, 1);
-					retVal = new Date(retVal.getTime() - 1L);
 					break;
 				case GREATERTHAN_OR_EQUALS:
 				case GREATERTHAN:

--- a/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
+++ b/hapi-fhir-base/src/test/java/ca/uhn/fhir/rest/param/DateRangeParamTest.java
@@ -1,18 +1,22 @@
 package ca.uhn.fhir.rest.param;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.rest.api.QualifiedParamList;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjuster;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class DateRangeParamTest {
@@ -63,5 +67,57 @@ public class DateRangeParamTest {
 		dateRangeParam.setValuesAsQueryTokens(fhirContext, "_lastUpdated", params);
 
 		assertTrue(dateRangeParam.isEmpty());
+	}
+
+	private void doLowerBoundTest(String prefix, TemporalAdjuster resultAdjuster) {
+		Instant timestamp = Instant.parse("2013-01-01T13:28:17.000Z");
+		QualifiedParamList qualifiedParamList = new QualifiedParamList(1);
+		qualifiedParamList.add(prefix + timestamp.toString());
+
+		DateRangeParam dateRangeParam = new DateRangeParam();
+		dateRangeParam.setValuesAsQueryTokens(fhirContext, "_lastUpdated", Collections.singletonList(qualifiedParamList));
+
+		assertEquals(dateRangeParam.getLowerBoundAsInstant().toInstant(), resultAdjuster.adjustInto(timestamp));
+	}
+
+	@Test
+	public void testLowerBoundWithPrefixGreaterThan() {
+		doLowerBoundTest("gt", instant -> instant.plus(1, ChronoUnit.SECONDS));
+	}
+
+	@Test
+	public void testLowerBoundWithPrefixGreaterThanEqual() {
+		doLowerBoundTest("ge", instant -> instant);
+	}
+
+	@Test
+	public void testLowerBoundWithPrefixStartsAfter() {
+		doLowerBoundTest("sa", instant -> instant.plus(1, ChronoUnit.SECONDS));
+	}
+
+	private void doUpperBoundTest(String prefix, TemporalAdjuster resultAdjuster) {
+		Instant timestamp = Instant.parse("2013-01-01T13:28:17.000Z");
+		QualifiedParamList qualifiedParamList = new QualifiedParamList(1);
+		qualifiedParamList.add(prefix + timestamp.toString());
+
+		DateRangeParam dateRangeParam = new DateRangeParam();
+		dateRangeParam.setValuesAsQueryTokens(fhirContext, "_lastUpdated", Collections.singletonList(qualifiedParamList));
+
+		assertEquals(dateRangeParam.getUpperBoundAsInstant().toInstant(), (Instant)resultAdjuster.adjustInto(timestamp));
+	}
+
+	@Test
+	public void testUpperBoundWithPrefixLessThan() {
+		doUpperBoundTest("lt", instant -> instant.minus(1, ChronoUnit.SECONDS));
+	}
+
+	@Test
+	public void testUpperBoundWithPrefixLessThanEqual() {
+		doUpperBoundTest("le", instant -> instant);
+	}
+
+	@Test
+	public void testBoundsWithPrefixEndsBefore() {
+		doUpperBoundTest("eb", instant -> instant.minus(1, ChronoUnit.SECONDS));
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/jamesagnew/hapi-fhir/issues/1268

It looks like DateRangeParam handles "sa" and "eb" fine, the enum values just aren't included in the `addParam` method, so you can't use them. 

The other change here is to make lower bound and upper bound to instant handling more alike. When getting the lower bound as a Date in getLowerBoundAsInstant, and the prefix is "gt" or "sa", we add one unit of the precision to the lower bound. So e.g. if the range is gt19:00:58, and the precision is 1s, the lower bound instant would be 19:00:59.

The upper bound to instant handling was pretty different. When getting the upper bound and the prefix is "lt" or "eb", getUpperBoundToInstant subtracts 1 milliscond instead of using the specified precision. So upper bound for lt19:00:58 would be 19:00:57.999.

Additionally the handling for "eq" on upper bounds is weird. For lower bounds, we just pass the original timestamp through, so if you do "eq19:00:58", getLowerBoundAsInstant would return "19:00:58". For upper bounds, we instead add 1 unit of precision, then subtract a millisecond. If the precision is 1 second, we would therefore get that "eq19:00:58" works out to an upper bound instant of "19:00:57.999".

I've changed the upper bound handling to be like the lower bound handling.