### PR TITLE
avoid including duplicate copies of hapi-fhir-testpage-overlay classes

### DIFF
--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -232,6 +232,9 @@
 						<overlay>
 							<groupId>ca.uhn.hapi.fhir</groupId>
 							<artifactId>hapi-fhir-testpage-overlay</artifactId>
+							<excludes>
+								<exclude>WEB-INF/classes/**/*.class</exclude>
+							</excludes>
 						</overlay>
 					</overlays>
 				</configuration>


### PR DESCRIPTION
This exclusion added to the hapi-fhir-testpage-overlay overlay configuration resolves some "(class) scanned from multiple locations" warnings generated by mvn jetty:run, e.g.:

[WARNING] ca.uhn.fhir.to.BaseController$1 scanned from multiple locations: file:///Users/jschneid/git/hapi-fhir-pr/hapi-fhir-jpaserver-uhnfhirtest/target/jetty_overlays/hapi-fhir-testpage-overlay-5_1_0-SNAPSHOT_war/WEB-INF/classes/ca/uhn/fhir/to/BaseController$1.class, jar:file:///Users/jschneid/.m2/repository/ca/uhn/hapi/fhir/hapi-fhir-testpage-overlay/5.1.0-SNAPSHOT/hapi-fhir-testpage-overlay-5.1.0-SNAPSHOT-classes.jar!/ca/uhn/fhir/to/BaseController$1.class
...