### PR TITLE
Make BaseOrListParam and BaseParam visible outside of the package

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/BaseOrListParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/BaseOrListParam.java
@@ -28,7 +28,7 @@ import ca.uhn.fhir.rest.api.QualifiedParamList;
 import java.util.ArrayList;
 import java.util.List;
 
-abstract class BaseOrListParam<MT extends BaseOrListParam<?, ?>, PT extends IQueryParameterType> implements IQueryParameterOr<PT> {
+public abstract class BaseOrListParam<MT extends BaseOrListParam<?, ?>, PT extends IQueryParameterType> implements IQueryParameterOr<PT> {
 
 	private List<PT> myList = new ArrayList<>();
 

--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/BaseParam.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/BaseParam.java
@@ -31,7 +31,7 @@ import ca.uhn.fhir.rest.server.exceptions.InvalidRequestException;
 /**
  * Base class for RESTful operation parameter types
  */
-abstract class BaseParam implements IQueryParameterType {
+public abstract class BaseParam implements IQueryParameterType {
 
 	private Boolean myMissing;
 


### PR DESCRIPTION
This is just a simple PR to make `BaseOrListParam` and `BaseParam` visible outside the `ca.uhn.fhir.rest.param` package similar to how `BaseAndListParam` is. This is useful for creating more generic APIs.