### PR TITLE
narrative gen removed old code and enhanced error message

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative2/NarrativeTemplateManifest.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/narrative2/NarrativeTemplateManifest.java
@@ -155,18 +155,6 @@ public class NarrativeTemplateManifest implements INarrativeTemplateManifest {
 					.map(t -> t.trim())
 					.filter(t -> isNotBlank(t))
 					.forEach(t -> nextTemplate.addAppliesToDatatype(t));
-			} else if (nextKey.endsWith(".class")) {
-				String className = file.getProperty(nextKey);
-				Class<? extends IBase> clazz;
-				try {
-					clazz = (Class<? extends IBase>) Class.forName(className);
-				} catch (ClassNotFoundException e) {
-					ourLog.debug("Unknown datatype class '{}' identified in manifest", name);
-					clazz = null;
-				}
-				if (clazz != null) {
-					nextTemplate.addAppliesToResourceClass(clazz);
-				}
 			} else if (nextKey.endsWith(".style")) {
 				String templateTypeName = file.getProperty(nextKey).toUpperCase();
 				TemplateTypeEnum templateType = TemplateTypeEnum.valueOf(templateTypeName);
@@ -183,7 +171,9 @@ public class NarrativeTemplateManifest implements INarrativeTemplateManifest {
 			} else if (nextKey.endsWith(".title")) {
 				ourLog.debug("Ignoring title property as narrative generator no longer generates titles: {}", nextKey);
 			} else {
-				throw new ConfigurationException("Invalid property name: " + nextKey);
+				throw new ConfigurationException("Invalid property name: " + nextKey 
+															+ " - the key must end in one of the expected extensions "
+															+ "'.profile', '.resourceType', '.dataType', '.style', '.contextPath', '.narrative', '.title'");
 			}
 
 		}


### PR DESCRIPTION
I ran into an issue trying to use the old .class style property. The validation message was useful, but I spotted some unreachable code investigating which I've removed. I also enhanced the configuration exception to indicate what was wrong with a supplied key and expected extension types.