### PR TITLE
in-memory id match

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/primitive/IdDt.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/primitive/IdDt.java
@@ -645,16 +645,8 @@ public class IdDt extends UriDt implements /*IPrimitiveDatatype<String>, */IIdTy
 		return new IdDt(value + '/' + Constants.PARAM_HISTORY + '/' + theVersion);
 	}
 
-	private static boolean isValidLong(String id) {
-		if (StringUtils.isBlank(id)) {
-			return false;
-		}
-		for (int i = 0; i < id.length(); i++) {
-			if (Character.isDigit(id.charAt(i)) == false) {
-				return false;
-			}
-		}
-		return true;
+	public static boolean isValidLong(String id) {
+		return StringUtils.isNumeric(id);
 	}
 
 	/**

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/ReferenceParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/ReferenceParam.java
@@ -19,6 +19,7 @@ package ca.uhn.fhir.rest.param;
  * limitations under the License.
  * #L%
  */
+import static ca.uhn.fhir.model.primitive.IdDt.isValidLong;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -279,5 +280,9 @@ public class ReferenceParam extends BaseParam /*implements IQueryParameterType*/
 		TokenParam retVal = new TokenParam();
 		retVal.setValueAsQueryToken(theContext, null, null, getValueAsQueryToken(theContext));
 		return retVal;
+	}
+
+	public boolean isIdPartValidLong() {
+		return isValidLong(getIdPart());
 	}
 }

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
@@ -260,7 +260,7 @@ public final class ResourceIndexedSearchParams {
 		return resourceParams.stream().anyMatch(namedParamPredicate);
 	}
 
