### PR TITLE
Replaced migration task column length constants with literals because…

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptDesignation.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermConceptDesignation.java
@@ -36,7 +36,8 @@ import static org.apache.commons.lang3.StringUtils.length;
 public class TermConceptDesignation implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-	private static final int MAX_LENGTH = 500;
+	public static final int MAX_LENGTH = 500;
+	public static final int MAX_VAL_LENGTH = 2000;
 
 	@ManyToOne
 	@JoinColumn(name = "CONCEPT_PID", referencedColumnName = "PID", foreignKey = @ForeignKey(name = "FK_CONCEPTDESIG_CONCEPT"))
@@ -54,7 +55,7 @@ public class TermConceptDesignation implements Serializable {
 	private String myUseCode;
 	@Column(name = "USE_DISPLAY", nullable = true, length = MAX_LENGTH)
 	private String myUseDisplay;
-	@Column(name = "VAL", nullable = false, length = MAX_LENGTH)
+	@Column(name = "VAL", nullable = false, length = MAX_VAL_LENGTH)
 	private String myValue;
 	/**
 	 * TODO: Make this non-null
@@ -113,8 +114,8 @@ public class TermConceptDesignation implements Serializable {
 
 	public TermConceptDesignation setValue(@Nonnull String theValue) {
 		ValidateUtil.isNotBlankOrThrowIllegalArgument(theValue, "theValue must not be null or empty");
-		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theValue, MAX_LENGTH,
-			"Value exceeds maximum length (" + MAX_LENGTH + "): " + length(theValue));
+		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theValue, MAX_VAL_LENGTH,
+			"Value exceeds maximum length (" + MAX_VAL_LENGTH + "): " + length(theValue));
 		myValue = theValue;
 		return this;
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermValueSetConceptDesignation.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermValueSetConceptDesignation.java
@@ -40,8 +40,6 @@ import static org.apache.commons.lang3.StringUtils.length;
 public class TermValueSetConceptDesignation implements Serializable {
 	private static final long serialVersionUID = 1L;
 
-	public static final int MAX_LENGTH = 500;
-
 	@Id()
 	@SequenceGenerator(name = "SEQ_VALUESET_C_DSGNTN_PID", sequenceName = "SEQ_VALUESET_C_DSGNTN_PID")
 	@GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_VALUESET_C_DSGNTN_PID")
@@ -68,19 +66,19 @@ public class TermValueSetConceptDesignation implements Serializable {
 	@Transient
 	private String myValueSetName;
 
-	@Column(name = "LANG", nullable = true, length = MAX_LENGTH)
+	@Column(name = "LANG", nullable = true, length = TermConceptDesignation.MAX_LENGTH)
 	private String myLanguage;
 
-	@Column(name = "USE_SYSTEM", nullable = true, length = MAX_LENGTH)
+	@Column(name = "USE_SYSTEM", nullable = true, length = TermConceptDesignation.MAX_LENGTH)
 	private String myUseSystem;
 
-	@Column(name = "USE_CODE", nullable = true, length = MAX_LENGTH)
+	@Column(name = "USE_CODE", nullable = true, length = TermConceptDesignation.MAX_LENGTH)
 	private String myUseCode;
 
-	@Column(name = "USE_DISPLAY", nullable = true, length = MAX_LENGTH)
+	@Column(name = "USE_DISPLAY", nullable = true, length = TermConceptDesignation.MAX_LENGTH)
 	private String myUseDisplay;
 
-	@Column(name = "VAL", nullable = false, length = MAX_LENGTH)
+	@Column(name = "VAL", nullable = false, length = TermConceptDesignation.MAX_VAL_LENGTH)
 	private String myValue;
 
 	@Transient
@@ -129,8 +127,8 @@ public class TermValueSetConceptDesignation implements Serializable {
 	}
 
 	public TermValueSetConceptDesignation setLanguage(String theLanguage) {
-		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theLanguage, MAX_LENGTH,
-			"Language exceeds maximum length (" + MAX_LENGTH + "): " + length(theLanguage));
+		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theLanguage, TermConceptDesignation.MAX_LENGTH,
+			"Language exceeds maximum length (" + TermConceptDesignation.MAX_LENGTH + "): " + length(theLanguage));
 		myLanguage = theLanguage;
 		return this;
 	}
@@ -140,8 +138,8 @@ public class TermValueSetConceptDesignation implements Serializable {
 	}
 
 	public TermValueSetConceptDesignation setUseSystem(String theUseSystem) {
-		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theUseSystem, MAX_LENGTH,
-			"Use system exceeds maximum length (" + MAX_LENGTH + "): " + length(theUseSystem));
+		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theUseSystem, TermConceptDesignation.MAX_LENGTH,
+			"Use system exceeds maximum length (" + TermConceptDesignation.MAX_LENGTH + "): " + length(theUseSystem));
 		myUseSystem = theUseSystem;
 		return this;
 	}
@@ -151,8 +149,8 @@ public class TermValueSetConceptDesignation implements Serializable {
 	}
 
 	public TermValueSetConceptDesignation setUseCode(String theUseCode) {
-		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theUseCode, MAX_LENGTH,
-			"Use code exceeds maximum length (" + MAX_LENGTH + "): " + length(theUseCode));
+		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theUseCode, TermConceptDesignation.MAX_LENGTH,
+			"Use code exceeds maximum length (" + TermConceptDesignation.MAX_LENGTH + "): " + length(theUseCode));
 		myUseCode = theUseCode;
 		return this;
 	}
@@ -162,7 +160,7 @@ public class TermValueSetConceptDesignation implements Serializable {
 	}
 
 	public TermValueSetConceptDesignation setUseDisplay(String theUseDisplay) {
-		myUseDisplay = left(theUseDisplay, MAX_LENGTH);
+		myUseDisplay = left(theUseDisplay, TermConceptDesignation.MAX_LENGTH);
 		return this;
 	}
 
@@ -172,8 +170,8 @@ public class TermValueSetConceptDesignation implements Serializable {
 
 	public TermValueSetConceptDesignation setValue(@Nonnull String theValue) {
 		ValidateUtil.isNotBlankOrThrowIllegalArgument(theValue, "theValue must not be null or empty");
-		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theValue, MAX_LENGTH,
-			"Value exceeds maximum length (" + MAX_LENGTH + "): " + length(theValue));
+		ValidateUtil.isNotTooLongOrThrowIllegalArgument(theValue, TermConceptDesignation.MAX_VAL_LENGTH,
+			"Value exceeds maximum length (" + TermConceptDesignation.MAX_VAL_LENGTH + "): " + length(theValue));
 		myValue = theValue;
 		return this;
 	}

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermValueSetConceptView.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/entity/TermValueSetConceptView.java
@@ -77,19 +77,19 @@ public class TermValueSetConceptView implements Serializable {
 	@Column(name = "DESIGNATION_PID")
 	private Long myDesignationPid;
 
-	@Column(name = "DESIGNATION_LANG", length = TermValueSetConceptDesignation.MAX_LENGTH)
+	@Column(name = "DESIGNATION_LANG", length = TermConceptDesignation.MAX_LENGTH)
 	private String myDesignationLang;
 
-	@Column(name = "DESIGNATION_USE_SYSTEM", length = TermValueSetConceptDesignation.MAX_LENGTH)
+	@Column(name = "DESIGNATION_USE_SYSTEM", length = TermConceptDesignation.MAX_LENGTH)
 	private String myDesignationUseSystem;
 
-	@Column(name = "DESIGNATION_USE_CODE", length = TermValueSetConceptDesignation.MAX_LENGTH)
+	@Column(name = "DESIGNATION_USE_CODE", length = TermConceptDesignation.MAX_LENGTH)
 	private String myDesignationUseCode;
 
-	@Column(name = "DESIGNATION_USE_DISPLAY", length = TermValueSetConceptDesignation.MAX_LENGTH)
+	@Column(name = "DESIGNATION_USE_DISPLAY", length = TermConceptDesignation.MAX_LENGTH)
 	private String myDesignationUseDisplay;
 
-	@Column(name = "DESIGNATION_VAL", length = TermValueSetConceptDesignation.MAX_LENGTH)
+	@Column(name = "DESIGNATION_VAL", length = TermConceptDesignation.MAX_VAL_LENGTH)
 	private String myDesignationVal;
 
 

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -20,7 +20,6 @@ package ca.uhn.fhir.jpa.migrate.tasks;
  * #L%
  */
 
-import ca.uhn.fhir.jpa.entity.*;
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
 import ca.uhn.fhir.jpa.migrate.taskdef.AddColumnTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.ArbitrarySqlTask;
@@ -28,7 +27,6 @@ import ca.uhn.fhir.jpa.migrate.taskdef.BaseTableColumnTypeTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateHashesTask;
 import ca.uhn.fhir.jpa.migrate.tasks.api.BaseMigrationTasks;
 import ca.uhn.fhir.jpa.model.entity.*;
-import ca.uhn.fhir.rest.api.Constants;
 import ca.uhn.fhir.util.VersionEnum;
 
 import java.util.Arrays;
@@ -74,8 +72,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.addForeignKey("FK_RESVERPROV_RES_PID")
 			.toColumn("RES_PID")
 			.references("HFJ_RESOURCE", "RES_ID");
-		resVerProv.addColumn("SOURCE_URI").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, ResourceHistoryProvenanceEntity.SOURCE_URI_LENGTH);
-		resVerProv.addColumn("REQUEST_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, Constants.REQUEST_ID_LENGTH);
+		resVerProv.addColumn("SOURCE_URI").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
+		resVerProv.addColumn("REQUEST_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 16);
 		resVerProv.addIndex("IDX_RESVERPROV_SOURCEURI").unique(false).withColumns("SOURCE_URI");
 		resVerProv.addIndex("IDX_RESVERPROV_REQUESTID").unique(false).withColumns("REQUEST_ID");
 
@@ -87,6 +85,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.addForeignKey("FK_TRM_VSCD_VS_PID")
 			.toColumn("VALUESET_PID")
 			.references("TRM_VALUESET", "PID");
+
 		// Drop HFJ_SEARCH_RESULT foreign keys
 		version.onTable("HFJ_SEARCH_RESULT").dropForeignKey("FK_SEARCHRES_RES", "HFJ_RESOURCE");
 		version.onTable("HFJ_SEARCH_RESULT").dropForeignKey("FK_SEARCHRES_SEARCH", "HFJ_SEARCH");
@@ -118,7 +117,13 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable("HFJ_RES_LINK").modifyColumn("TARGET_RESOURCE_TYPE").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 35);
 		version.onTable("HFJ_RES_TAG").modifyColumn("RES_TYPE").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 35);
 
