### PR TITLE
Allow using AWS-managed Elasticsearch

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/elastic/ElasticsearchHibernatePropertiesBuilder.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/elastic/ElasticsearchHibernatePropertiesBuilder.java
@@ -20,6 +20,7 @@ package ca.uhn.fhir.jpa.search.elastic;
  * #L%
  */
 
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.elasticsearch.cfg.ElasticsearchEnvironment;
 import org.hibernate.search.elasticsearch.cfg.ElasticsearchIndexStatus;
@@ -63,8 +64,12 @@ public class ElasticsearchHibernatePropertiesBuilder {
 		theProperties.put("hibernate.search." + ElasticsearchEnvironment.ANALYSIS_DEFINITION_PROVIDER, ElasticsearchMappingProvider.class.getName());
 
 		theProperties.put("hibernate.search.default.elasticsearch.host", myRestUrl);
-		theProperties.put("hibernate.search.default.elasticsearch.username", myUsername);
-		theProperties.put("hibernate.search.default.elasticsearch.password", myPassword);
+		if (StringUtils.isNotBlank(myUsername)) {
+			theProperties.put("hibernate.search.default.elasticsearch.username", myUsername);
+		}
+		if (StringUtils.isNotBlank(myPassword)) {
+			theProperties.put("hibernate.search.default.elasticsearch.password", myPassword);
+		}
 
 		theProperties.put("hibernate.search.default." + ElasticsearchEnvironment.INDEX_SCHEMA_MANAGEMENT_STRATEGY, myIndexSchemaManagementStrategy.getExternalName());
 		theProperties.put("hibernate.search.default." + ElasticsearchEnvironment.INDEX_MANAGEMENT_WAIT_TIMEOUT, Long.toString(myIndexManagementWaitTimeoutMillis));


### PR DESCRIPTION
Recently I've been trying to deploy HAPI with elasticsearch support using AWS-managed Elasticsearch service and it wasn't a smooth ride. Basically, HAPI was unable to connect to the Elasticsearch cluster, even though the configuration seemed correct.

It turned out that AWS Elasticsearch does not accept HTTP requests with Basic authentication, and because HAPI sets the `hibernate.search.default.elasticsearch.username` and `hibernate.search.default.elasticsearch.password` properties even if the configured username and password are blank, the underlying hibernate search is actually using those blank values to make basic authenticated requests.

Setting those two properties only of the configured values are not blank did the trick in our case.