### PR TITLE
Fix #1481 - Add missing dependency to hapi-fhir-docs

### DIFF
--- a/hapi-fhir-docs/pom.xml
+++ b/hapi-fhir-docs/pom.xml
@@ -87,6 +87,12 @@
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.7.28</version>
 		</dependency>
+		<!-- Needed for JEE/Servlet support -->
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
There's a missing dependency in hapi-fhir-docs due to the fix in issue 1481