+		// TermConceptDesignation
+		version.startSectionWithMessage("Processing table: TRM_CONCEPT_DESIG");
+		version.onTable("TRM_CONCEPT_DESIG").modifyColumn("VAL").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 2000);
 
+		// TermValueSetConceptDesignation
+		version.startSectionWithMessage("Processing table: TRM_VALUESET_C_DESIGNATION");
+		version.onTable("TRM_VALUESET_C_DESIGNATION").modifyColumn("VAL").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 2000);
 	}
 
 	protected void init400() {
@@ -194,7 +199,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.addIdGenerator("SEQ_VALUESET_PID");
 		Builder.BuilderAddTableByColumns termValueSetTable = version.addTableByColumns("TRM_VALUESET", "PID");
 		termValueSetTable.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		termValueSetTable.addColumn("URL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSet.MAX_URL_LENGTH);
+		termValueSetTable.addColumn("URL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
 		termValueSetTable
 			.addIndex("IDX_VALUESET_URL")
 			.unique(true)
@@ -204,7 +209,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.addForeignKey("FK_TRMVALUESET_RES")
 			.toColumn("RES_ID")
 			.references("HFJ_RESOURCE", "RES_ID");
-		termValueSetTable.addColumn("NAME").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSet.MAX_NAME_LENGTH);
+		termValueSetTable.addColumn("NAME").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
 
 		version.onTable("TRM_VALUESET")
 			.renameColumn("NAME", "VSNAME", true, true);
@@ -212,7 +217,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.modifyColumn("RES_ID").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
 
 		Builder.BuilderWithTableName termValueSetTableChange = version.onTable("TRM_VALUESET");
-		termValueSetTableChange.addColumn("EXPANSION_STATUS").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSet.MAX_EXPANSION_STATUS_LENGTH);
+		termValueSetTableChange.addColumn("EXPANSION_STATUS").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 50);
 		termValueSetTableChange
 			.addIndex("IDX_VALUESET_EXP_STATUS")
 			.unique(false)
