### PR TITLE
Raise an error on including invalid query string parameter(s) in read operations

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/api/Constants.java
@@ -149,6 +149,8 @@ public class Constants {
 	 */
 	public static final String PARAM_BUNDLETYPE = "_bundletype";
 	public static final String PARAM_FILTER = "_filter";
+	public static final String PARAM_CONTAINED = "_contained";
+	public static final String PARAM_CONTAINED_TYPE = "_containedType";
 	public static final String PARAM_CONTENT = "_content";
 	public static final String PARAM_COUNT = "_count";
 	public static final String PARAM_DELETE = "_delete";

--- a/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
+++ b/hapi-fhir-base/src/main/resources/ca/uhn/fhir/i18n/hapi-messages.properties
@@ -36,6 +36,8 @@ ca.uhn.fhir.rest.server.method.IncludeParameter.orIncludeInRequest='OR' query pa
 
 ca.uhn.fhir.rest.server.method.PageMethodBinding.unknownSearchId=Search ID "{0}" does not exist and may have expired
 
+ca.uhn.fhir.rest.server.method.ReadMethodBinding.invalidParamsInRequest=Invalid query parameter(s) for this request: "{0}"
+
 ca.uhn.fhir.rest.server.method.SearchMethodBinding.invalidSpecialParamName=Method [{0}] in provider [{1}] contains search parameter annotated to use name [{2}] - This name is reserved according to the FHIR specification and can not be used as a search parameter name.
 ca.uhn.fhir.rest.server.method.SearchMethodBinding.idWithoutCompartment=Method [{0}] in provider [{1}] has an @IdParam parameter. This is only allowable for compartment search (e.g. @Search(compartment="foo") )
 ca.uhn.fhir.rest.server.method.SearchMethodBinding.idNullForCompartmentSearch=ID parameter can not be null or empty for compartment search

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/method/ReadMethodBinding.java
@@ -51,6 +51,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -153,6 +154,22 @@ public class ReadMethodBinding extends BaseResourceReturningMethodBinding {
 	@Override
 	public IBundleProvider invokeServer(IRestfulServer<?> theServer, RequestDetails theRequest, Object[] theMethodParams) throws InvalidRequestException, InternalErrorException {
 		IIdType requestId = theRequest.getId();
+		FhirContext ctx = theRequest.getServer().getFhirContext();
+
+		String[] invalidQueryStringParams = new String[]{Constants.PARAM_CONTAINED, Constants.PARAM_COUNT, Constants.PARAM_INCLUDE, Constants.PARAM_REVINCLUDE, Constants.PARAM_SORT, Constants.PARAM_SEARCH_TOTAL_MODE};
+		List<String> invalidQueryStringParamsInRequest = new ArrayList<>();
+		Set<String> queryStringParamsInRequest = theRequest.getParameters().keySet();
+
+		for (String queryStringParamName : queryStringParamsInRequest) {
+			String lowercaseQueryStringParamName = queryStringParamName.toLowerCase();
+			if (StringUtils.startsWithAny(lowercaseQueryStringParamName, invalidQueryStringParams)) {
+				invalidQueryStringParamsInRequest.add(queryStringParamName);
+			}
+		}
+
+		if (!invalidQueryStringParamsInRequest.isEmpty()) {
+			throw new InvalidRequestException(ctx.getLocalizer().getMessage(ReadMethodBinding.class, "invalidParamsInRequest", invalidQueryStringParamsInRequest));
+		}
 
 		theMethodParams[myIdIndex] = ParameterUtil.convertIdToType(requestId, myIdParameterType);
 
@@ -201,7 +218,7 @@ public class ReadMethodBinding extends BaseResourceReturningMethodBinding {
 			}
 				
 		} // if we have at least 1 result
-		
+
 		
 		return retVal;
 	}

--- a/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/ReadDstu3Test.java
+++ b/hapi-fhir-structures-dstu3/src/test/java/ca/uhn/fhir/rest/server/ReadDstu3Test.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
@@ -62,6 +63,131 @@ public class ReadDstu3Test {
 				"  <valueDate value=\"2011-01-01\"/>",
 				" </modifierExtension>",
 				"</Patient>"));
