### PR TITLE
add support to stub out renameindex

### DIFF
--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -163,10 +163,19 @@ public class Builder {
 		}
 
 		public void renameIndex(String theVersion, String theOldIndexName, String theNewIndexName) {
+			renameIndexOptional(false, theVersion, theOldIndexName, theNewIndexName);
+		}
+
+		public void renameIndexStub(String theVersion, String theOldIndexName, String theNewIndexName) {
+			renameIndexOptional(true, theVersion, theOldIndexName, theNewIndexName);
+		}
+
+		private void renameIndexOptional(boolean theDoNothing, String theVersion, String theOldIndexName, String theNewIndexName) {
 			RenameIndexTask task = new RenameIndexTask(myRelease, theVersion);
 			task.setOldIndexName(theOldIndexName);
 			task.setNewIndexName(theNewIndexName);
 			task.setTableName(myTableName);
+			task.setDoNothing(theDoNothing);
 			addTask(task);
 		}
 


### PR DESCRIPTION
tiny MR to deal with a migration copy/paste error (oopsie)