-	public boolean matchResourceLinks(String theResourceName, String theParamName, IQueryParameterType theParam, String theParamPath) {
+	boolean matchResourceLinks(String theResourceName, String theParamName, IQueryParameterType theParam, String theParamPath) {
 		ReferenceParam reference = (ReferenceParam)theParam;
 
 		Predicate<ResourceLink> namedParamPredicate = resourceLink ->

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
@@ -274,7 +274,11 @@ public final class ResourceIndexedSearchParams {
 		ResourceTable target = theResourceLink.getTargetResource();
 		IdDt idDt = target.getIdDt();
 		if (idDt.isIdPartValidLong()) {
-			return theReference.getIdPartAsLong().equals(idDt.getIdPartAsLong());
+			if (theReference.isIdPartValidLong()) {
+				return theReference.getIdPartAsLong().equals(idDt.getIdPartAsLong());
+			} else {
+				return false;
+			}
 		} else {
 			ForcedId forcedId = target.getForcedId();
 			if (forcedId != null) {

--- a/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
+++ b/hapi-fhir-jpaserver-searchparam/src/main/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParams.java
@@ -260,7 +260,8 @@ public final class ResourceIndexedSearchParams {
 		return resourceParams.stream().anyMatch(namedParamPredicate);
 	}
 
-	boolean matchResourceLinks(String theResourceName, String theParamName, IQueryParameterType theParam, String theParamPath) {
+	// KHS This needs to be public as libraries outside of hapi call it directly
+	public boolean matchResourceLinks(String theResourceName, String theParamName, IQueryParameterType theParam, String theParamPath) {
 		ReferenceParam reference = (ReferenceParam)theParam;
 
 		Predicate<ResourceLink> namedParamPredicate = resourceLink ->

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
@@ -1,0 +1,58 @@
+package ca.uhn.fhir.jpa.searchparam.extractor;
+
+import ca.uhn.fhir.jpa.model.entity.ForcedId;
+import ca.uhn.fhir.jpa.model.entity.ResourceLink;
+import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.model.primitive.IdDt;
+import ca.uhn.fhir.rest.param.ReferenceParam;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class ResourceIndexedSearchParamsTest {
+
+	@Test
+	public void matchResourceLinksStringCompareToLong() {
+		ResourceTable source = new ResourceTable();
+		source.setResourceType("Patient");
+
+		ResourceTable target = new ResourceTable();
+		target.setResourceType("Organization");
+		target.setId(123L);
+
+
+		ResourceIndexedSearchParams params = new ResourceIndexedSearchParams(source);
+		ResourceLink link = new ResourceLink("organization", source, target, new Date());
+		params.getResourceLinks().add(link);
+
+		ReferenceParam referenceParam = new ReferenceParam();
+		referenceParam.setValue("StringId");
+		boolean result = params.matchResourceLinks("Patient", "organization", referenceParam, "organization");
+		assertFalse(result);
+	}
+
+	@Test
+	public void matchResourceLinksLongCompareToString() {
+		ResourceTable source = new ResourceTable();
+		source.setResourceType("Patient");
+
+		ResourceTable target = new ResourceTable();
+		target.setResourceType("Organization");
+		ForcedId forcedid = new ForcedId();
+		forcedid.setForcedId("StringId");
+		target.setForcedId(forcedid);
+
+		ResourceIndexedSearchParams params = new ResourceIndexedSearchParams(source);
+		ResourceLink link = new ResourceLink("organization", source, target, new Date());
+		params.getResourceLinks().add(link);
+
+		ReferenceParam referenceParam = new ReferenceParam();
+		referenceParam.setValue("123");
+		boolean result = params.matchResourceLinks("Patient", "organization", referenceParam, "organization");
+		assertFalse(result);
+	}
+
+}

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
@@ -6,6 +6,7 @@ import ca.uhn.fhir.jpa.model.entity.ResourceTable;
 import ca.uhn.fhir.model.primitive.IdDt;
 import ca.uhn.fhir.rest.param.ReferenceParam;
 import org.hl7.fhir.instance.model.api.IIdType;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
@@ -14,44 +15,68 @@ import static org.junit.Assert.*;
 
 public class ResourceIndexedSearchParamsTest {
 
-	@Test
-	public void matchResourceLinksStringCompareToLong() {
+	public static final String STRING_ID = "StringId";
+	public static final String LONG_ID = "123";
+	private ResourceIndexedSearchParams myParams;
+	private ResourceTable myTarget;
+
+	@Before
+	public void before() {
 		ResourceTable source = new ResourceTable();
 		source.setResourceType("Patient");
 
-		ResourceTable target = new ResourceTable();
-		target.setResourceType("Organization");
-		target.setId(123L);
+		myTarget = new ResourceTable();
+		myTarget.setResourceType("Organization");
 
-		ResourceIndexedSearchParams params = new ResourceIndexedSearchParams(source);
-		ResourceLink link = new ResourceLink("organization", source, target, new Date());
-		params.getResourceLinks().add(link);
+		myParams = new ResourceIndexedSearchParams(source);
+		ResourceLink link = new ResourceLink("organization", source, myTarget, new Date());
+		myParams.getResourceLinks().add(link);
+	}
 
-		ReferenceParam referenceParam = new ReferenceParam();
-		referenceParam.setValue("StringId");
-		boolean result = params.matchResourceLinks("Patient", "organization", referenceParam, "organization");
+	@Test
+	public void matchResourceLinksStringCompareToLong() {
+		ReferenceParam referenceParam = getReferenceParam(STRING_ID);
+		myTarget.setId(123L);
+
+		boolean result = myParams.matchResourceLinks("Patient", "organization", referenceParam, "organization");
 		assertFalse(result);
 	}
 
 	@Test
-	public void matchResourceLinksLongCompareToString() {
-		ResourceTable source = new ResourceTable();
-		source.setResourceType("Patient");
-
-		ResourceTable target = new ResourceTable();
-		target.setResourceType("Organization");
+	public void matchResourceLinksStringCompareToString() {
+		ReferenceParam referenceParam = getReferenceParam(STRING_ID);
 		ForcedId forcedid = new ForcedId();
-		forcedid.setForcedId("StringId");
-		target.setForcedId(forcedid);
+		forcedid.setForcedId(STRING_ID);
+		myTarget.setForcedId(forcedid);
 
-		ResourceIndexedSearchParams params = new ResourceIndexedSearchParams(source);
-		ResourceLink link = new ResourceLink("organization", source, target, new Date());
-		params.getResourceLinks().add(link);
+		boolean result = myParams.matchResourceLinks("Patient", "organization", referenceParam, "organization");
+		assertTrue(result);
+	}
 
-		ReferenceParam referenceParam = new ReferenceParam();
-		referenceParam.setValue("123");
-		boolean result = params.matchResourceLinks("Patient", "organization", referenceParam, "organization");
+	@Test
+	public void matchResourceLinksLongCompareToString() {
+		ReferenceParam referenceParam = getReferenceParam(LONG_ID);
+		ForcedId forcedid = new ForcedId();
+		forcedid.setForcedId(STRING_ID);
+		myTarget.setForcedId(forcedid);
+
+		boolean result = myParams.matchResourceLinks("Patient", "organization", referenceParam, "organization");
 		assertFalse(result);
+	}
+
+	@Test
+	public void matchResourceLinksLongCompareToLong() {
+		ReferenceParam referenceParam = getReferenceParam(LONG_ID);
+		myTarget.setId(123L);
+
+		boolean result = myParams.matchResourceLinks("Patient", "organization", referenceParam, "organization");
+		assertTrue(result);
+	}
+
+	private ReferenceParam getReferenceParam(String theId) {
+		ReferenceParam retval = new ReferenceParam();
+		retval.setValue(theId);
+		return retval;
 	}
 
 }

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/ResourceIndexedSearchParamsTest.java
@@ -23,7 +23,6 @@ public class ResourceIndexedSearchParamsTest {
 		target.setResourceType("Organization");
 		target.setId(123L);
 
-
 		ResourceIndexedSearchParams params = new ResourceIndexedSearchParams(source);
 		ResourceLink link = new ResourceLink("organization", source, target, new Date());
 		params.getResourceLinks().add(link);

--- a/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorDstu3Test.java
+++ b/hapi-fhir-jpaserver-searchparam/src/test/java/ca/uhn/fhir/jpa/searchparam/extractor/SearchParamExtractorDstu3Test.java
@@ -1,4 +1,4 @@
-package ca.uhn.fhir.jpa.searchparam;
+package ca.uhn.fhir.jpa.searchparam.extractor;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.context.RuntimeResourceDefinition;
@@ -7,6 +7,7 @@ import ca.uhn.fhir.jpa.model.entity.BaseResourceIndexedSearchParam;
 import ca.uhn.fhir.jpa.model.entity.ModelConfig;
 import ca.uhn.fhir.jpa.model.entity.ResourceIndexedSearchParamToken;
 import ca.uhn.fhir.jpa.model.entity.ResourceTable;
+import ca.uhn.fhir.jpa.searchparam.JpaRuntimeSearchParam;
 import ca.uhn.fhir.jpa.searchparam.extractor.SearchParamExtractorDstu3;
 import ca.uhn.fhir.jpa.searchparam.registry.ISearchParamRegistry;
 import ca.uhn.fhir.util.TestUtil;


### PR DESCRIPTION
There was a bug in the in-memory matcher that failed when trying to compare a long id to a string id.

This MR fixes that bug.