### PR TITLE
Update download docs with note on removal of hapi-fhir-utilities

### DIFF
--- a/download.html
+++ b/download.html
@@ -415,7 +415,7 @@
    </tr> 
    <tr class="a"> 
     <td style="font-weight: bold; white-space: nowrap;">hapi-fhir-utilities</td> 
-    <td> This is a support library containing various utility methods for working with FHIR. It is always required in order to use the framework. </td> 
+    <td> This module was discontinued in version 4.0.0.  Before version 4.0.0, this is a support library containing various utility methods for working with FHIR. It is always required in order to use the framework. </td> 
    </tr> 
    <tr class="b"> 
     <td style="text-align: center; font-size: 1.2em; background: #DDE; padding: 3px;" colspan="2">Structures</td> 


### PR DESCRIPTION
As noted by @jamesagnew  [here](https://github.com/jamesagnew/hapi-fhir/issues/1456#issuecomment-525950573), `hapi-fhir-utilities` no longer exists as of 4.0.0.