### PR TITLE
Maven build tweaks to enable clean build

### DIFF
--- a/hapi-fhir-test-utilities/pom.xml
+++ b/hapi-fhir-test-utilities/pom.xml
@@ -5,6 +5,7 @@
         <groupId>ca.uhn.hapi.fhir</groupId>
         <artifactId>hapi-deployable-pom</artifactId>
         <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../hapi-deployable-pom/pom.xml</relativePath>        
     </parent>
     
     <artifactId>hapi-fhir-test-utilities</artifactId>

--- a/hapi-fhir-testpage-overlay/pom.xml
+++ b/hapi-fhir-testpage-overlay/pom.xml
@@ -93,12 +93,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- Java -->
-		<dependency>
-			<groupId>javax.annotation</groupId>
-			<artifactId>javax.annotation-api</artifactId>
-		</dependency>
-
 		<!-- Spring -->
 		<dependency>
 			<groupId>org.springframework</groupId>


### PR DESCRIPTION
I work on OSX (10.14.5) and use maven 3.5.2 Java  1.8.0_144. 
Was getting a couple errors on an initial build keeping it from getting very far. Here was the mvn output:

```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for ca.uhn.hapi.fhir:hapi-fhir-test-utilities:[unknown-version]: Could not find artifact ca.uhn.hapi.fhir:hapi-deployable-pom:pom:4.0.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 13
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: javax.annotation:javax.annotation-api:jar -> duplicate declaration of version (?) @ ca.uhn.hapi.fhir:hapi-fhir-testpage-overlay:[unknown-version], /Users/gary/repos/hapi-fhir/hapi-fhir-testpage-overlay/pom.xml, line 97, column 15
[WARNING] 'build.plugins.plugin.version' for org.owasp:dependency-check-maven is missing. @ ca.uhn.hapi.fhir:hapi-fhir-jpaserver-cds-example:[unknown-version], /Users/gary/repos/hapi-fhir/example-projects/hapi-fhir-jpaserver-cds-example/pom.xml, line 246, column 12
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project ca.uhn.hapi.fhir:hapi-fhir-test-utilities:[unknown-version] (/Users/gary/repos/hapi-fhir/hapi-fhir-test-utilities/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for ca.uhn.hapi.fhir:hapi-fhir-test-utilities:[unknown-version]: Could not find artifact ca.uhn.hapi.fhir:hapi-deployable-pom:pom:4.0.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 4, column 13 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException


```

Loaded the project into NetBeans and the IDE pointed out the issues pretty quickly. I tweaked the 2 POM files for 2 sub-projects to stop the IDE from complaining on the builds. After these changes, the build went flawlessly.

The first change to **hapi-fhir-testpage-overlay/pom.xml** was to remove a redundant dependency to javax.annotation.
The second change to **hapi-fhir-test-utilities/pom.xml** was to add a **relativePath** tag to the **parent** tag so that the project could build.

Cheers!