### PR TITLE
Fix gettimezone performanceissue

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/primitive/BaseDateTimeDt.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/primitive/BaseDateTimeDt.java
@@ -22,7 +22,11 @@ package ca.uhn.fhir.model.primitive;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/primitive/BaseDateTimeDt.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/model/primitive/BaseDateTimeDt.java
@@ -22,10 +22,8 @@ package ca.uhn.fhir.model.primitive;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -39,6 +37,8 @@ import ca.uhn.fhir.parser.DataFormatException;
 public abstract class BaseDateTimeDt extends BasePrimitive<Date> {
 	static final long NANOS_PER_MILLIS = 1000000L;
 	static final long NANOS_PER_SECOND = 1000000000L;
+
+	private static final Map<String, TimeZone> timezoneCache = new ConcurrentHashMap<>();
 
 	private static final FastDateFormat ourHumanDateFormat = FastDateFormat.getDateInstance(FastDateFormat.MEDIUM);
 	private static final FastDateFormat ourHumanDateTimeFormat = FastDateFormat.getDateTimeInstance(FastDateFormat.MEDIUM, FastDateFormat.MEDIUM);
@@ -574,10 +574,15 @@ public abstract class BaseDateTimeDt extends BasePrimitive<Date> {
 			parseInt(theWholeValue, theValue.substring(1, 3), 0, 23);
 			parseInt(theWholeValue, theValue.substring(4, 6), 0, 59);
 			clearTimeZone();
-			setTimeZone(TimeZone.getTimeZone("GMT" + theValue));
+			setTimeZone(getTimeZone(theValue));
 		}
 
 		return this;
+	}
+
+	private TimeZone getTimeZone(String offset) {
+		return timezoneCache.computeIfAbsent(offset, (offsetLocal) ->
+			TimeZone.getTimeZone("GMT" + offsetLocal));
 	}
 
 	public BaseDateTimeDt setTimeZone(TimeZone theTimeZone) {


### PR DESCRIPTION
TimeZone.getTimeZone() is static synchronized and can take significant time for "custom" time zone ids like "GMT+01:00" - see CustomID on https://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html. This means that it is a performance bottleneck on systems with high number of transactions. Fixed such that TimeZone is cached in BaseDateTimeDt.