### PR TITLE
Add missing indexes on ResourceIndexedSearchParamDate

### DIFF
--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -130,8 +130,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 
 		Builder.BuilderWithTableName spidxDate = version.onTable("HFJ_SPIDX_DATE");
 		spidxDate.addIndex("20200514.1", "IDX_SP_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW");
-		spidxDate.addIndex("20200514.2", "IDX_SP_DATE_ORD_DATE_HASH").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL", "SP_VALUE_HIGH_DATE_ORDINAL");
-		spidxDate.addIndex("20200514.3", "IDX_SP_DATE_ORD_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL");
+		spidxDate.addIndex("20200514.2", "IDX_SP_DATE_ORD_HASH").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL", "SP_VALUE_HIGH_DATE_ORDINAL");
+		spidxDate.addIndex("20200514.3", "IDX_SP_DATE_ORD_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL");
 	}
 
 	protected void init500() { // 20200218 - 20200519

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -60,8 +60,10 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		init410(); // 20190815 - 20191014
 		init420(); // 20191015 - 20200217
 		init430(); // Replaced by 5.0.0
-		init500(); // 20200218 - present
+		init500(); // 20200218 - 20200519
+		init501(); // 20200520 - present
 	}
+
 
 	/**
 	 * Partway through the 4.3.0 releaase cycle we renumbered to
@@ -122,7 +124,17 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.addNop("20200420.42");
 	}
 
-	protected void init500() { // 20200218 - present
+
+	private void init501() { //20200520 - present
+		Builder version = forVersion(VersionEnum.V5_0_1);
+
+		Builder.BuilderWithTableName spidxDate = version.onTable("HFJ_SPIDX_DATE");
+		spidxDate.addIndex("20200520.1", "IDX_SP_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW");
+		spidxDate.addIndex("20200520.2", "IDX_SP_DATE_ORD_DATE_HASH").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL", "SP_VALUE_HIGH_DATE_ORDINAL");
+		spidxDate.addIndex("20200520.3", "IDX_SP_DATE_ORD_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL");
+	}
+
+	protected void init500() { // 20200218 - 20200519
 		Builder version = forVersion(VersionEnum.V5_0_0);
 
 		// Eliminate circular dependency.

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -129,9 +129,9 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		Builder version = forVersion(VersionEnum.V5_0_1);
 
 		Builder.BuilderWithTableName spidxDate = version.onTable("HFJ_SPIDX_DATE");
-		spidxDate.addIndex("20200520.1", "IDX_SP_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW");
-		spidxDate.addIndex("20200520.2", "IDX_SP_DATE_ORD_DATE_HASH").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL", "SP_VALUE_HIGH_DATE_ORDINAL");
-		spidxDate.addIndex("20200520.3", "IDX_SP_DATE_ORD_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL");
+		spidxDate.addIndex("20200514.1", "IDX_SP_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW");
+		spidxDate.addIndex("20200514.2", "IDX_SP_DATE_ORD_DATE_HASH").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL", "SP_VALUE_HIGH_DATE_ORDINAL");
+		spidxDate.addIndex("20200514.3", "IDX_SP_DATE_ORD_DATE_HASH_LOW").unique(false).withColumns("HASH_IDENTITY", "SP_VALUE_LOW_DATE_ORDINAL");
 	}
 
 	protected void init500() { // 20200218 - 20200519

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -60,8 +60,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		init410(); // 20190815 - 20191014
 		init420(); // 20191015 - 20200217
 		init430(); // Replaced by 5.0.0
-		init500(); // 20200218 - 20200519
-		init501(); // 20200520 - present
+		init500(); // 20200218 - 20200513
+		init501(); // 20200514 - present
 	}
 
 
@@ -125,7 +125,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 	}
 
 
-	private void init501() { //20200520 - present
+	private void init501() { //20200514 - present
 		Builder version = forVersion(VersionEnum.V5_0_1);
 
 		Builder.BuilderWithTableName spidxDate = version.onTable("HFJ_SPIDX_DATE");

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
@@ -57,8 +57,8 @@ import java.util.Date;
 	@Index(name = "IDX_SP_DATE_UPDATED", columnList = "SP_UPDATED"),
 	@Index(name = "IDX_SP_DATE_RESID", columnList = "RES_ID"),
 	@Index(name = "IDX_SP_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW"),
-	@Index(name = "IDX_SP_ORD_DATE_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL,SP_VALUE_HIGH_DATE_ORDINAL"),
-	@Index(name = "IDX_SP_ORD_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL")
+	@Index(name = "IDX_SP_DATE_ORD_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL,SP_VALUE_HIGH_DATE_ORDINAL"),
+	@Index(name = "IDX_SP_DATE_ORD_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL")
 })
 public class ResourceIndexedSearchParamDate extends BaseResourceIndexedSearchParam {
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
@@ -54,6 +54,10 @@ import java.util.Date;
 @Table(name = "HFJ_SPIDX_DATE", indexes = {
 	// We previously had an index called IDX_SP_DATE - Dont reuse
 	@Index(name = "IDX_SP_DATE_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW,SP_VALUE_HIGH"),
+	@Index(name = "IDX_SP_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW"),
+	@Index(name = "IDX_SP_ORD_DATE_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL,SP_VALUE_HIGH_DATE_ORDINAL"),
+	@Index(name = "IDX_SP_ORD_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL"),
+	@Index(name = "IDX_SP_DATE_HASH_LH", columnList = "HASH_IDENTITY,SP_VALUE_LOW,SP_VALUE_HIGH"),
 	@Index(name = "IDX_SP_DATE_UPDATED", columnList = "SP_UPDATED"),
 	@Index(name = "IDX_SP_DATE_RESID", columnList = "RES_ID")
 })

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
@@ -54,12 +54,11 @@ import java.util.Date;
 @Table(name = "HFJ_SPIDX_DATE", indexes = {
 	// We previously had an index called IDX_SP_DATE - Dont reuse
 	@Index(name = "IDX_SP_DATE_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW,SP_VALUE_HIGH"),
+	@Index(name = "IDX_SP_DATE_UPDATED", columnList = "SP_UPDATED"),
+	@Index(name = "IDX_SP_DATE_RESID", columnList = "RES_ID"),
 	@Index(name = "IDX_SP_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW"),
 	@Index(name = "IDX_SP_ORD_DATE_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL,SP_VALUE_HIGH_DATE_ORDINAL"),
-	@Index(name = "IDX_SP_ORD_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL"),
-	@Index(name = "IDX_SP_DATE_HASH_LH", columnList = "HASH_IDENTITY,SP_VALUE_LOW,SP_VALUE_HIGH"),
-	@Index(name = "IDX_SP_DATE_UPDATED", columnList = "SP_UPDATED"),
-	@Index(name = "IDX_SP_DATE_RESID", columnList = "RES_ID")
+	@Index(name = "IDX_SP_ORD_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL")
 })
 public class ResourceIndexedSearchParamDate extends BaseResourceIndexedSearchParam {
 

--- a/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
+++ b/hapi-fhir-jpaserver-model/src/main/java/ca/uhn/fhir/jpa/model/entity/ResourceIndexedSearchParamDate.java
@@ -54,11 +54,11 @@ import java.util.Date;
 @Table(name = "HFJ_SPIDX_DATE", indexes = {
 	// We previously had an index called IDX_SP_DATE - Dont reuse
 	@Index(name = "IDX_SP_DATE_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW,SP_VALUE_HIGH"),
-	@Index(name = "IDX_SP_DATE_UPDATED", columnList = "SP_UPDATED"),
-	@Index(name = "IDX_SP_DATE_RESID", columnList = "RES_ID"),
 	@Index(name = "IDX_SP_DATE_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW"),
 	@Index(name = "IDX_SP_DATE_ORD_HASH", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL,SP_VALUE_HIGH_DATE_ORDINAL"),
-	@Index(name = "IDX_SP_DATE_ORD_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL")
+	@Index(name = "IDX_SP_DATE_ORD_HASH_LOW", columnList = "HASH_IDENTITY,SP_VALUE_LOW_DATE_ORDINAL"),
+	@Index(name = "IDX_SP_DATE_RESID", columnList = "RES_ID"),
+	@Index(name = "IDX_SP_DATE_UPDATED", columnList = "SP_UPDATED"),
 })
 public class ResourceIndexedSearchParamDate extends BaseResourceIndexedSearchParam {
 


### PR DESCRIPTION
* Add migration tasks for new indexes on ResourceIndexedSearchParamDate.
* Add new indexes to ResourceIndexedSearchParamDate for low-high ordinal, low ordinal, and low date.