### PR TITLE
Issue-1387: Read version from resource meta when deciding whether to …

### DIFF
--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/ETagServerR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/rest/server/ETagServerR4Test.java
@@ -10,6 +10,7 @@ import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.rest.api.EncodingEnum;
 import ca.uhn.fhir.rest.api.MethodOutcome;
 import ca.uhn.fhir.rest.server.exceptions.PreconditionFailedException;
+import ca.uhn.fhir.test.utilities.JettyUtil;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
@@ -33,9 +34,8 @@ import org.junit.*;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
-
-import ca.uhn.fhir.test.utilities.JettyUtil;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class ETagServerR4Test {
 
@@ -58,12 +58,23 @@ public class ETagServerR4Test {
 
   @Test
   public void testAutomaticNotModified() throws Exception {
-    ourLastModifiedDate = new InstantDt("2012-11-25T02:34:45.2222Z").getValue();
+    doTestAutomaticNotModified();
+  }
 
-    HttpGet httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
-    httpGet.addHeader(Constants.HEADER_IF_NONE_MATCH, "\"222\"");
-    HttpResponse status = ourClient.execute(httpGet);
-    assertEquals(Constants.STATUS_HTTP_304_NOT_MODIFIED, status.getStatusLine().getStatusCode());
+  @Test
+  public void testAutomaticNotModifiedFromVersionInMeta() throws Exception {
+  	  ourPutVersionInPatientId = false;
+  	  ourPutVersionInPatientMeta = true;
+	  doTestAutomaticNotModified();
+  }
+
+  private void doTestAutomaticNotModified() throws Exception {
+	  ourLastModifiedDate = new InstantDt("2012-11-25T02:34:45.2222Z").getValue();
+
+	  HttpGet httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2");
+	  httpGet.addHeader(Constants.HEADER_IF_NONE_MATCH, "\"222\"");
+	  HttpResponse status = ourClient.execute(httpGet);
+	  assertEquals(Constants.STATUS_HTTP_304_NOT_MODIFIED, status.getStatusLine().getStatusCode());
   }
 
   @Test
@@ -99,7 +110,7 @@ public class ETagServerR4Test {
 
     Header cl = status.getFirstHeader(Constants.HEADER_ETAG_LC);
     assertNotNull(cl);
-    assertEquals("W/\"333\"", cl.getValue());
+    assertEquals("W/\"222\"", cl.getValue());
   }
 
   @Test
@@ -216,7 +227,7 @@ public class ETagServerR4Test {
         patient.setId(theId.withVersion("222"));
       }
       if (ourPutVersionInPatientMeta) {
-        patient.getMeta().setVersionId("333");
+        patient.getMeta().setVersionId("222");
       }
       return patient;
     }


### PR DESCRIPTION
…return 304 on read

Fixes #1387 

I'm not sure why HAPI FHIR is looking in the resource id for versions, is this from an earlier version of FHIR?