@@ -228,9 +233,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.addForeignKey("FK_TRM_VALUESET_PID")
 			.toColumn("VALUESET_PID")
 			.references("TRM_VALUESET", "PID");
-		termValueSetConceptTable.addColumn("SYSTEM_URL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermCodeSystem.MAX_URL_LENGTH);
-		termValueSetConceptTable.addColumn("CODEVAL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermConcept.MAX_CODE_LENGTH);
-		termValueSetConceptTable.addColumn("DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermConcept.MAX_DESC_LENGTH);
+		termValueSetConceptTable.addColumn("SYSTEM_URL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		termValueSetConceptTable.addColumn("CODEVAL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+		termValueSetConceptTable.addColumn("DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 400);
 		version.onTable("TRM_VALUESET_CONCEPT")
 			.renameColumn("CODE", "CODEVAL", true, true)
 			.renameColumn("SYSTEM", "SYSTEM_URL", true, true);
@@ -252,11 +257,11 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.addForeignKey("FK_TRM_VALUESET_CONCEPT_PID")
 			.toColumn("VALUESET_CONCEPT_PID")
 			.references("TRM_VALUESET_CONCEPT", "PID");
-		termValueSetConceptDesignationTable.addColumn("LANG").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSetConceptDesignation.MAX_LENGTH);
-		termValueSetConceptDesignationTable.addColumn("USE_SYSTEM").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSetConceptDesignation.MAX_LENGTH);
-		termValueSetConceptDesignationTable.addColumn("USE_CODE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSetConceptDesignation.MAX_LENGTH);
-		termValueSetConceptDesignationTable.addColumn("USE_DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSetConceptDesignation.MAX_LENGTH);
-		termValueSetConceptDesignationTable.addColumn("VAL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermValueSetConceptDesignation.MAX_LENGTH);
+		termValueSetConceptDesignationTable.addColumn("LANG").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("USE_SYSTEM").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("USE_CODE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("USE_DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("VAL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
 		termValueSetConceptDesignationTable
 			.addIndex("IDX_VALUESET_C_DSGNTN_VAL")
 			.unique(false)
@@ -265,13 +270,13 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		// TermCodeSystemVersion
 		version.startSectionWithMessage("Processing table: TRM_CODESYSTEM_VER");
 		Builder.BuilderWithTableName termCodeSystemVersionTable = version.onTable("TRM_CODESYSTEM_VER");
-		termCodeSystemVersionTable.addColumn("CS_DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, TermCodeSystemVersion.MAX_VERSION_LENGTH);
+		termCodeSystemVersionTable.addColumn("CS_DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
 
 		// ResourceReindexJobEntry
 		version.addIdGenerator("SEQ_RES_REINDEX_JOB");
 		Builder.BuilderAddTableByColumns reindex = version.addTableByColumns("HFJ_RES_REINDEX_JOB", "PID");
 		reindex.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		reindex.addColumn("RES_TYPE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, Constants.MAX_RESOURCE_NAME_LENGTH);
+		reindex.addColumn("RES_TYPE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
 		reindex.addColumn("UPDATE_THRESHOLD_HIGH").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
 		reindex.addColumn("JOB_DELETED").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
 		reindex.addColumn("UPDATE_THRESHOLD_LOW").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
@@ -286,7 +291,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable("HFJ_SEARCH")
 			.addColumn("SEARCH_PARAM_MAP").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BLOB);
 		version.onTable("HFJ_SEARCH")
-			.modifyColumn("SEARCH_UUID").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, Search.UUID_COLUMN_LENGTH);
+			.modifyColumn("SEARCH_UUID").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 36);
 
 		version.onTable("HFJ_SEARCH_PARM").dropThisTable();
 
@@ -319,7 +324,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		resourceLink
 			.modifyColumn("SRC_PATH")
 			.nonNullable()
-			.withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, ResourceLink.SRC_PATH_LENGTH);
+			.withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
 
 		// Search
 		Builder.BuilderWithTableName search = version.onTable("HFJ_SEARCH");


### PR DESCRIPTION
… they are not necessarily constant across schema versions.

Also increased `val` column length for for TermConceptDesignation and TermValueSetConceptDesignation ([see this post](https://groups.google.com/forum/#!topic/hapi-fhir/OD96QMWSEhc)).