### PR TITLE
Add metadata for eclipse-pde-build to manifest-file

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -159,6 +159,7 @@
 							ca.uhn.fhir.model.api;resolution:=optional,
 							*
 						</Import-Package>
+						<Eclipse-ExtensibleAPI>true</Eclipse-ExtensibleAPI>
 					</instructions>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
When developing OSGi-bundles and using the eclipse-pde-build requires
additional meta-data in the manifest-file at compile-time.

Detailed explanations are described in
http://blog.vogella.com/2016/02/09/osgi-bundles-fragments-dependencies/.
The section "When are fragments the wrong agent of choice?" describes
exactly the hapi-fhir-architecture, the problems that I had and the
solution.

This change is completly safe because it is ignored at runtime. It is
just needed at compile time in a special usa case within eclipse.