### PR TITLE
Missing mandatory status on created Snomed CodeSystem

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermLoaderSvcImpl.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/term/TermLoaderSvcImpl.java
@@ -550,6 +550,7 @@ public class TermLoaderSvcImpl implements ITermLoaderSvc {
 		cs.setUrl(SCT_URI);
 		cs.setName("SNOMED CT");
 		cs.setContent(CodeSystem.CodeSystemContentMode.NOTPRESENT);
+		cs.setStatus(Enumerations.PublicationStatus.ACTIVE);
 		IIdType target = storeCodeSystem(theRequestDetails, codeSystemVersion, cs, null, null);
 
 		return new UploadStatistics(code2concept.size(), target);


### PR DESCRIPTION
Status is mandatory accroding to the Fhir profile.

https://groups.google.com/forum/#!topic/hapi-fhir/Z2p5Uo1ds80