+	}
+
+	@Test
+	public void testInvalidQueryParamsInRead() throws Exception {
+		CloseableHttpResponse status;
+		HttpGet httpGet;
+
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2?_contained=both&_format=xml&_pretty=true");
+		status = ourClient.execute(httpGet);
+		try (InputStream inputStream = status.getEntity().getContent()) {
+			assertEquals(400, status.getStatusLine().getStatusCode());
+
+			String responseContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+			assertThat(responseContent, stringContainsInOrder(
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\">",
+				" <issue>",
+				"  <severity value=\"error\"/>",
+				"  <code value=\"processing\"/>",
+				"  <diagnostics value=\"Invalid query parameter(s) for this request: &quot;[_contained]&quot;\"/>",
+				" </issue>",
+				"</OperationOutcome>"
+			));
+		}
+
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2?_containedType=contained&_format=xml&_pretty=true");
+		status = ourClient.execute(httpGet);
+		try (InputStream inputStream = status.getEntity().getContent()) {
+			assertEquals(400, status.getStatusLine().getStatusCode());
+
+			String responseContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+			assertThat(responseContent, stringContainsInOrder(
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\">",
+				" <issue>",
+				"  <severity value=\"error\"/>",
+				"  <code value=\"processing\"/>",
+				"  <diagnostics value=\"Invalid query parameter(s) for this request: &quot;[_containedType]&quot;\"/>",
+				" </issue>",
+				"</OperationOutcome>"
+			));
+		}
+
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2?_count=10&_format=xml&_pretty=true");
+		status = ourClient.execute(httpGet);
+		try (InputStream inputStream = status.getEntity().getContent()) {
+			assertEquals(400, status.getStatusLine().getStatusCode());
+
+			String responseContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+			assertThat(responseContent, stringContainsInOrder(
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\">",
+				" <issue>",
+				"  <severity value=\"error\"/>",
+				"  <code value=\"processing\"/>",
+				"  <diagnostics value=\"Invalid query parameter(s) for this request: &quot;[_count]&quot;\"/>",
+				" </issue>",
+				"</OperationOutcome>"
+			));
+		}
+
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2?_include=Patient:organization&_format=xml&_pretty=true");
+		status = ourClient.execute(httpGet);
+		try (InputStream inputStream = status.getEntity().getContent()) {
+			assertEquals(400, status.getStatusLine().getStatusCode());
+
+			String responseContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+			assertThat(responseContent, stringContainsInOrder(
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\">",
+				" <issue>",
+				"  <severity value=\"error\"/>",
+				"  <code value=\"processing\"/>",
+				"  <diagnostics value=\"Invalid query parameter(s) for this request: &quot;[_include]&quot;\"/>",
+				" </issue>",
+				"</OperationOutcome>"
+			));
+		}
+
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2?_revinclude=Provenance:target&_format=xml&_pretty=true");
+		status = ourClient.execute(httpGet);
+		try (InputStream inputStream = status.getEntity().getContent()) {
+			assertEquals(400, status.getStatusLine().getStatusCode());
+
+			String responseContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+			assertThat(responseContent, stringContainsInOrder(
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\">",
+				" <issue>",
+				"  <severity value=\"error\"/>",
+				"  <code value=\"processing\"/>",
+				"  <diagnostics value=\"Invalid query parameter(s) for this request: &quot;[_revinclude]&quot;\"/>",
+				" </issue>",
+				"</OperationOutcome>"
+			));
+		}
+
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2?_sort=family&_format=xml&_pretty=true");
+		status = ourClient.execute(httpGet);
+		try (InputStream inputStream = status.getEntity().getContent()) {
+			assertEquals(400, status.getStatusLine().getStatusCode());
+
+			String responseContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+			assertThat(responseContent, stringContainsInOrder(
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\">",
+				" <issue>",
+				"  <severity value=\"error\"/>",
+				"  <code value=\"processing\"/>",
+				"  <diagnostics value=\"Invalid query parameter(s) for this request: &quot;[_sort]&quot;\"/>",
+				" </issue>",
+				"</OperationOutcome>"
+			));
+		}
+
+		httpGet = new HttpGet("http://localhost:" + ourPort + "/Patient/2?_total=accurate&_format=xml&_pretty=true");
+		status = ourClient.execute(httpGet);
+		try (InputStream inputStream = status.getEntity().getContent()) {
+			assertEquals(400, status.getStatusLine().getStatusCode());
+
+			String responseContent = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+			assertThat(responseContent, stringContainsInOrder(
+				"<OperationOutcome xmlns=\"http://hl7.org/fhir\">",
+				" <issue>",
+				"  <severity value=\"error\"/>",
+				"  <code value=\"processing\"/>",
+				"  <diagnostics value=\"Invalid query parameter(s) for this request: &quot;[_total]&quot;\"/>",
+				" </issue>",
+				"</OperationOutcome>"
+			));
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Hello people,
This pull request has been submitted as a response to issue #1774. It covers a feature enhancement that involves raising an error whenever a query string parameter that doesn't befit a read operation is encountered in a particular request.

Please let me know if I can make any improvements. I would be extremely thankful if I received some feedback as well.

Thanks,
Jafer