### PR TITLE
enhanced Restfulserver constructor

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/RestfulServer.java
@@ -148,8 +148,12 @@ public class RestfulServer extends HttpServlet implements IRestfulServer<Servlet
 	 * Constructor
 	 */
 	public RestfulServer(FhirContext theCtx) {
+		this(theCtx, new InterceptorService());
+	}
+
+	public RestfulServer(FhirContext theCtx, IInterceptorService theInterceptorService)	{
 		myFhirContext = theCtx;
-		setInterceptorService(new InterceptorService());
+		setInterceptorService(theInterceptorService);
 	}
 
 	private void addContentLocationHeaders(RequestDetails theRequest, HttpServletResponse servletResponse, MethodOutcome response, String resourceName) {


### PR DESCRIPTION
enhanced the Constructor to accept an existing Intercpetorservice (e.g. jpaInterceptorService Bean of hapi-fhir-jpaserver-base)