### PR TITLE
Resolve #1320: "import-csv-to-conceptmap is failing unexpectedly."

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/AbstractImportExportCsvConceptMapCommand.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/AbstractImportExportCsvConceptMapCommand.java
@@ -27,10 +27,19 @@ import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
@@ -62,6 +71,29 @@ public abstract class AbstractImportExportCsvConceptMapCommand extends BaseComma
 			.sorted()
 			.collect(Collectors.joining(", "));
 		addRequiredOption(theOptions, FHIR_VERSION_PARAM, FHIR_VERSION_PARAM_LONGOPT, FHIR_VERSION_PARAM_NAME, FHIR_VERSION_PARAM_DESC + versions);
+	}
+
+	protected BufferedReader getBufferedReader() throws IOException {
+		return new BufferedReader(getInputStreamReader());
+	}
+
+	protected InputStreamReader getInputStreamReader() throws IOException {
+		return new InputStreamReader(getBOMInputStream());
+	}
+
+	protected BOMInputStream getBOMInputStream() throws IOException {
+		return new BOMInputStream(
+			getInputStream(),
+			false,
+			ByteOrderMark.UTF_8,
+			ByteOrderMark.UTF_16BE,
+			ByteOrderMark.UTF_16LE,
+			ByteOrderMark.UTF_32BE,
+			ByteOrderMark.UTF_32LE);
+	}
+
+	protected InputStream getInputStream() throws IOException {
+		return Files.newInputStream(Paths.get(file), StandardOpenOption.READ);
 	}
 
 	@Override

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/ImportCsvToConceptMapCommand.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/ImportCsvToConceptMapCommand.java
@@ -39,8 +39,6 @@ import org.hl7.fhir.r4.model.UriType;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -166,8 +164,7 @@ public class ImportCsvToConceptMapCommand extends AbstractImportExportCsvConcept
 		ourLog.info("Converting CSV to ConceptMap...");
 		ConceptMap retVal = new ConceptMap();
 		try (
-			// FIXME: DM 2019-05-27 - Need to use BOMInputStream to handle byte order marks.
-			Reader reader = Files.newBufferedReader(Paths.get(file));
+			Reader reader = getBufferedReader();
 			CSVParser csvParser = new CSVParser(
 				reader,
 				CSVFormat

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/ImportCsvToConceptMapCommand.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/main/java/ca/uhn/fhir/cli/ImportCsvToConceptMapCommand.java
@@ -166,6 +166,7 @@ public class ImportCsvToConceptMapCommand extends AbstractImportExportCsvConcept
 		ourLog.info("Converting CSV to ConceptMap...");
 		ConceptMap retVal = new ConceptMap();
 		try (
+			// FIXME: DM 2019-05-27 - Need to use BOMInputStream to handle byte order marks.
 			Reader reader = Files.newBufferedReader(Paths.get(file));
 			CSVParser csvParser = new CSVParser(
 				reader,

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/ImportCsvToConceptMapCommandR4Test.java
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/java/ca/uhn/fhir/cli/ImportCsvToConceptMapCommandR4Test.java
@@ -388,7 +388,7 @@ public class ImportCsvToConceptMapCommandR4Test {
 		Bundle response = ourClient
 			.search()
 			.forResource(ConceptMap.class)
-			.where(ConceptMap.URL.matches().value(CM_URL))
+			.where(ConceptMap.URL.matches().value("http://loinc.org/cm/loinc-to-phenx"))
 			.returnBundle(Bundle.class)
 			.execute();
 
@@ -402,7 +402,7 @@ public class ImportCsvToConceptMapCommandR4Test {
 		assertEquals("http://loinc.org", conceptMap.getSourceUriType().getValueAsString());
 		assertEquals("http://phenxtoolkit.org", conceptMap.getTargetUriType().getValueAsString());
 
-		assertEquals(3, conceptMap.getGroup().size());
+		assertEquals(1, conceptMap.getGroup().size());
 
 		ConceptMapGroupComponent group = conceptMap.getGroup().get(0);
 		assertEquals("http://loinc.org", group.getSource());
@@ -410,7 +410,7 @@ public class ImportCsvToConceptMapCommandR4Test {
 		assertEquals("http://phenxtoolkit.org", group.getTarget());
 		assertNull(group.getTargetVersion());
 
-		assertEquals(4, group.getElement().size());
+		assertEquals(1, group.getElement().size());
 
 		SourceElementComponent source = group.getElement().get(0);
 		assertEquals("65191-9", source.getCode());
@@ -436,7 +436,7 @@ public class ImportCsvToConceptMapCommandR4Test {
 		response = ourClient
 			.search()
 			.forResource(ConceptMap.class)
-			.where(ConceptMap.URL.matches().value(CM_URL))
+			.where(ConceptMap.URL.matches().value("http://loinc.org/cm/loinc-to-phenx"))
 			.returnBundle(Bundle.class)
 			.execute();
 

--- a/hapi-fhir-cli/hapi-fhir-cli-api/src/test/resources/loinc-to-phenx.csv
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/src/test/resources/loinc-to-phenx.csv
@@ -1,0 +1,2 @@
+﻿SOURCE_CODE_SYSTEM,SOURCE_CODE_SYSTEM_VERSION,TARGET_CODE_SYSTEM,TARGET_CODE_SYSTEM_VERSION,SOURCE_CODE,SOURCE_DISPLAY,TARGET_CODE,TARGET_DISPLAY,EQUIVALENCE,COMMENT
+http://loinc.org,,http://phenxtoolkit.org,,65191-9,"During the past 30 days, about how often did you feel restless or fidgety [Kessler 6 Distress]",PX121301010300,PX121301_Restless,equivalent,

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -226,8 +226,8 @@
 				@zaewonyx for the PR!
 			</action>
 			<action type="fix" issue="1320">
-				The HAPI FHIR CLI import-csv-to-conceptmap command was not accounting for byte order marks in CSV (e.g. some
-				Excel CSV files). This has been fixed.
+				The HAPI FHIR CLI import-csv-to-conceptmap command was not accounting for byte order marks in
+				CSV files (e.g. some Excel CSV files). This has been fixed.
 			</action>
 		</release>
 		<release version="3.7.0" date="2019-02-06" description="Gale">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -225,6 +225,10 @@
 				Two incorrect package declarations in unit tests were corrected. Thanks to github user
 				@zaewonyx for the PR!
 			</action>
+			<action type="fix" issue="1320">
+				The HAPI FHIR CLI import-csv-to-conceptmap was not accounting for byte order marks in CSV (e.g. some
+				Excel CSV files). This has been fixed.
+			</action>
 		</release>
 		<release version="3.7.0" date="2019-02-06" description="Gale">
 			<action type="add">

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -226,7 +226,7 @@
 				@zaewonyx for the PR!
 			</action>
 			<action type="fix" issue="1320">
-				The HAPI FHIR CLI import-csv-to-conceptmap was not accounting for byte order marks in CSV (e.g. some
+				The HAPI FHIR CLI import-csv-to-conceptmap command was not accounting for byte order marks in CSV (e.g. some
 				Excel CSV files). This has been fixed.
 			</action>
 		</release>


### PR DESCRIPTION
The HAPI FHIR CLI import-csv-to-conceptmap command was not accounting for byte order marks in CSV files (e.g. some Excel CSV files). This has been fixed.