### PR TITLE
Im 20200520 cascade delete

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/interceptor/api/Pointcut.java
@@ -1244,7 +1244,7 @@ public enum Pointcut {
 
 	/**
 	 * <b>Storage Hook:</b>
-	 * Invoked before a resource will be created
+	 * Invoked before a resource will be deleted
 	 * <p>
 	 * Hooks will have access to the contents of the resource being deleted
 	 * but should not make any changes as storage has already occurred
@@ -1282,7 +1282,7 @@ public enum Pointcut {
 
 	/**
 	 * <b>Storage Hook:</b>
-	 * Invoked when a resource delete operation is about to fail due to referential integrity hcts.
+	 * Invoked when a resource delete operation is about to fail due to referential integrity checks. Intended for use with ca.uhn.fhir.jpa.interceptor.CascadingDeleteInterceptor.
 	 * <p>
 	 * Hooks will have access to the list of resources that have references to the resource being deleted.
 	 * </p>

--- a/hapi-fhir-jpaserver-api/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
+++ b/hapi-fhir-jpaserver-api/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
@@ -83,6 +83,9 @@ public class DaoConfig {
 	private static final Logger ourLog = LoggerFactory.getLogger(DaoConfig.class);
 	private static final int DEFAULT_EXPUNGE_BATCH_SIZE = 800;
 	private IndexEnabledEnum myIndexMissingFieldsEnabled = IndexEnabledEnum.DISABLED;
+	private static final int DEFAULT_MAXIMUM_DELETE_CONFLICT_COUNT = 60;
+	private static final int DEFAULT_MAXIMUM_DELETE_CONFLICT_RETRY_ATTEMPTS = 10;
+
 
 	/**
 	 * Child Configurations
@@ -153,6 +156,10 @@ public class DaoConfig {
 	private ClientIdStrategyEnum myResourceClientIdStrategy = ClientIdStrategyEnum.ALPHANUMERIC;
 	private boolean myFilterParameterEnabled = false;
 	private StoreMetaSourceInformationEnum myStoreMetaSourceInformation = StoreMetaSourceInformationEnum.SOURCE_URI_AND_REQUEST_ID;
+	/**
+	 * update setter javadoc if default changes
+	 */
+	private Integer myMaximumDeleteConflictQueryCount = DEFAULT_MAXIMUM_DELETE_CONFLICT_COUNT;
 	/**
 	 * Do not change default of {@code true}!
 	 *
@@ -2021,4 +2028,33 @@ public class DaoConfig {
 		 */
 		ANY
 	}
+
+	/**
+	 * <p>
+	 * This determines the maximum number of conflicts that should be fetched and handled while retrying a delete of a resource.
+	 * </p>
+	 * <p>
+	 * The default value for this setting is {@code 60}.
+	 * </p>
+	 *
+	 * @since 4.1.0
+	 */
+	public Integer getMaximumDeleteConflictQueryCount() {
+		return myMaximumDeleteConflictQueryCount;
+	}
+
+	/**
+	 * <p>
+	 * This determines the maximum number of conflicts that should be fetched and handled while retrying a delete of a resource.
+	 * </p>
+	 * <p>
+	 * The default value for this setting is {@code 60}.
+	 * </p>
+	 *
+	 * @since 4.1.0
+	 */
+	public void setMaximumDeleteConflictQueryCount(Integer theMaximumDeleteConflictQueryCount) {
+		myMaximumDeleteConflictQueryCount = theMaximumDeleteConflictQueryCount;
+	}
+
 }

--- a/hapi-fhir-jpaserver-api/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
+++ b/hapi-fhir-jpaserver-api/src/main/java/ca/uhn/fhir/jpa/api/config/DaoConfig.java
@@ -84,8 +84,6 @@ public class DaoConfig {
 	private static final int DEFAULT_EXPUNGE_BATCH_SIZE = 800;
 	private IndexEnabledEnum myIndexMissingFieldsEnabled = IndexEnabledEnum.DISABLED;
 	private static final int DEFAULT_MAXIMUM_DELETE_CONFLICT_COUNT = 60;
-	private static final int DEFAULT_MAXIMUM_DELETE_CONFLICT_RETRY_ATTEMPTS = 10;
-
 
 	/**
 	 * Child Configurations

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/DeleteConflictService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/delete/DeleteConflictService.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Iterator;
 import java.util.List;
 
 @Service
@@ -87,7 +86,7 @@ public class DeleteConflictService {
 			++retryCount;
 		}
 		theDeleteConflicts.addAll(newConflicts);
-		if(retryCount >= MAX_RETRY_ATTEMPTS && !newConflicts.isEmpty()) {
+		if(retryCount >= MAX_RETRY_ATTEMPTS && !theDeleteConflicts.isEmpty()) {
 			IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(myFhirContext);
 			OperationOutcomeUtil.addIssue(myFhirContext, oo, BaseHapiFhirDao.OO_SEVERITY_ERROR, MAX_RETRY_ATTEMPTS_EXCEEDED_MSG,null, "processing");
 			throw new ResourceVersionConflictException(MAX_RETRY_ATTEMPTS_EXCEEDED_MSG, oo);
@@ -149,17 +148,13 @@ public class DeleteConflictService {
 		IBaseOperationOutcome oo = OperationOutcomeUtil.newInstance(theFhirContext);
 		String firstMsg = null;
 
-		Iterator<DeleteConflict> iterator = theDeleteConflicts.iterator();
-		while (iterator.hasNext()) {
-			DeleteConflict next = iterator.next();
-			StringBuilder b = new StringBuilder();
-			b.append("Unable to delete ");
-			b.append(next.getTargetId().toUnqualifiedVersionless().getValue());
-			b.append(" because at least one resource has a reference to this resource. First reference found was resource ");
-			b.append(next.getSourceId().toUnqualifiedVersionless().getValue());
-			b.append(" in path ");
-			b.append(next.getSourcePath());
-			String msg = b.toString();
+		for (DeleteConflict next : theDeleteConflicts) {
+			String msg = "Unable to delete " +
+				next.getTargetId().toUnqualifiedVersionless().getValue() +
+				" because at least one resource has a reference to this resource. First reference found was resource " +
+				next.getSourceId().toUnqualifiedVersionless().getValue() +
+				" in path " +
+				next.getSourcePath();
 			if (firstMsg == null) {
 				firstMsg = msg;
 			}


### PR DESCRIPTION
Replaced a hard-coded limit that restricted the number of delete conflicts that could be handled by a cascade delete request with a configurable value that can be increased where needed.