### PR TITLE
Update identifier example type

### DIFF
--- a/hapi-fhir-validation-resources-dstu2/src/main/resources/org/hl7/fhir/instance/model/profile/identifier.profile.xml
+++ b/hapi-fhir-validation-resources-dstu2/src/main/resources/org/hl7/fhir/instance/model/profile/identifier.profile.xml
@@ -155,7 +155,7 @@
    <type>
     <code value="uri"/>
    </type>
-   <exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri"/>
+   <exampleString value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri"/>
    <isSummary value="true"/>
    <mapping>
     <identity value="v2"/>
@@ -335,7 +335,7 @@
    <type>
     <code value="uri"/>
    </type>
-   <exampleUri value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri"/>
+   <exampleString value="http://www.acme.com/identifiers/patient or urn:ietf:rfc:3986 if the Identifier.value itself is a full uri"/>
    <isSummary value="true"/>
    <mapping>
     <identity value="v2"/>


### PR DESCRIPTION
This change updates the example definition for the `Identifier` datatype to use a String type, rather than URI. This should address an issue that we're facing when creating profiles on top of this definition:

`StructureDefinition.snapshot.element[16].example.valueUri,message=URI values cannot have whitespace`

I'm sure there are other changes that I'm missing, happy to expand the PR to address them.

Thanks for the excellent work!