### PR TITLE
avoid overlap/collision between spring-jcl and jcl-over-slf4j

### DIFF
--- a/hapi-fhir-base/pom.xml
+++ b/hapi-fhir-base/pom.xml
@@ -107,8 +107,8 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jcl</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>ch.qos.logback</groupId>

--- a/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
+++ b/hapi-fhir-cli/hapi-fhir-cli-api/pom.xml
@@ -189,8 +189,8 @@
 			<artifactId>websocket-client</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jcl</artifactId>
 		</dependency>
 
 		<dependency>

--- a/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
+++ b/hapi-fhir-jpaserver-uhnfhirtest/pom.xml
@@ -82,8 +82,8 @@
 			<artifactId>logback-classic</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-jcl</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/osgi/hapi-fhir-karaf-integration-tests/pom.xml
+++ b/osgi/hapi-fhir-karaf-integration-tests/pom.xml
@@ -172,8 +172,8 @@
             <scope>runtime</scope>
       </dependency>
       <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jcl</artifactId>
       </dependency>
       <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1112,12 +1112,16 @@
 				<artifactId>apache-jena-libs</artifactId>
 				<version>3.12.0</version>
 				<type>pom</type>
-		      <exclusions>
+				<exclusions>
 					<exclusion>
-				      <groupId>com.github.jsonld-java</groupId>
-			         <artifactId>jsonld-java</artifactId>
-		         </exclusion>
-	         </exclusions>
+						<groupId>com.github.jsonld-java</groupId>
+						<artifactId>jsonld-java</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>jcl-over-slf4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
@@ -1426,11 +1430,6 @@
 				<version>${slf4j_version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>jcl-over-slf4j</artifactId>
-				<version>${slf4j_version}</version>
-			</dependency>
-			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-beans</artifactId>
 				<version>${spring_version}</version>
@@ -1448,6 +1447,11 @@
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-core</artifactId>
+				<version>${spring_version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-jcl</artifactId>
 				<version>${spring_version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
The spring-jcl and jcl-over-slf4j libraries both do essentially the same thing, and both libraries provide their own versions of Jakarta commons-logging classes.

Having both libraries present could lead to unpredictable behavior at run time.

This PR proposes to add an explicit dependency on spring-jcl, and use spring-jcl in place of jcl-over-slf4j where applicable.