### PR TITLE
Preventing infinite recursion when two resources that have a referenc…

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/BaseParser.java
@@ -192,7 +192,7 @@ public abstract class BaseParser implements IParser {
 			IBaseResource resource = next.getResource();
 			if (resource != null) {
 				if (resource.getIdElement().isEmpty() || resource.getIdElement().isLocal()) {
-					if (theContained.getResourceId(resource) != null) {
+					if (theContained.getResourceToIdMap().containsKey(resource)) {
 						// Prevent infinite recursion if there are circular loops in the contained resources
 						continue;
 					}


### PR DESCRIPTION
Preventing infinite recursion when two resources that have a reference to each other are created in the same transaction.

Problem: the id of the resources is null in this case and that causes the loop because of the check

https://groups.google.com/forum/#!topic/hapi-fhir/Q8J2BITYqg4