### PR TITLE
Remove transient fields from migration task

### DIFF
--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/RenameColumnTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/RenameColumnTask.java
@@ -146,8 +146,6 @@ public class RenameColumnTask extends BaseTableTask<RenameColumnTask> {
 
 		return new EqualsBuilder()
 			.appendSuper(super.equals(theO))
-			.append(myIsOkayIfNeitherColumnExists, that.myIsOkayIfNeitherColumnExists)
-			.append(myDeleteTargetColumnFirstIfBothExist, that.myDeleteTargetColumnFirstIfBothExist)
 			.append(myOldName, that.myOldName)
 			.append(myNewName, that.myNewName)
 			.isEquals();
@@ -159,8 +157,6 @@ public class RenameColumnTask extends BaseTableTask<RenameColumnTask> {
 			.appendSuper(super.hashCode())
 			.append(myOldName)
 			.append(myNewName)
-			.append(myIsOkayIfNeitherColumnExists)
-			.append(myDeleteTargetColumnFirstIfBothExist)
 			.toHashCode();
 	}
 }


### PR DESCRIPTION
Hello people,

This pull request fixes issue #1674, which asks for the removal of transient fields from the migration task named `RenameColumnTask`, as these fields could cause un-intended side effects whilst running this task.

Please let me know if there is any room for improvement.

Thanks,
Jafer