### PR TITLE
Duplicate maven-enforcer-plugin removed, executions consolidated.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2041,20 +2041,6 @@
 							</rules>
 						</configuration>
 					</execution>
-					<execution>
-						<id>enforce-property</id>
-						<goals>
-							<goal>enforce</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<requireJavaVersion>
-									<version>11</version>
-								</requireJavaVersion>
-							</rules>
-							<fail>true</fail>
-						</configuration>
-					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2041,12 +2041,6 @@
 							</rules>
 						</configuration>
 					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-enforcer-plugin</artifactId>
-				<executions>
 					<execution>
 						<id>enforce-property</id>
 						<goals>


### PR DESCRIPTION
Resolving the following Maven warning:

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for ca.jd.cdr:cdr-endpoint-hl7v2:jar:2020.08.PRE
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-enforcer-plugin @ ca.uhn.hapi.fhir:hapi-fhir:5.1.0-SNAPSHOT, /home/dmuylwyk/.m2/repository/ca/uhn/hapi/fhir/hapi-fhir/5.1.0-SNAPSHOT/hapi-fhir-5.1.0-SNAPSHOT.pom, line 2046, column 12
```

There were two plugins for maven-enforcer-plugin, each with a different execution. I put both executions in the first plugin and removed the second.