### PR TITLE
updated custom narrative generation documentation

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/narrative_generation.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/model/narrative_generation.md
@@ -64,7 +64,7 @@ The first (name.class) defines the class name of the resource to define a templa
 
 ```properties
 # Two property lines in the file per template
-practitioner.class=ca.uhn.fhir.model.dstu.resource.Practitioner
+practitioner.resourceType=Practitioner
 practitioner.narrative=file:src/test/resources/narrative/Practitioner.html
 
 observation.class=ca.uhn.fhir.model.dstu.resource.Observation
@@ -77,7 +77,7 @@ You may also override/define behaviour for datatypes. These datatype narrative d
 
 ```properties
 # datatypes use the same format as resources
-humanname.class=ca.uhn.fhir.model.dstu.composite.HumanNameDt
+humanname.resourceType=HumanNameDt
 humanname.narrative=classpath:ca/uhn/fhir/narrative/HumanNameDt.html]]></source>
 ```
 


### PR DESCRIPTION
I found that the documented pattern of
 [name].class=[fully qualified classname]
No longer works. The pattern of
 [name].resourceType=[ResourceType]
worked for me, I updated the datatype example as well in kind, but I've not used it that way.

Maybe some extended examples for the other property type extensions would be good - e.g. .profile, .style, .contextPath, .narrative, .title