### PR TITLE
Preserve contained resource meta when encoding to dao

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -161,7 +161,7 @@ public abstract class BaseParser implements IParser {
 							 */
 							if (myNext.getDef().getElementName().equals("id")) {
 								myNext = null;
-							} else if (!myNext.shouldBeEncoded()) {
+							} else if (!myNext.shouldBeEncoded() && !theContainedResource) {
 								myNext = null;
 							} else if (isSummaryMode() && !myNext.getDef().isSummary()) {
 								myNext = null;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -47,6 +47,8 @@ public abstract class BaseParser implements IParser {
 
 	private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(BaseParser.class);
 
+	private static final Set<String> notEncodeForContainedResource = new HashSet<>(Arrays.asList("security", "versionId", "lastUpdated"));
+
 	private ContainedResources myContainedResources;
 	private boolean myEncodeElementsAppliesToChildResourcesOnly;
 	private FhirContext myContext;
@@ -161,7 +163,7 @@ public abstract class BaseParser implements IParser {
 							 */
 							if (myNext.getDef().getElementName().equals("id")) {
 								myNext = null;
-							} else if (!myNext.shouldBeEncoded() && !theContainedResource) {
+							} else if (!myNext.shouldBeEncoded(theContainedResource)) {
 								myNext = null;
 							} else if (isSummaryMode() && !myNext.getDef().isSummary()) {
 								myNext = null;
@@ -176,7 +178,6 @@ public abstract class BaseParser implements IParser {
 									myNext = null;
 								}
 							}
-
 						} while (myNext == null);
 
 						myHasNext = true;
@@ -1157,13 +1158,16 @@ public abstract class BaseParser implements IParser {
 			return myParent;
 		}
 
-		public boolean shouldBeEncoded() {
+		public boolean shouldBeEncoded(boolean theContainedResource) {
 			boolean retVal = true;
 			if (myEncodeElements != null) {
 				retVal = checkIfParentShouldBeEncodedAndBuildPath();
 			}
 			if (retVal && myDontEncodeElements != null) {
 				retVal = !checkIfParentShouldNotBeEncodedAndBuildPath();
+			}
+			if (theContainedResource) {
+				retVal = !notEncodeForContainedResource.contains(myDef.getElementName());
 			}
 
 			return retVal;


### PR DESCRIPTION
The contained resource meta data is not persisted when saving parent resource to database. When persisting resource to database the following setting is used on the database:
parser.setDontEncodeElements(ResourceMetaParams.EXCLUDE_ELEMENTS_IN_ENCODED);

This is okay for the parent resource beause the meta data is saved somewhere else, but for the contained resource the meta is just lost when not persisting.

Test to reproduce problem: https://groups.google.com/forum/#!topic/hapi-fhir/uxVxxldqsBI