### PR TITLE
Feature/json performance

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -287,8 +287,6 @@ public abstract class BaseParser implements IParser {
 	protected void findBaseReferences(List<IBaseReference> allElements, IBase theElement, BaseRuntimeElementDefinition<?> theDefinition) {
 		if (theElement instanceof IBaseReference) {
 			allElements.add((IBaseReference) theElement);
-			// end traversal here, we recursively process nested resources later
-			return;
 		}
 		
 		BaseRuntimeElementDefinition<?> def = theDefinition;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -287,6 +287,8 @@ public abstract class BaseParser implements IParser {
 	protected void findBaseReferences(List<IBaseReference> allElements, IBase theElement, BaseRuntimeElementDefinition<?> theDefinition) {
 		if (theElement instanceof IBaseReference) {
 			allElements.add((IBaseReference) theElement);
+			// end traversal here, we recursively process nested resources later
+			return;
 		}
 		
 		BaseRuntimeElementDefinition<?> def = theDefinition;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -204,31 +204,6 @@ public abstract class BaseParser implements IParser {
 	}
 
 	private void containResourcesForEncoding(ContainedResources theContained, IBaseResource theResource, IBaseResource theTarget) {
-
-		if (theTarget instanceof IResource) {
-			List<? extends IResource> containedResources = ((IResource) theTarget).getContained().getContainedResources();
-			for (IResource next : containedResources) {
-				String nextId = next.getId().getValue();
-				if (StringUtils.isNotBlank(nextId)) {
-					if (!nextId.startsWith("#")) {
-						nextId = '#' + nextId;
-					}
-					theContained.getExistingIdToContainedResource().put(nextId, next);
-				}
-			}
-		} else if (theTarget instanceof IDomainResource) {
-			List<? extends IAnyResource> containedResources = ((IDomainResource) theTarget).getContained();
-			for (IAnyResource next : containedResources) {
-				String nextId = next.getIdElement().getValue();
-				if (StringUtils.isNotBlank(nextId)) {
-					if (!nextId.startsWith("#")) {
-						nextId = '#' + nextId;
-					}
-					theContained.getExistingIdToContainedResource().put(nextId, next);
-				}
-			}
-		}
-
 		List<IBaseReference> allReferences = getAllBaseReferences(theResource);
 		for (IBaseReference next : allReferences) {
 			IBaseResource resource = next.getResource();
@@ -268,6 +243,31 @@ public abstract class BaseParser implements IParser {
 
 	protected void containResourcesForEncoding(IBaseResource theResource) {
 		ContainedResources contained = new ContainedResources();
+
+		if (theResource instanceof IResource) {
+			List<? extends IResource> containedResources = ((IResource) theResource).getContained().getContainedResources();
+			for (IResource next : containedResources) {
+				String nextId = next.getId().getValue();
+				if (StringUtils.isNotBlank(nextId)) {
+					if (!nextId.startsWith("#")) {
+						nextId = '#' + nextId;
+					}
+					contained.getExistingIdToContainedResource().put(nextId, next);
+				}
+			}
+		} else if (theResource instanceof IDomainResource) {
+			List<? extends IAnyResource> containedResources = ((IDomainResource) theResource).getContained();
+			for (IAnyResource next : containedResources) {
+				String nextId = next.getIdElement().getValue();
+				if (StringUtils.isNotBlank(nextId)) {
+					if (!nextId.startsWith("#")) {
+						nextId = '#' + nextId;
+					}
+					contained.getExistingIdToContainedResource().put(nextId, next);
+				}
+			}
+		}
+
 		containResourcesForEncoding(contained, theResource, theResource);
 		contained.assignIdsToContainedResources();
 		myContainedResources = contained;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -469,7 +469,7 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 						if (nextValue instanceof IBaseHasModifierExtensions) {
 							IBaseHasModifierExtensions element = (IBaseHasModifierExtensions) nextValue;
 							List<? extends IBaseExtension<?, ?>> ext = element.getModifierExtension();
-							force |= addToHeldExtensions(valueIdx, ext, extensions, true, nextChildElem, theParent, theEncodeContext, theContainedResource, theElement);
+							force |= addToHeldExtensions(valueIdx, ext, modifierExtensions, true, nextChildElem, theParent, theEncodeContext, theContainedResource, theElement);
 						}
 					}
 					if (nextValue.hasFormatComment()) {

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/JsonParser.java
@@ -224,9 +224,20 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 			}
 			case PRIMITIVE_DATATYPE: {
 				final IPrimitiveType<?> value = (IPrimitiveType<?>) theNextValue;
-				if (isBlank(value.getValueAsString())) {
+				final String valueStr = value.getValueAsString();
+				if (isBlank(valueStr)) {
 					if (theForceEmpty) {
 						theEventWriter.writeNull();
+					}
+					break;
+				}
+
+				// check for the common case first - String value types
+				if (value.getValue() instanceof String) {
+					if (theChildName != null) {
+						theEventWriter.write(theChildName, valueStr);
+					} else {
+						theEventWriter.write(valueStr);
 					}
 					break;
 				}
@@ -262,7 +273,6 @@ public class JsonParser extends BaseParser implements IJsonLikeParser {
 						}
 					}
 				} else {
-					String valueStr = value.getValueAsString();
 					if (theChildName != null) {
 						write(theEventWriter, theChildName, valueStr);
 					} else {


### PR DESCRIPTION
Improve performance of JsonParser when encoding resources to JSON.  There are 3 main improvements:
 * Optimising the search for resources to contain by avoiding repeated traversals of the model
 * Caching the calculation of which composite children need encoding for a given composite
 * Optimise for encoding String primitive data types as these are much more common than the other primitive data types