### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1326,7 +1326,7 @@
 			<dependency>
 				<groupId>org.quartz-scheduler</groupId>
 				<artifactId>quartz</artifactId>
-				<version>2.3.1</version>
+				<version>2.3.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.slf4j</groupId>


### PR DESCRIPTION
A run on master using https://jeremylong.github.io/DependencyCheck/dependency-check-maven/index.html shows quartz as having a critical security issue in version 2.3.1