### PR TITLE
#1892 Add support for :of-type Token Modifier

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/TokenParamModifier.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/rest/param/TokenParamModifier.java
@@ -55,8 +55,13 @@ public enum TokenParamModifier {
 	/** 
 	 * :text
 	 */
-	TEXT(":text");
-	
+	TEXT(":text"),
+
+	/**
+	 * :of-type
+	 */
+	OF_TYPE(":of-type");
+
 	private static final Map<String, TokenParamModifier> VALUE_TO_ENUM;
 
 	static {


### PR DESCRIPTION
#1892 Add support for `:of-type` Token Modifier

The following token request from [FHIR specification](https://www.hl7.org/fhir/search.html#token)
`Patient?identifier:of-type=http://terminology.hl7.org/CodeSystem/v2-0203|MR|446053`

is parsed with modifier now -
<img width="738" alt="image" src="https://user-images.githubusercontent.com/6069066/83673122-5c015700-a5a5-11ea-948a-3d4c1db5e748.png">
