### PR TITLE
no need the jar under web-inf/lib,it will be smaller 100M than before

### DIFF
--- a/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-app/pom.xml
@@ -112,6 +112,7 @@
 									<excludes>
 										<exclude>**/*.SF</exclude>
 										<exclude>**/*.RSA</exclude>
+                                                                                <exclude>**/*.jar</exclude><!--no need the jar under web-inf/lib,it will be smaller 100M than before-->
 									</excludes>
 								</filter>
 							</filters>


### PR DESCRIPTION


no need the jar under web-inf/lib,the package will be smaller 100M than before which not added this.I test it ,it works normally.