### PR TITLE
Keep original baseUrl (if it exist) when setting Content_Location in header

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServerUtils.java
@@ -735,8 +735,12 @@ public class RestfulServerUtils {
 			fullId = theOperationResourceId;
 		} else if (theResource != null) {
 			if (theResource.getIdElement() != null) {
-				IIdType resourceId = theResource.getIdElement();
-				fullId = fullyQualifyResourceIdOrReturnNull(theServer, theResource, serverBase, resourceId);
+				if (theResource.getIdElement().hasBaseUrl()) {
+					fullId = theResource.getIdElement();
+				} else {
+					IIdType resourceId = theResource.getIdElement();
+					fullId = fullyQualifyResourceIdOrReturnNull(theServer, theResource, serverBase, resourceId);
+				}
 			}
 		}
 


### PR DESCRIPTION
When returning a resource with an existing baseUrl then keep it when setting Content_Location in the header.
This can happen when a service returns a resource that belongs on another service.