### PR TITLE
revise fhir_core_version property to avoid using SNAPSHOT dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -665,7 +665,7 @@
 
 	<properties>
 
-		<fhir_core_version>5.0.1-SNAPSHOT</fhir_core_version>
+		<fhir_core_version>5.0.1</fhir_core_version>
 		<ucum_version>1.0.2</ucum_version>
 
 		<surefire_jvm_args>-Dfile.encoding=UTF-8 -Xmx2048m</surefire_jvm_args>


### PR DESCRIPTION
NOTE:  This change currently leads to a build failure, because version 5.0.1 of some artifacts are not yet available from Maven Central, e.g. "Could not find artifact ca.uhn.hapi.fhir:org.hl7.fhir.utilities:jar:5.0.1"

Additionally, some of the already-published version 5.0.1 artifacts have dependencies on version 5.0.1-SNAPSHOT of other artifacts, e.g.

[INFO] |  +- ca.uhn.hapi.fhir:hapi-fhir-server:jar:5.0.1:compile
[INFO] |  |  \- ca.uhn.hapi.fhir:org.hl7.fhir.utilities:jar:5.0.1-SNAPSHOT:compile

Making a version 5.0.2 release may be the most straightforward way to resolve this.