### PR TITLE
Make constructor of 'Verdict' public

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/interceptor/auth/AuthorizationInterceptor.java
@@ -423,7 +423,7 @@ public class AuthorizationInterceptor implements IRuleApplier {
 		private final IAuthRule myDecidingRule;
 		private final PolicyEnum myDecision;
 
-		Verdict(PolicyEnum theDecision, IAuthRule theDecidingRule) {
+		public Verdict(PolicyEnum theDecision, IAuthRule theDecidingRule) {
 			Validate.notNull(theDecision);
 
 			myDecision = theDecision;

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/VerdictTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/VerdictTest.java
@@ -1,0 +1,48 @@
+package ca.uhn.fhir.rest.server;
+
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationFlagsEnum;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor.Verdict;
+import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
+import ca.uhn.fhir.rest.server.interceptor.auth.IRuleApplier;
+import ca.uhn.fhir.rest.server.interceptor.auth.PolicyEnum;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.IIdType;
+import org.junit.Test;
+
+import java.util.Set;
+
+/**
+ * Tests for {@link Verdict}
+ *
+ * @author Jafer Khan Shamshad
+ */
+public class VerdictTest {
+
+	/**
+	 * Implementers should be able to instantiate {@link Verdict} outside the package where it has been defined.
+	 */
+	@Test
+	public void testInstantiationFromAnotherPackage() {
+		Verdict verdict = new Verdict(PolicyEnum.ALLOW, new CustomRule());
+	}
+
+	/**
+	 * Existing implementations of {@link IAuthRule} are inaccessible from this package.
+	 * This test class is a sample implementation of {@link IAuthRule}.
+	 */
+	public static class CustomRule implements IAuthRule {
+
+		@Override
+		public Verdict applyRule(RestOperationTypeEnum theOperation, RequestDetails theRequestDetails, IBaseResource theInputResource, IIdType theInputResourceId, IBaseResource theOutputResource, IRuleApplier theRuleApplier, Set<AuthorizationFlagsEnum> theFlags, Pointcut thePointcut) {
+			return new Verdict(PolicyEnum.ALLOW, this);
+		}
+
+		@Override
+		public String getName() {
+			return "Custom rule";
+		}
+	}
+}

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/VerdictTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/auth/VerdictTest.java
@@ -1,9 +1,11 @@
 package ca.uhn.fhir.rest.server.interceptor.auth;
 
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor.Verdict;
+import org.junit.Test;
 
 public class VerdictTest {
 
+	@Test
 	public void testToString() {
 		Verdict v = new AuthorizationInterceptor.Verdict(PolicyEnum.ALLOW, new RuleImplOp("foo"));
 		v.toString();


### PR DESCRIPTION
Hello people,

This pull request has been submitted in order to allow implementers to instantiate `Verdict` objects from their custom implementations of `IAuthRule`. Please see issue #1621

The fix was to increase the access level of the constructor defined in `Verdict` class from `package-private` to `public`.

Please let me know if there is any room for improvement.

Thanks,
Jafer