### PR TITLE
Add missing @Override annotations

### DIFF
--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/apache/ApacheHttpClient.java
@@ -87,11 +87,13 @@ public class ApacheHttpClient extends BaseHttpClient implements IHttpClient {
 	}
 
 
+	@Override
 	protected IHttpRequest createHttpRequest() {
 		IHttpRequest retVal = createHttpRequest((HttpEntity)null);
 		return retVal;
 	}
 
+	@Override
 	protected IHttpRequest createHttpRequest(byte[] content) {
 		/*
 		 * Note: Be careful about changing which constructor we use for
@@ -109,6 +111,7 @@ public class ApacheHttpClient extends BaseHttpClient implements IHttpClient {
 		return result;
 	}
 
+	@Override
 	protected IHttpRequest createHttpRequest(Map<String, List<String>> theParams) {
 		List<NameValuePair> parameters = new ArrayList<NameValuePair>();
 		for (Entry<String, List<String>> nextParam : theParams.entrySet()) {
@@ -124,6 +127,7 @@ public class ApacheHttpClient extends BaseHttpClient implements IHttpClient {
 	}
 
 
+	@Override
 	protected IHttpRequest createHttpRequest(String theContents) {
 		/*
 		 * We aren't using a StringEntity here because the constructors

--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/LoggingInterceptor.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/interceptor/LoggingInterceptor.java
@@ -76,6 +76,7 @@ public class LoggingInterceptor implements IClientInterceptor {
 		}
 	}
 
+	@Override
 	@Hook(Pointcut.CLIENT_REQUEST)
 	public void interceptRequest(IHttpRequest theRequest) {
 		if (myLogRequestSummary) {
@@ -101,6 +102,7 @@ public class LoggingInterceptor implements IClientInterceptor {
 		}
 	}
 
+	@Override
 	@Hook(Pointcut.CLIENT_RESPONSE)
 	public void interceptResponse(IHttpResponse theResponse) throws IOException {
 		if (myLogResponseSummary) {

--- a/hapi-fhir-igpacks/src/main/java/ca/uhn/fhir/igpacks/parser/IgPackParserDstu2.java
+++ b/hapi-fhir-igpacks/src/main/java/ca/uhn/fhir/igpacks/parser/IgPackParserDstu2.java
@@ -35,10 +35,12 @@ public class IgPackParserDstu2 extends BaseIgPackParser<IValidationSupport> {
 		super(massage(theCtx));
 	}
 
+	@Override
 	protected IValidationSupport createValidationSupport(Map<IIdType, IBaseResource> theIgResources) {
 		return new IgPackValidationSupportDstu2(theIgResources);
 	}
 
+	@Override
 	protected FhirVersionEnum provideExpectedVersion() {
 		return FhirVersionEnum.DSTU2_HL7ORG;
 	}

--- a/hapi-fhir-igpacks/src/main/java/ca/uhn/fhir/igpacks/parser/IgPackParserDstu3.java
+++ b/hapi-fhir-igpacks/src/main/java/ca/uhn/fhir/igpacks/parser/IgPackParserDstu3.java
@@ -37,10 +37,12 @@ public class IgPackParserDstu3 extends BaseIgPackParser<IValidationSupport> {
 		super(theCtx);
 	}
 
+	@Override
 	protected IValidationSupport createValidationSupport(Map<IIdType, IBaseResource> theIgResources) {
 		return new IgPackValidationSupportDstu3(theIgResources);
 	}
 
+	@Override
 	protected FhirVersionEnum provideExpectedVersion() {
 		return FhirVersionEnum.DSTU3;
 	}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSubscriptionDstu2Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/email/EmailSubscriptionDstu2Test.java
@@ -39,6 +39,7 @@ public class EmailSubscriptionDstu2Test extends BaseResourceProviderDstu2Test {
 	@Autowired
 	private SubscriptionTestUtil mySubscriptionTestUtil;
 
+	@Override
 	@After
 	public void after() throws Exception {
 		ourLog.info("** AFTER **");

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/websocket/WebsocketWithCriteriaDstu2Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/websocket/WebsocketWithCriteriaDstu2Test.java
@@ -41,11 +41,13 @@ public class WebsocketWithCriteriaDstu2Test extends BaseResourceProviderDstu2Tes
 	private WebSocketClient myWebSocketClient;
 	private SocketImplementation mySocketImplementation;
 
+	@Override
 	@After
 	public void after() throws Exception {
 		super.after();
 	}
 	
+	@Override
 	@Before
 	public void before() throws Exception {
 		super.before();

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/websocket/WebsocketWithSubscriptionIdDstu2Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/subscription/websocket/WebsocketWithSubscriptionIdDstu2Test.java
@@ -58,6 +58,7 @@ public class WebsocketWithSubscriptionIdDstu2Test extends BaseResourceProviderDs
 	@Autowired
 	private SubscriptionTestUtil mySubscriptionTestUtil;
 
+	@Override
 	@After
 	public void after() throws Exception {
 		super.after();
@@ -70,6 +71,7 @@ public class WebsocketWithSubscriptionIdDstu2Test extends BaseResourceProviderDs
 		myWebSocketClient.stop();
 	}
 
+	@Override
 	@Before
 	public void before() throws Exception {
 		super.before();

--- a/hapi-fhir-structures-dstu2.1/src/main/java/org/hl7/fhir/dstu2016may/validation/InstanceValidator.java
+++ b/hapi-fhir-structures-dstu2.1/src/main/java/org/hl7/fhir/dstu2016may/validation/InstanceValidator.java
@@ -1021,6 +1021,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
 			return Utilities.appendSlash(base) + type + "/" + id;
 	}  
 
+	@Override
 	public BestPracticeWarningLevel getBasePracticeWarningLevel() {
 		return bpWarnings;
 	}  
@@ -1416,6 +1417,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
 		this.anyExtensionsAllowed = anyExtensionsAllowed;
 	}
 
+	@Override
 	public void setBestPracticeWarningLevel(BestPracticeWarningLevel value) {
 		bpWarnings = value;
 	}
@@ -1429,10 +1431,12 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
 		this.suppressLoincSnomedMessages = suppressLoincSnomedMessages;
 	}
 
+	@Override
 	public IdStatus getResourceIdRule() {
 		return resourceIdRule;
 	}
 
+	@Override
 	public void setResourceIdRule(IdStatus resourceIdRule) {
 		this.resourceIdRule = resourceIdRule;
 	}

--- a/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/composite/ContainedDt.java
+++ b/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/composite/ContainedDt.java
@@ -35,6 +35,7 @@ public class ContainedDt extends BaseContainedDt {
 	@Child(name = "resource", type = IResource.class, order = 0, min = 0, max = Child.MAX_UNLIMITED)
 	private List<IResource> myContainedResources;
 
+	@Override
 	public List<IResource> getContainedResources() {
 		if (myContainedResources == null) {
 			myContainedResources = new ArrayList<IResource>();

--- a/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/composite/NarrativeDt.java
+++ b/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/composite/NarrativeDt.java
@@ -114,7 +114,8 @@ public class NarrativeDt extends BaseNarrativeDt {
      * The status of the narrative - whether it's entirely generated (from just the defined data or the extensions too), or whether a human authored it and it may contain additional data
      * </p> 
 	 */
-	public BoundCodeDt<NarrativeStatusEnum> getStatus() {  
+	@Override
+	public BoundCodeDt<NarrativeStatusEnum> getStatus() {
 		if (myStatus == null) {
 			myStatus = new BoundCodeDt<NarrativeStatusEnum>(NarrativeStatusEnum.VALUESET_BINDER);
 		}
@@ -170,7 +171,8 @@ public class NarrativeDt extends BaseNarrativeDt {
      * The actual narrative content, a stripped down version of XHTML
      * </p> 
 	 */
-	public XhtmlDt getDiv() {  
+	@Override
+	public XhtmlDt getDiv() {
 		if (myDiv == null) {
 			myDiv = new XhtmlDt();
 		}

--- a/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/composite/ResourceReferenceDt.java
+++ b/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/composite/ResourceReferenceDt.java
@@ -162,7 +162,8 @@ public class ResourceReferenceDt
      * A reference to a location at which the other resource is found. The reference may a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources
      * </p> 
 	 */
-	public IdDt getReference() {  
+	@Override
+	public IdDt getReference() {
 		if (myReference == null) {
 			myReference = new IdDt();
 		}
@@ -183,6 +184,7 @@ public class ResourceReferenceDt
      * A reference to a location at which the other resource is found. The reference may a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources
      * </p> 
 	 */
+	@Override
 	public ResourceReferenceDt setReference(IdDt theValue) {
 		myReference = theValue;
 		return this;
@@ -196,7 +198,8 @@ public class ResourceReferenceDt
      * A reference to a location at which the other resource is found. The reference may a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources
      * </p> 
 	 */
-	public ResourceReferenceDt setReference( String theId) {
+	@Override
+	public ResourceReferenceDt setReference(String theId) {
 		myReference = new IdDt(theId); 
 		return this; 
 	}
@@ -240,7 +243,8 @@ public class ResourceReferenceDt
      * Plain text narrative that identifies the resource in addition to the resource reference
      * </p> 
 	 */
-	public ResourceReferenceDt setDisplay( String theString) {
+	@Override
+	public ResourceReferenceDt setDisplay(String theString) {
 		myDisplay = new StringDt(theString); 
 		return this; 
 	}

--- a/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/resource/BaseResource.java
+++ b/hapi-fhir-structures-dstu2/src/main/java/ca/uhn/fhir/model/dstu2/resource/BaseResource.java
@@ -303,10 +303,12 @@ public abstract class BaseResource extends BaseElement implements IResource {
 		myContained = theContained;
 	}
 	
+	@Override
 	public void setId(IdDt theId) {
 		myId = theId;
 	}
 
+	@Override
 	public BaseResource setId(IIdType theId) {
 		if (theId instanceof IdDt) {
 			myId = (IdDt) theId;
@@ -318,6 +320,7 @@ public abstract class BaseResource extends BaseElement implements IResource {
 		return this;
 	}
 
+	@Override
 	public BaseResource setId(String theId) {
 		if (theId == null) {
 			myId = null;

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/ctx/FhirContextDstu2Test.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/ctx/FhirContextDstu2Test.java
@@ -142,6 +142,7 @@ public class FhirContextDstu2Test {
 			final CountDownLatch allDone = new CountDownLatch(numThreads);
 			for (final Runnable submittedTestRunnable : runnables) {
 				threadPool.submit(new Runnable() {
+					@Override
 					public void run() {
 						allExecutorThreadsReady.countDown();
 						try {

--- a/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/parser/CustomMedicationOrderDstu2.java
+++ b/hapi-fhir-structures-dstu2/src/test/java/ca/uhn/fhir/parser/CustomMedicationOrderDstu2.java
@@ -17,6 +17,7 @@ public class CustomMedicationOrderDstu2 extends MedicationOrder {
 	@Child(name = "medication", order = Child.REPLACE_PARENT, min = 1, max = 1, summary = false, modifier = false, type = { Medication.class })
 	private ResourceReferenceDt myMedication;
 
+	@Override
 	public ResourceReferenceDt getMedication() {
 		return myMedication;
 	}

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/jsonlike/JsonLikeParserTest.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/jsonlike/JsonLikeParserTest.java
@@ -699,21 +699,25 @@ public class JsonLikeParserTest {
 				return super.getAsBoolean();
 			}
 
+			@Override
 			public boolean isObject () {
 				return (nativeValue != null)
 					&& ( (nativeValue instanceof Map) || Map.class.isAssignableFrom(nativeValue.getClass()) );
 			}
 
+			@Override
 			public boolean isArray () {
 				return (nativeValue != null)
 					&& ( (nativeValue instanceof List) || List.class.isAssignableFrom(nativeValue.getClass()));
 			}
 
+			@Override
 			public boolean isString () {
 				return (nativeValue != null)
 					&& ( (nativeValue instanceof String) || String.class.isAssignableFrom(nativeValue.getClass()));
 			}
 
+			@Override
 			public boolean isNumber () {
 				return (nativeValue != null)
 					&& ( (nativeValue instanceof Number) || Number.class.isAssignableFrom(nativeValue.getClass()) );
@@ -724,6 +728,7 @@ public class JsonLikeParserTest {
 					&& ( (nativeValue instanceof Boolean) || Boolean.class.isAssignableFrom(nativeValue.getClass()) );
 			}
 			
+			@Override
 			public boolean isNull () {
 				return (null == nativeValue);
 			}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/instance/validation/InstanceValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/instance/validation/InstanceValidator.java
@@ -787,6 +787,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       return Utilities.appendSlash(base) + type + "/" + id;
   }
 
+  @Override
   public BestPracticeWarningLevel getBasePracticeWarningLevel() {
     return bpWarnings;
   }
@@ -941,10 +942,12 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
     return context.fetchResource(StructureDefinition.class, "http://hl7.org/fhir/StructureDefinition/" + type);
   }
 
+	@Override
 	public IdStatus getResourceIdRule() {
 		return resourceIdRule;
 	}
 
+	@Override
 	public void setResourceIdRule(IdStatus resourceIdRule) {
 		this.resourceIdRule = resourceIdRule;
 	}
@@ -1209,6 +1212,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
       return sd.getSnapshot().getElement().get(0);
   }
 
+  @Override
   public void setBestPracticeWarningLevel(BestPracticeWarningLevel value) {
     bpWarnings = value;
   }
@@ -2071,6 +2075,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
 			this.typeProfile = typeProfile;
 		}
 
+		@Override
 		public boolean equalsDeep(Base other) {
 			if (!super.equalsDeep(other) || !fhirType().equals(other.fhirType()))
 			  return false;
@@ -2153,6 +2158,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
 	  	return true;
 		}
 
+		@Override
 		public boolean isPrimitive() {
 			String t = fhirType();
 			return t.equalsIgnoreCase("boolean") || t.equalsIgnoreCase("integer") || t.equalsIgnoreCase("string") || t.equalsIgnoreCase("decimal") || t.equalsIgnoreCase("uri") || t.equalsIgnoreCase("base64Binary") ||
@@ -2188,6 +2194,7 @@ public class InstanceValidator extends BaseValidator implements IResourceValidat
 			return list;
 		}
 
+		@Override
 		public String primitiveValue() {
 			return wrapper.getAttribute("value");
 		}

--- a/hapi-fhir-validation/src/main/java/org/hl7/fhir/instance/validation/ProfileValidator.java
+++ b/hapi-fhir-validation/src/main/java/org/hl7/fhir/instance/validation/ProfileValidator.java
@@ -23,6 +23,7 @@ public class ProfileValidator extends BaseValidator {
     this.context = context;    
   }
 
+  @Override
   protected boolean rule(List<ValidationMessage> errors, IssueType type, String path, boolean b, String msg) {
     String rn = path.contains(".") ? path.substring(0, path.indexOf(".")) : path;
     return super.rule(errors, type, path, b, msg, "<a href=\""+(rn.toLowerCase())+".html\">"+rn+"</a>: "+Utilities.escapeXml(msg));

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/CodingDt.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/CodingDt.java
@@ -126,7 +126,8 @@ public class CodingDt
      * The identification of the code system that defines the meaning of the symbol in the code.
      * </p> 
 	 */
-	public UriDt getSystemElement() {  
+	@Override
+	public UriDt getSystemElement() {
 		if (mySystem == null) {
 			mySystem = new UriDt();
 		}
@@ -144,7 +145,8 @@ public class CodingDt
      * The identification of the code system that defines the meaning of the symbol in the code.
      * </p> 
 	 */
-	public String getSystem() {  
+	@Override
+	public String getSystem() {
 		return getSystemElement().getValue();
 	}
 
@@ -171,7 +173,8 @@ public class CodingDt
      * The identification of the code system that defines the meaning of the symbol in the code.
      * </p> 
 	 */
-	public CodingDt setSystem( String theUri) {
+	@Override
+	public CodingDt setSystem(String theUri) {
 		mySystem = new UriDt(theUri); 
 		return this; 
 	}
@@ -248,7 +251,8 @@ public class CodingDt
      * A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)
      * </p> 
 	 */
-	public CodeDt getCodeElement() {  
+	@Override
+	public CodeDt getCodeElement() {
 		if (myCode == null) {
 			myCode = new CodeDt();
 		}
@@ -266,7 +270,8 @@ public class CodingDt
      * A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)
      * </p> 
 	 */
-	public String getCode() {  
+	@Override
+	public String getCode() {
 		return getCodeElement().getValue();
 	}
 
@@ -293,7 +298,8 @@ public class CodingDt
      * A symbol in syntax defined by the system. The symbol may be a predefined code or an expression in a syntax defined by the coding system (e.g. post-coordination)
      * </p> 
 	 */
-	public CodingDt setCode( String theCode) {
+	@Override
+	public CodingDt setCode(String theCode) {
 		myCode = new CodeDt(theCode); 
 		return this; 
 	}
@@ -309,7 +315,8 @@ public class CodingDt
      * A representation of the meaning of the code in the system, following the rules of the system
      * </p> 
 	 */
-	public StringDt getDisplayElement() {  
+	@Override
+	public StringDt getDisplayElement() {
 		if (myDisplay == null) {
 			myDisplay = new StringDt();
 		}
@@ -327,7 +334,8 @@ public class CodingDt
      * A representation of the meaning of the code in the system, following the rules of the system
      * </p> 
 	 */
-	public String getDisplay() {  
+	@Override
+	public String getDisplay() {
 		return getDisplayElement().getValue();
 	}
 
@@ -354,7 +362,8 @@ public class CodingDt
      * A representation of the meaning of the code in the system, following the rules of the system
      * </p> 
 	 */
-	public CodingDt setDisplay( String theString) {
+	@Override
+	public CodingDt setDisplay(String theString) {
 		myDisplay = new StringDt(theString); 
 		return this; 
 	}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/ContainedDt.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/ContainedDt.java
@@ -35,6 +35,7 @@ public class ContainedDt extends BaseContainedDt {
 	@Child(name = "resource", type = IResource.class, order = 0, min = 0, max = Child.MAX_UNLIMITED)
 	private List<IResource> myContainedResources;
 
+	@Override
 	public List<IResource> getContainedResources() {
 		if (myContainedResources == null) {
 			myContainedResources = new ArrayList<IResource>();

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/NarrativeDt.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/NarrativeDt.java
@@ -104,7 +104,8 @@ public class NarrativeDt extends BaseNarrativeDt {
      * The actual narrative content, a stripped down version of XHTML
      * </p> 
 	 */
-	public XhtmlDt getDiv() {  
+	@Override
+	public XhtmlDt getDiv() {
 		if (myDiv == null) {
 			myDiv = new XhtmlDt();
 		}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/QuantityDt.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/QuantityDt.java
@@ -193,7 +193,8 @@ public class QuantityDt
      * The value of the measured amount. The value includes an implicit precision in the presentation of the value
      * </p> 
 	 */
-	public DecimalDt getValueElement() {  
+	@Override
+	public DecimalDt getValueElement() {
 		if (myValue == null) {
 			myValue = new DecimalDt();
 		}
@@ -264,7 +265,8 @@ public class QuantityDt
      * The value of the measured amount. The value includes an implicit precision in the presentation of the value
      * </p> 
 	 */
-	public QuantityDt setValue( java.math.BigDecimal theValue) {
+	@Override
+	public QuantityDt setValue(java.math.BigDecimal theValue) {
 		myValue = new DecimalDt(theValue); 
 		return this; 
 	}
@@ -280,7 +282,8 @@ public class QuantityDt
      * How the value should be understood and represented - whether the actual value is greater or less than the stated value due to measurement issues; e.g. if the comparator is \&quot;&lt;\&quot; , then the real value is &lt; stated value
      * </p> 
 	 */
-	public BoundCodeDt<QuantityComparatorEnum> getComparatorElement() {  
+	@Override
+	public BoundCodeDt<QuantityComparatorEnum> getComparatorElement() {
 		if (myComparator == null) {
 			myComparator = new BoundCodeDt<QuantityComparatorEnum>(QuantityComparatorEnum.VALUESET_BINDER);
 		}
@@ -406,7 +409,8 @@ public class QuantityDt
      * The identification of the system that provides the coded form of the unit
      * </p> 
 	 */
-	public UriDt getSystemElement() {  
+	@Override
+	public UriDt getSystemElement() {
 		if (mySystem == null) {
 			mySystem = new UriDt();
 		}
@@ -451,7 +455,8 @@ public class QuantityDt
      * The identification of the system that provides the coded form of the unit
      * </p> 
 	 */
-	public QuantityDt setSystem( String theUri) {
+	@Override
+	public QuantityDt setSystem(String theUri) {
 		mySystem = new UriDt(theUri); 
 		return this; 
 	}
@@ -467,7 +472,8 @@ public class QuantityDt
      * A computer processable form of the unit in some unit representation system
      * </p> 
 	 */
-	public CodeDt getCodeElement() {  
+	@Override
+	public CodeDt getCodeElement() {
 		if (myCode == null) {
 			myCode = new CodeDt();
 		}
@@ -512,7 +518,8 @@ public class QuantityDt
      * A computer processable form of the unit in some unit representation system
      * </p> 
 	 */
-	public QuantityDt setCode( String theCode) {
+	@Override
+	public QuantityDt setCode(String theCode) {
 		myCode = new CodeDt(theCode); 
 		return this; 
 	}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/ResourceReferenceDt.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/model/dstu3/composite/ResourceReferenceDt.java
@@ -162,7 +162,8 @@ public class ResourceReferenceDt
      * A reference to a location at which the other resource is found. The reference may a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources
      * </p> 
 	 */
-	public IdDt getReference() {  
+	@Override
+	public IdDt getReference() {
 		if (myReference == null) {
 			myReference = new IdDt();
 		}
@@ -183,6 +184,7 @@ public class ResourceReferenceDt
      * A reference to a location at which the other resource is found. The reference may a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources
      * </p> 
 	 */
+	@Override
 	public ResourceReferenceDt setReference(IdDt theValue) {
 		myReference = theValue;
 		return this;
@@ -196,7 +198,8 @@ public class ResourceReferenceDt
      * A reference to a location at which the other resource is found. The reference may a relative reference, in which case it is relative to the service base URL, or an absolute URL that resolves to the location where the resource is found. The reference may be version specific or not. If the reference is not to a FHIR RESTful server, then it should be assumed to be version specific. Internal fragment references (start with '#') refer to contained resources
      * </p> 
 	 */
-	public ResourceReferenceDt setReference( String theId) {
+	@Override
+	public ResourceReferenceDt setReference(String theId) {
 		myReference = new IdDt(theId); 
 		return this; 
 	}
@@ -240,7 +243,8 @@ public class ResourceReferenceDt
      * Plain text narrative that identifies the resource in addition to the resource reference
      * </p> 
 	 */
-	public ResourceReferenceDt setDisplay( String theString) {
+	@Override
+	public ResourceReferenceDt setDisplay(String theString) {
 		myDisplay = new StringDt(theString); 
 		return this; 
 	}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/ResourceBlock.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/model/ResourceBlock.java
@@ -59,6 +59,7 @@ public class ResourceBlock extends Child {
 		return getClassName();
 	}
 
+	@Override
 	public boolean isBlock() {
 		return true;
 	}

--- a/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/util/XMLUtils.java
+++ b/hapi-tinder-plugin/src/main/java/ca/uhn/fhir/tinder/util/XMLUtils.java
@@ -116,8 +116,9 @@ public class XMLUtils {
             impl = getDOMImpl();
         }
 
-        public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId,
-                String baseURI) {
+        @Override
+		  public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId,
+													String baseURI) {
             LSInput lsInput = impl.createLSInput();
             InputStream is = getClass().getResourceAsStream("/" + systemId);
             if (is == null)

--- a/hapi-tinder-plugin/src/main/java/org/hl7/fhir/instance/model/IIdType.java
+++ b/hapi-tinder-plugin/src/main/java/org/hl7/fhir/instance/model/IIdType.java
@@ -24,6 +24,7 @@ package org.hl7.fhir.dstu2.model;
 
 public interface IIdType extends IBase {
 
+	@Override
 	boolean isEmpty();
 
 	/**


### PR DESCRIPTION
Added missing @Override annotations so that if/when methods in superclasses change
there will be a compile-time error if subclasses haven't been changed accordingly.

This was done using IntelliJ IDEA's "Missing @Override annotation" inspection.