### PR TITLE
Enable rename table column migration task for MySQL.

### DIFF
--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/JdbcUtils.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/JdbcUtils.java
@@ -20,7 +20,7 @@ package ca.uhn.fhir.jpa.migrate;
  * #L%
  */
 
-import ca.uhn.fhir.jpa.migrate.taskdef.BaseTableColumnTypeTask;
+import ca.uhn.fhir.jpa.migrate.taskdef.ColumnTypeEnum;
 import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -68,19 +68,19 @@ public class JdbcUtils {
 	private static final Logger ourLog = LoggerFactory.getLogger(JdbcUtils.class);
 
 	public static class ColumnType {
-		private final BaseTableColumnTypeTask.ColumnTypeEnum myColumnTypeEnum;
+		private final ColumnTypeEnum myColumnTypeEnum;
 		private final Long myLength;
 
-		public ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum theColumnType, Long theLength) {
+		public ColumnType(ColumnTypeEnum theColumnType, Long theLength) {
 			myColumnTypeEnum = theColumnType;
 			myLength = theLength;
 		}
 
-		public ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum theColumnType, int theLength) {
+		public ColumnType(ColumnTypeEnum theColumnType, int theLength) {
 			this(theColumnType, (long) theLength);
 		}
 
-		public ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum theColumnType) {
+		public ColumnType(ColumnTypeEnum theColumnType) {
 			this(theColumnType, null);
 		}
 
@@ -120,7 +120,7 @@ public class JdbcUtils {
 			return b.toString();
 		}
 
-		public BaseTableColumnTypeTask.ColumnTypeEnum getColumnTypeEnum() {
+		public ColumnTypeEnum getColumnTypeEnum() {
 			return myColumnTypeEnum;
 		}
 
@@ -128,7 +128,7 @@ public class JdbcUtils {
 			return myLength;
 		}
 
-		public boolean equals(BaseTableColumnTypeTask.ColumnTypeEnum theTaskColumnType, Long theTaskColumnLength) {
+		public boolean equals(ColumnTypeEnum theTaskColumnType, Long theTaskColumnLength) {
 			ourLog.debug("Comparing existing {} {} to new {} {}", myColumnTypeEnum, myLength, theTaskColumnType, theTaskColumnLength);
 			return myColumnTypeEnum == theTaskColumnType && (theTaskColumnLength == null || theTaskColumnLength.equals(myLength));
 		}
@@ -240,22 +240,22 @@ public class JdbcUtils {
 						switch (dataType) {
 							case Types.BIT:
 							case Types.BOOLEAN:
-								return new ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN, length);
+								return new ColumnType(ColumnTypeEnum.BOOLEAN, length);
 							case Types.VARCHAR:
-								return new ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, length);
+								return new ColumnType(ColumnTypeEnum.STRING, length);
 							case Types.NUMERIC:
 							case Types.BIGINT:
 							case Types.DECIMAL:
-								return new ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, length);
+								return new ColumnType(ColumnTypeEnum.LONG, length);
 							case Types.INTEGER:
-								return new ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.INT, length);
+								return new ColumnType(ColumnTypeEnum.INT, length);
 							case Types.TIMESTAMP:
 							case Types.TIMESTAMP_WITH_TIMEZONE:
-								return new ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP, length);
+								return new ColumnType(ColumnTypeEnum.DATE_TIMESTAMP, length);
 							case Types.BLOB:
-								return new ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.BLOB, length);
+								return new ColumnType(ColumnTypeEnum.BLOB, length);
 							case Types.CLOB:
-								return new ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.CLOB, length);
+								return new ColumnType(ColumnTypeEnum.CLOB, length);
 							default:
 								throw new IllegalArgumentException("Don't know how to handle datatype " + dataType + " for column " + theColumnName + " on table " + theTableName);
 						}

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableColumnTypeTask.java
@@ -20,19 +20,13 @@ package ca.uhn.fhir.jpa.migrate.taskdef;
  * #L%
  */
 
-import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
 public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 	private ColumnTypeEnum myColumnType;
-	private Map<ColumnTypeEnum, Map<DriverTypeEnum, String>> myColumnTypeToDriverTypeToSqlType = new HashMap<>();
 	private Boolean myNullable;
 	private Long myColumnLength;
 
@@ -42,77 +36,6 @@ public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 
 	public BaseTableColumnTypeTask(String theProductVersion, String theSchemaVersion) {
 		super(theProductVersion, theSchemaVersion);
-		setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.H2_EMBEDDED, "integer");
-		setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.DERBY_EMBEDDED, "integer");
-		setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.MARIADB_10_1, "integer");
-		setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.MYSQL_5_7, "integer");
-		setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.MSSQL_2012, "int");
-		setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.ORACLE_12C, "number(10,0)");
-		setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.POSTGRES_9_4, "int4");
-
-		setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.H2_EMBEDDED, "float");
-		setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.DERBY_EMBEDDED, "float");
-		setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.MARIADB_10_1, "float");
-		setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.MYSQL_5_7, "float");
-		setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.MSSQL_2012, "float");
-		setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.ORACLE_12C, "float");
-		setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.POSTGRES_9_4, "float");
-
-		setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.H2_EMBEDDED, "bigint");
-		setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.DERBY_EMBEDDED, "bigint");
-		setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.MARIADB_10_1, "bigint");
-		setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.MYSQL_5_7, "bigint");
-		setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.MSSQL_2012, "bigint");
-		setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.ORACLE_12C, "number(19,0)");
-		setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.POSTGRES_9_4, "int8");
-
-		setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.H2_EMBEDDED, "varchar(?)");
-		setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.DERBY_EMBEDDED, "varchar(?)");
-		setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.MARIADB_10_1, "varchar(?)");
-		setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.MYSQL_5_7, "varchar(?)");
-		setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.MSSQL_2012, "varchar(?)");
-		setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.ORACLE_12C, "varchar2(?)");
-		setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.POSTGRES_9_4, "varchar(?)");
-
-		setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.H2_EMBEDDED, "timestamp");
-		setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.DERBY_EMBEDDED, "timestamp");
-		setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.MARIADB_10_1, "datetime(6)");
-		setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.MYSQL_5_7, "datetime(6)");
-		setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.MSSQL_2012, "datetime2");
-		setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.ORACLE_12C, "timestamp");
-		setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.POSTGRES_9_4, "timestamp");
-
-		setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.H2_EMBEDDED, "date");
-		setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.DERBY_EMBEDDED, "date");
-		setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.MARIADB_10_1, "date");
-		setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.MYSQL_5_7, "date");
-		setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.MSSQL_2012, "date");
-		setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.ORACLE_12C, "date");
-		setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.POSTGRES_9_4, "date");
-
-		setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.H2_EMBEDDED, "boolean");
-		setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.DERBY_EMBEDDED, "boolean");
-		setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.MSSQL_2012, "bit");
-		setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.MARIADB_10_1, "bit");
-		setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.ORACLE_12C, "number(1,0)");
-		setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.POSTGRES_9_4, "boolean");
-		setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.MYSQL_5_7, "bit");
-
-		setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.H2_EMBEDDED, "blob");
-		setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.DERBY_EMBEDDED, "blob");
-		setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.MARIADB_10_1, "longblob");
-		setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.MYSQL_5_7, "longblob");
-		setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.ORACLE_12C, "blob");
-		setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.POSTGRES_9_4, "oid");
-		setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.MSSQL_2012, "varbinary(MAX)");
-
-		setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.H2_EMBEDDED, "clob");
-		setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.DERBY_EMBEDDED, "clob(100000)");
-		setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.MARIADB_10_1, "longtext");
-		setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.MYSQL_5_7, "longtext");
-		setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.ORACLE_12C, "clob");
-		setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.POSTGRES_9_4, "text");
-		setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.MSSQL_2012, "varchar(MAX)");
 	}
 
 	public ColumnTypeEnum getColumnType() {
@@ -122,14 +45,6 @@ public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 	public BaseTableColumnTask setColumnType(ColumnTypeEnum theColumnType) {
 		myColumnType = theColumnType;
 		return this;
-	}
-
-	private void setColumnType(ColumnTypeEnum theColumnType, DriverTypeEnum theDriverType, String theColumnTypeSql) {
-		Map<DriverTypeEnum, String> columnSqlType = myColumnTypeToDriverTypeToSqlType.computeIfAbsent(theColumnType, k -> new HashMap<>());
-		if (columnSqlType.containsKey(theDriverType)) {
-			throw new IllegalStateException("Duplicate key: " + theDriverType);
-		}
-		columnSqlType.put(theDriverType, theColumnTypeSql);
 	}
 
 	@Override
@@ -150,14 +65,7 @@ public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 	}
 
 	protected String getSqlType(Long theColumnLength) {
-		String retVal = myColumnTypeToDriverTypeToSqlType.get(myColumnType).get(getDriverType());
-		Objects.requireNonNull(retVal);
-
-		if (myColumnType == ColumnTypeEnum.STRING) {
-			retVal = retVal.replace("?", Long.toString(theColumnLength));
-		}
-
-		return retVal;
+		return getSqlType(myColumnType, theColumnLength);
 	}
 
 	public boolean isNullable() {
@@ -207,17 +115,8 @@ public abstract class BaseTableColumnTypeTask extends BaseTableColumnTask {
 		return myColumnType.name();
 	}
 
-	public enum ColumnTypeEnum {
-
-		LONG,
-		STRING,
-		DATE_ONLY,
-		DATE_TIMESTAMP,
-		BOOLEAN,
-		FLOAT,
-		INT,
-		BLOB,
-		CLOB;
-
+	public ColumnTypeToDriverTypeToSqlType getColumnTypeToDriverTypeToSqlType() {
+		return myColumnTypeToDriverTypeToSqlType;
 	}
+
 }

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTableTask.java
@@ -24,7 +24,10 @@ import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import java.util.Objects;
+
 public abstract class BaseTableTask extends BaseTask {
+	protected final ColumnTypeToDriverTypeToSqlType myColumnTypeToDriverTypeToSqlType = new ColumnTypeToDriverTypeToSqlType();
 	private String myTableName;
 
 
@@ -52,6 +55,17 @@ public abstract class BaseTableTask extends BaseTask {
 	protected void generateEquals(EqualsBuilder theBuilder, BaseTask theOtherObject) {
 		BaseTableTask otherObject = (BaseTableTask) theOtherObject;
 		theBuilder.append(myTableName, otherObject.myTableName);
+	}
+
+	protected String getSqlType(ColumnTypeEnum theColumnType, Long theColumnLength) {
+		String retVal = myColumnTypeToDriverTypeToSqlType.getColumnTypeToDriverTypeToSqlType().get(theColumnType).get(getDriverType());
+		Objects.requireNonNull(retVal);
+
+		if (theColumnType == ColumnTypeEnum.STRING) {
+			retVal = retVal.replace("?", Long.toString(theColumnLength));
+		}
+
+		return retVal;
 	}
 
 	@Override

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnTypeEnum.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnTypeEnum.java
@@ -1,0 +1,15 @@
+package ca.uhn.fhir.jpa.migrate.taskdef;
+
+public enum ColumnTypeEnum {
+
+    LONG,
+    STRING,
+    DATE_ONLY,
+    DATE_TIMESTAMP,
+    BOOLEAN,
+    FLOAT,
+    INT,
+    BLOB,
+    CLOB
+
+}

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnTypeToDriverTypeToSqlType.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/ColumnTypeToDriverTypeToSqlType.java
@@ -1,0 +1,96 @@
+package ca.uhn.fhir.jpa.migrate.taskdef;
+
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ColumnTypeToDriverTypeToSqlType {
+    Map<ColumnTypeEnum, Map<DriverTypeEnum, String>> myColumnTypeToDriverTypeToSqlType = new HashMap<>();
+
+    public Map<ColumnTypeEnum, Map<DriverTypeEnum, String>> getColumnTypeToDriverTypeToSqlType() {
+        return myColumnTypeToDriverTypeToSqlType;
+    }
+
+    public ColumnTypeToDriverTypeToSqlType() {
+		 setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.H2_EMBEDDED, "integer");
+		 setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.DERBY_EMBEDDED, "integer");
+		 setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.MARIADB_10_1, "integer");
+		 setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.MYSQL_5_7, "integer");
+		 setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.MSSQL_2012, "int");
+		 setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.ORACLE_12C, "number(10,0)");
+		 setColumnType(ColumnTypeEnum.INT, DriverTypeEnum.POSTGRES_9_4, "int4");
+
+		 setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.H2_EMBEDDED, "float");
+		 setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.DERBY_EMBEDDED, "float");
+		 setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.MARIADB_10_1, "float");
+		 setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.MYSQL_5_7, "float");
+		 setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.MSSQL_2012, "float");
+		 setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.ORACLE_12C, "float");
+		 setColumnType(ColumnTypeEnum.FLOAT, DriverTypeEnum.POSTGRES_9_4, "float");
+
+		 setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.H2_EMBEDDED, "bigint");
+		 setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.DERBY_EMBEDDED, "bigint");
+		 setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.MARIADB_10_1, "bigint");
+		 setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.MYSQL_5_7, "bigint");
+		 setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.MSSQL_2012, "bigint");
+		 setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.ORACLE_12C, "number(19,0)");
+		 setColumnType(ColumnTypeEnum.LONG, DriverTypeEnum.POSTGRES_9_4, "int8");
+
+		 setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.H2_EMBEDDED, "varchar(?)");
+		 setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.DERBY_EMBEDDED, "varchar(?)");
+		 setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.MARIADB_10_1, "varchar(?)");
+		 setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.MYSQL_5_7, "varchar(?)");
+		 setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.MSSQL_2012, "varchar(?)");
+		 setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.ORACLE_12C, "varchar2(?)");
+		 setColumnType(ColumnTypeEnum.STRING, DriverTypeEnum.POSTGRES_9_4, "varchar(?)");
+
+		 setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.H2_EMBEDDED, "timestamp");
+		 setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.DERBY_EMBEDDED, "timestamp");
+		 setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.MARIADB_10_1, "datetime(6)");
+		 setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.MYSQL_5_7, "datetime(6)");
+		 setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.MSSQL_2012, "datetime2");
+		 setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.ORACLE_12C, "timestamp");
+		 setColumnType(ColumnTypeEnum.DATE_TIMESTAMP, DriverTypeEnum.POSTGRES_9_4, "timestamp");
+
+		 setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.H2_EMBEDDED, "date");
+		 setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.DERBY_EMBEDDED, "date");
+		 setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.MARIADB_10_1, "date");
+		 setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.MYSQL_5_7, "date");
+		 setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.MSSQL_2012, "date");
+		 setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.ORACLE_12C, "date");
+		 setColumnType(ColumnTypeEnum.DATE_ONLY, DriverTypeEnum.POSTGRES_9_4, "date");
+
+		 setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.H2_EMBEDDED, "boolean");
+		 setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.DERBY_EMBEDDED, "boolean");
+		 setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.MSSQL_2012, "bit");
+		 setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.MARIADB_10_1, "bit");
+		 setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.ORACLE_12C, "number(1,0)");
+		 setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.POSTGRES_9_4, "boolean");
+		 setColumnType(ColumnTypeEnum.BOOLEAN, DriverTypeEnum.MYSQL_5_7, "bit");
+
+		 setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.H2_EMBEDDED, "blob");
+		 setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.DERBY_EMBEDDED, "blob");
+		 setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.MARIADB_10_1, "longblob");
+		 setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.MYSQL_5_7, "longblob");
+		 setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.ORACLE_12C, "blob");
+		 setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.POSTGRES_9_4, "oid");
+		 setColumnType(ColumnTypeEnum.BLOB, DriverTypeEnum.MSSQL_2012, "varbinary(MAX)");
+
+		 setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.H2_EMBEDDED, "clob");
+		 setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.DERBY_EMBEDDED, "clob(100000)");
+		 setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.MARIADB_10_1, "longtext");
+		 setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.MYSQL_5_7, "longtext");
+		 setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.ORACLE_12C, "clob");
+		 setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.POSTGRES_9_4, "text");
+		 setColumnType(ColumnTypeEnum.CLOB, DriverTypeEnum.MSSQL_2012, "varchar(MAX)");
+    }
+
+    private void setColumnType(ColumnTypeEnum theColumnType, DriverTypeEnum theDriverType, String theColumnTypeSql) {
+        Map<DriverTypeEnum, String> columnSqlType = myColumnTypeToDriverTypeToSqlType.computeIfAbsent(theColumnType, k -> new HashMap<>());
+        if (columnSqlType.containsKey(theDriverType)) {
+            throw new IllegalStateException("Duplicate key: " + theDriverType);
+        }
+        columnSqlType.put(theDriverType, theColumnTypeSql);
+    }
+}

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/RenameColumnTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/RenameColumnTask.java
@@ -21,6 +21,7 @@ package ca.uhn.fhir.jpa.migrate.taskdef;
  */
 
 import ca.uhn.fhir.jpa.migrate.JdbcUtils;
+import ca.uhn.fhir.rest.server.exceptions.InternalErrorException;
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
@@ -77,7 +78,7 @@ public class RenameColumnTask extends BaseTableTask {
 					jdbcTemplate.setMaxRows(1);
 					return jdbcTemplate.query(sql, new ColumnMapRowMapper()).size();
 				});
-				if (rowsWithData > 0) {
+				if (rowsWithData != null && rowsWithData > 0) {
 					throw new SQLException("Can not rename " + getTableName() + "." + myOldName + " to " + myNewName + " because both columns exist and data exists in " + myNewName);
 				}
 
@@ -97,23 +98,40 @@ public class RenameColumnTask extends BaseTableTask {
 			return;
 		}
 
-		String sql = "";
+		String existingType;
+		String notNull;
+		try {
+			JdbcUtils.ColumnType existingColumnType = JdbcUtils.getColumnType(getConnectionProperties(), getTableName(), myOldName);
+			existingType = getSqlType(existingColumnType.getColumnTypeEnum(), existingColumnType.getLength());
+			notNull = JdbcUtils.isColumnNullable(getConnectionProperties(), getTableName(), myOldName) ? " null " : " not null";
+		} catch (SQLException e) {
+			throw new InternalErrorException(e);
+		}
+		String sql = buildRenameColumnSqlStatement(existingType, notNull);
+
+		logInfo(ourLog, "Renaming column {} on table {} to {}", myOldName, getTableName(), myNewName);
+		executeSql(getTableName(), sql);
+
+	}
+
+	String buildRenameColumnSqlStatement(String theExistingType, String theExistingNotNull) {
+		String sql;
 		switch (getDriverType()) {
 			case DERBY_EMBEDDED:
 				sql = "RENAME COLUMN " + getTableName() + "." + myOldName + " TO " + myNewName;
 				break;
 			case MARIADB_10_1:
-			case MYSQL_5_7:
 				sql = "ALTER TABLE " + getTableName() + " CHANGE COLUMN " + myOldName + " TO " + myNewName;
 				break;
+			case MYSQL_5_7:
+				sql = "ALTER TABLE " + getTableName() + " CHANGE COLUMN " + myOldName + " " + myNewName + " " + theExistingType + " " + theExistingNotNull;
+				break;
 			case POSTGRES_9_4:
+			case ORACLE_12C:
 				sql = "ALTER TABLE " + getTableName() + " RENAME COLUMN " + myOldName + " TO " + myNewName;
 				break;
 			case MSSQL_2012:
 				sql = "sp_rename '" + getTableName() + "." + myOldName + "', '" + myNewName + "', 'COLUMN'";
-				break;
-			case ORACLE_12C:
-				sql = "ALTER TABLE " + getTableName() + " RENAME COLUMN " + myOldName + " TO " + myNewName;
 				break;
 			case H2_EMBEDDED:
 				sql = "ALTER TABLE " + getTableName() + " ALTER COLUMN " + myOldName + " RENAME TO " + myNewName;
@@ -121,10 +139,7 @@ public class RenameColumnTask extends BaseTableTask {
 			default:
 				throw new IllegalStateException();
 		}
-
-		logInfo(ourLog, "Renaming column {} on table {} to {}", myOldName, getTableName(), myNewName);
-		executeSql(getTableName(), sql);
-
+		return sql;
 	}
 
 	public boolean isOkayIfNeitherColumnExists() {

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -21,11 +21,10 @@ package ca.uhn.fhir.jpa.migrate.tasks;
  */
 
 import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
-import ca.uhn.fhir.jpa.migrate.taskdef.AddColumnTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.ArbitrarySqlTask;
-import ca.uhn.fhir.jpa.migrate.taskdef.BaseTableColumnTypeTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateHashesTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateOrdinalDatesTask;
+import ca.uhn.fhir.jpa.migrate.taskdef.ColumnTypeEnum;
 import ca.uhn.fhir.jpa.migrate.tasks.api.BaseMigrationTasks;
 import ca.uhn.fhir.jpa.migrate.tasks.api.Builder;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
@@ -78,46 +77,46 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		// NPM Packages
 		version.addIdGenerator("20200610.1", "SEQ_NPM_PACK");
 		Builder.BuilderAddTableByColumns pkg = version.addTableByColumns("20200610.2", "NPM_PACKAGE", "PID");
-		pkg.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkg.addColumn("PACKAGE_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkg.addColumn("CUR_VERSION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkg.addColumn("UPDATED_TIME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		pkg.addColumn("PACKAGE_DESC").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		pkg.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		pkg.addColumn("PACKAGE_ID").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		pkg.addColumn("CUR_VERSION_ID").nullable().type(ColumnTypeEnum.STRING, 200);
+		pkg.addColumn("UPDATED_TIME").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		pkg.addColumn("PACKAGE_DESC").nullable().type(ColumnTypeEnum.STRING, 200);
 		pkg.addIndex("20200610.3", "IDX_PACK_ID").unique(true).withColumns("PACKAGE_ID");
 
 		version.addIdGenerator("20200610.4", "SEQ_NPM_PACKVER");
 		Builder.BuilderAddTableByColumns pkgVer = version.addTableByColumns("20200610.5", "NPM_PACKAGE_VER", "PID");
-		pkgVer.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVer.addColumn("PACKAGE_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVer.addColumn("VERSION_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVer.addColumn("PACKAGE_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVer.addColumn("BINARY_RES_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVer.addColumn("SAVED_TIME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		pkgVer.addColumn("PKG_DESC").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVer.addColumn("DESC_UPPER").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVer.addColumn("CURRENT_VERSION").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		pkgVer.addColumn("FHIR_VERSION_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 10);
-		pkgVer.addColumn("FHIR_VERSION").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 10);
-		pkgVer.addColumn("PACKAGE_SIZE_BYTES").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVer.addColumn("UPDATED_TIME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
+		pkgVer.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVer.addColumn("PACKAGE_ID").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVer.addColumn("VERSION_ID").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVer.addColumn("PACKAGE_PID").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVer.addColumn("BINARY_RES_ID").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVer.addColumn("SAVED_TIME").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		pkgVer.addColumn("PKG_DESC").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVer.addColumn("DESC_UPPER").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVer.addColumn("CURRENT_VERSION").nonNullable().type(ColumnTypeEnum.BOOLEAN);
+		pkgVer.addColumn("FHIR_VERSION_ID").nonNullable().type(ColumnTypeEnum.STRING, 10);
+		pkgVer.addColumn("FHIR_VERSION").nonNullable().type(ColumnTypeEnum.STRING, 10);
+		pkgVer.addColumn("PACKAGE_SIZE_BYTES").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVer.addColumn("UPDATED_TIME").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
 		pkgVer.addForeignKey("20200610.6", "FK_NPM_PKV_PKG").toColumn("PACKAGE_PID").references("NPM_PACKAGE", "PID");
 		pkgVer.addForeignKey("20200610.7", "FK_NPM_PKV_RESID").toColumn("BINARY_RES_ID").references("HFJ_RESOURCE", "RES_ID");
 		pkgVer.addIndex("20200610.8", "IDX_PACKVER").unique(true).withColumns("PACKAGE_ID", "VERSION_ID");
 
 		version.addIdGenerator("20200610.9", "SEQ_NPM_PACKVERRES");
 		Builder.BuilderAddTableByColumns pkgVerRes = version.addTableByColumns("20200610.10", "NPM_PACKAGE_VER_RES", "PID");
-		pkgVerRes.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVerRes.addColumn("PACKVER_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVerRes.addColumn("BINARY_RES_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVerRes.addColumn("FILE_DIR").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVerRes.addColumn("FILE_NAME").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVerRes.addColumn("RES_TYPE").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
-		pkgVerRes.addColumn("CANONICAL_URL").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVerRes.addColumn("CANONICAL_VERSION").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		pkgVerRes.addColumn("FHIR_VERSION_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 10);
-		pkgVerRes.addColumn("FHIR_VERSION").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 10);
-		pkgVerRes.addColumn("RES_SIZE_BYTES").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		pkgVerRes.addColumn("UPDATED_TIME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
+		pkgVerRes.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVerRes.addColumn("PACKVER_PID").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVerRes.addColumn("BINARY_RES_ID").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVerRes.addColumn("FILE_DIR").nullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVerRes.addColumn("FILE_NAME").nullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVerRes.addColumn("RES_TYPE").nonNullable().type(ColumnTypeEnum.STRING, 40);
+		pkgVerRes.addColumn("CANONICAL_URL").nullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVerRes.addColumn("CANONICAL_VERSION").nullable().type(ColumnTypeEnum.STRING, 200);
+		pkgVerRes.addColumn("FHIR_VERSION_ID").nonNullable().type(ColumnTypeEnum.STRING, 10);
+		pkgVerRes.addColumn("FHIR_VERSION").nonNullable().type(ColumnTypeEnum.STRING, 10);
+		pkgVerRes.addColumn("RES_SIZE_BYTES").nonNullable().type(ColumnTypeEnum.LONG);
+		pkgVerRes.addColumn("UPDATED_TIME").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
 		pkgVerRes.addForeignKey("20200610.11", "FK_NPM_PACKVERRES_PACKVER").toColumn("PACKVER_PID").references("NPM_PACKAGE_VER", "PID");
 		pkgVerRes.addForeignKey("20200610.12", "FK_NPM_PKVR_RESID").toColumn("BINARY_RES_ID").references("HFJ_RESOURCE", "PID");
 		pkgVerRes.addIndex("20200610.13", "IDX_PACKVERRES_URL").unique(false).withColumns("CANONICAL_URL");
@@ -135,24 +134,24 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		// MPI_LINK
 		version.addIdGenerator("20200517.1", "SEQ_EMPI_LINK_ID");
 		Builder.BuilderAddTableByColumns empiLink = version.addTableByColumns("20200517.2", "MPI_LINK", "PID");
-		empiLink.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		empiLink.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
 
-		empiLink.addColumn("PERSON_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		empiLink.addColumn("PERSON_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		empiLink
 			.addForeignKey("20200517.3", "FK_EMPI_LINK_PERSON")
 			.toColumn("PERSON_PID")
 			.references("HFJ_RESOURCE", "RES_ID");
 
-		empiLink.addColumn("TARGET_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		empiLink.addColumn("TARGET_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		empiLink
 			.addForeignKey("20200517.4", "FK_EMPI_LINK_TARGET")
 			.toColumn("TARGET_PID")
 			.references("HFJ_RESOURCE", "RES_ID");
 
-		empiLink.addColumn("MATCH_RESULT").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		empiLink.addColumn("LINK_SOURCE").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		empiLink.addColumn("CREATED").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		empiLink.addColumn("UPDATED").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
+		empiLink.addColumn("MATCH_RESULT").nonNullable().type(ColumnTypeEnum.INT);
+		empiLink.addColumn("LINK_SOURCE").nonNullable().type(ColumnTypeEnum.INT);
+		empiLink.addColumn("CREATED").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		empiLink.addColumn("UPDATED").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
 
 
 		empiLink.addIndex("20200517.5", "IDX_EMPI_PERSON_TGT").unique(true).withColumns("PERSON_PID", "TARGET_PID");
@@ -166,7 +165,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.onTable("HFJ_RESOURCE").dropColumn("20200218.1", "FORCED_ID_PID");
 		version.onTable("HFJ_RES_VER").dropColumn("20200218.2", "FORCED_ID_PID");
 		version.onTable("HFJ_RES_VER").addForeignKey("20200218.3", "FK_RESOURCE_HISTORY_RESOURCE").toColumn("RES_ID").references("HFJ_RESOURCE", "RES_ID");
-		version.onTable("HFJ_RES_VER").modifyColumn("20200220.1", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		version.onTable("HFJ_RES_VER").modifyColumn("20200220.1", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
 		//
 
 		// Drop unused column
@@ -175,59 +174,59 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 
 		// Add Partitioning
 		Builder.BuilderAddTableByColumns partition = version.addTableByColumns("20200420.0", "HFJ_PARTITION", "PART_ID");
-		partition.addColumn("PART_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		partition.addColumn("PART_NAME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		partition.addColumn("PART_DESC").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		partition.addColumn("PART_ID").nonNullable().type(ColumnTypeEnum.INT);
+		partition.addColumn("PART_NAME").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		partition.addColumn("PART_DESC").nullable().type(ColumnTypeEnum.STRING, 200);
 		partition.addIndex("20200420.1", "IDX_PART_NAME").unique(true).withColumns("PART_NAME");
 
 		// Partition columns on individual tables
-		version.onTable("HFJ_RESOURCE").addColumn("20200420.2", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_RESOURCE").addColumn("20200420.3", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_RES_VER").addColumn("20200420.4", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_RES_VER").addColumn("20200420.5", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.6", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.7", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.8", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.9", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_HISTORY_TAG").addColumn("20200420.10", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_HISTORY_TAG").addColumn("20200420.11", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_RES_TAG").addColumn("20200420.12", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_RES_TAG").addColumn("20200420.13", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_FORCED_ID").addColumn("20200420.14", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_FORCED_ID").addColumn("20200420.15", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_RES_LINK").addColumn("20200420.16", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_RES_LINK").addColumn("20200420.17", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_SPIDX_STRING").addColumn("20200420.18", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_SPIDX_STRING").addColumn("20200420.19", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_SPIDX_COORDS").addColumn("20200420.20", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_SPIDX_COORDS").addColumn("20200420.21", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_SPIDX_NUMBER").addColumn("20200420.22", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_SPIDX_NUMBER").addColumn("20200420.23", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_SPIDX_TOKEN").addColumn("20200420.24", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_SPIDX_TOKEN").addColumn("20200420.25", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_SPIDX_DATE").addColumn("20200420.26", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_SPIDX_DATE").addColumn("20200420.27", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_SPIDX_URI").addColumn("20200420.28", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_SPIDX_URI").addColumn("20200420.29", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_SPIDX_QUANTITY").addColumn("20200420.30", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_SPIDX_QUANTITY").addColumn("20200420.31", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_RES_VER_PROV").addColumn("20200420.32", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_RES_VER_PROV").addColumn("20200420.33", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
-		version.onTable("HFJ_RES_PARAM_PRESENT").addColumn("20200420.34", "PARTITION_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		version.onTable("HFJ_RES_PARAM_PRESENT").addColumn("20200420.35", "PARTITION_DATE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_RESOURCE").addColumn("20200420.2", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_RESOURCE").addColumn("20200420.3", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_RES_VER").addColumn("20200420.4", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_RES_VER").addColumn("20200420.5", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.6", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.7", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.8", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").addColumn("20200420.9", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_HISTORY_TAG").addColumn("20200420.10", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_HISTORY_TAG").addColumn("20200420.11", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_RES_TAG").addColumn("20200420.12", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_RES_TAG").addColumn("20200420.13", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_FORCED_ID").addColumn("20200420.14", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_FORCED_ID").addColumn("20200420.15", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_RES_LINK").addColumn("20200420.16", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_RES_LINK").addColumn("20200420.17", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_SPIDX_STRING").addColumn("20200420.18", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_SPIDX_STRING").addColumn("20200420.19", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_SPIDX_COORDS").addColumn("20200420.20", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_SPIDX_COORDS").addColumn("20200420.21", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_SPIDX_NUMBER").addColumn("20200420.22", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_SPIDX_NUMBER").addColumn("20200420.23", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_SPIDX_TOKEN").addColumn("20200420.24", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_SPIDX_TOKEN").addColumn("20200420.25", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_SPIDX_DATE").addColumn("20200420.26", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_SPIDX_DATE").addColumn("20200420.27", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_SPIDX_URI").addColumn("20200420.28", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_SPIDX_URI").addColumn("20200420.29", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_SPIDX_QUANTITY").addColumn("20200420.30", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_SPIDX_QUANTITY").addColumn("20200420.31", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_RES_VER_PROV").addColumn("20200420.32", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_RES_VER_PROV").addColumn("20200420.33", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
+		version.onTable("HFJ_RES_PARAM_PRESENT").addColumn("20200420.34", "PARTITION_ID").nullable().type(ColumnTypeEnum.INT);
+		version.onTable("HFJ_RES_PARAM_PRESENT").addColumn("20200420.35", "PARTITION_DATE").nullable().type(ColumnTypeEnum.DATE_ONLY);
 
-		version.onTable("HFJ_SPIDX_STRING").modifyColumn("20200420.36", "SP_MISSING").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20200420.37", "SP_MISSING").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		version.onTable("HFJ_SPIDX_NUMBER").modifyColumn("20200420.38", "SP_MISSING").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		version.onTable("HFJ_SPIDX_TOKEN").modifyColumn("20200420.39", "SP_MISSING").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		version.onTable("HFJ_SPIDX_DATE").modifyColumn("20200420.40", "SP_MISSING").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		version.onTable("HFJ_SPIDX_URI").modifyColumn("20200420.41", "SP_MISSING").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		version.onTable("HFJ_SPIDX_QUANTITY").modifyColumn("20200420.42", "SP_MISSING").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
+		version.onTable("HFJ_SPIDX_STRING").modifyColumn("20200420.36", "SP_MISSING").nonNullable().failureAllowed().withType(ColumnTypeEnum.BOOLEAN);
+		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20200420.37", "SP_MISSING").nonNullable().failureAllowed().withType(ColumnTypeEnum.BOOLEAN);
+		version.onTable("HFJ_SPIDX_NUMBER").modifyColumn("20200420.38", "SP_MISSING").nonNullable().failureAllowed().withType(ColumnTypeEnum.BOOLEAN);
+		version.onTable("HFJ_SPIDX_TOKEN").modifyColumn("20200420.39", "SP_MISSING").nonNullable().failureAllowed().withType(ColumnTypeEnum.BOOLEAN);
+		version.onTable("HFJ_SPIDX_DATE").modifyColumn("20200420.40", "SP_MISSING").nonNullable().failureAllowed().withType(ColumnTypeEnum.BOOLEAN);
+		version.onTable("HFJ_SPIDX_URI").modifyColumn("20200420.41", "SP_MISSING").nonNullable().failureAllowed().withType(ColumnTypeEnum.BOOLEAN);
+		version.onTable("HFJ_SPIDX_QUANTITY").modifyColumn("20200420.42", "SP_MISSING").nonNullable().failureAllowed().withType(ColumnTypeEnum.BOOLEAN);
 
 		// Add support for integer comparisons during day-precision date search.
 		Builder.BuilderWithTableName spidxDate = version.onTable("HFJ_SPIDX_DATE");
-		spidxDate.addColumn("20200501.1", "SP_VALUE_LOW_DATE_ORDINAL").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		spidxDate.addColumn("20200501.2", "SP_VALUE_HIGH_DATE_ORDINAL").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+		spidxDate.addColumn("20200501.1", "SP_VALUE_LOW_DATE_ORDINAL").nullable().type(ColumnTypeEnum.INT);
+		spidxDate.addColumn("20200501.2", "SP_VALUE_HIGH_DATE_ORDINAL").nullable().type(ColumnTypeEnum.INT);
 
 		spidxDate.addTask(new CalculateOrdinalDatesTask(VersionEnum.V5_0_0, "20200501.3")
 			.addCalculator("SP_VALUE_LOW_DATE_ORDINAL", t -> ResourceIndexedSearchParamDate.calculateOrdinalValue(t.getDate("SP_VALUE_LOW")))
@@ -315,74 +314,74 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		 * doing is setting a not-null on a column that will never be null anyway. Setting not null
 		 * fails on SQL Server because there is an index on this column... Which is dumb, but hey.
 		 */
-		version.onTable("HFJ_SPIDX_NUMBER").modifyColumn("20190920.1", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20190920.2", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		version.onTable("HFJ_SPIDX_TOKEN").modifyColumn("20190920.3", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		version.onTable("HFJ_SPIDX_STRING").modifyColumn("20190920.4", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		version.onTable("HFJ_SPIDX_DATE").modifyColumn("20190920.5", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		version.onTable("HFJ_SPIDX_QUANTITY").modifyColumn("20190920.6", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		version.onTable("HFJ_SPIDX_URI").modifyColumn("20190920.7", "RES_ID").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_NUMBER").modifyColumn("20190920.1", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20190920.2", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_TOKEN").modifyColumn("20190920.3", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_STRING").modifyColumn("20190920.4", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_DATE").modifyColumn("20190920.5", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_QUANTITY").modifyColumn("20190920.6", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_URI").modifyColumn("20190920.7", "RES_ID").nonNullable().failureAllowed().withType(ColumnTypeEnum.LONG);
 
 		// HFJ_SEARCH
-		version.onTable("HFJ_SEARCH").addColumn("20190921.1", "EXPIRY_OR_NULL").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		version.onTable("HFJ_SEARCH").addColumn("20190921.2", "NUM_BLOCKED").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+		version.onTable("HFJ_SEARCH").addColumn("20190921.1", "EXPIRY_OR_NULL").nullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		version.onTable("HFJ_SEARCH").addColumn("20190921.2", "NUM_BLOCKED").nullable().type(ColumnTypeEnum.INT);
 
 		// HFJ_BLK_EXPORT_JOB
 		version.addIdGenerator("20190921.3", "SEQ_BLKEXJOB_PID");
 		Builder.BuilderAddTableByColumns bulkExportJob = version.addTableByColumns("20190921.4", "HFJ_BLK_EXPORT_JOB", "PID");
-		bulkExportJob.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		bulkExportJob.addColumn("JOB_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 36);
-		bulkExportJob.addColumn("JOB_STATUS").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 10);
-		bulkExportJob.addColumn("CREATED_TIME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		bulkExportJob.addColumn("STATUS_TIME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		bulkExportJob.addColumn("EXP_TIME").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		bulkExportJob.addColumn("REQUEST").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
-		bulkExportJob.addColumn("OPTLOCK").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		bulkExportJob.addColumn("EXP_SINCE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		bulkExportJob.addColumn("STATUS_MESSAGE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+		bulkExportJob.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		bulkExportJob.addColumn("JOB_ID").nonNullable().type(ColumnTypeEnum.STRING, 36);
+		bulkExportJob.addColumn("JOB_STATUS").nonNullable().type(ColumnTypeEnum.STRING, 10);
+		bulkExportJob.addColumn("CREATED_TIME").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		bulkExportJob.addColumn("STATUS_TIME").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		bulkExportJob.addColumn("EXP_TIME").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		bulkExportJob.addColumn("REQUEST").nonNullable().type(ColumnTypeEnum.STRING, 500);
+		bulkExportJob.addColumn("OPTLOCK").nonNullable().type(ColumnTypeEnum.INT);
+		bulkExportJob.addColumn("EXP_SINCE").nullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		bulkExportJob.addColumn("STATUS_MESSAGE").nullable().type(ColumnTypeEnum.STRING, 500);
 		bulkExportJob.addIndex("20190921.5", "IDX_BLKEX_EXPTIME").unique(false).withColumns("EXP_TIME");
 		bulkExportJob.addIndex("20190921.6", "IDX_BLKEX_JOB_ID").unique(true).withColumns("JOB_ID");
 
 		// HFJ_BLK_EXPORT_COLLECTION
 		version.addIdGenerator("20190921.7", "SEQ_BLKEXCOL_PID");
 		Builder.BuilderAddTableByColumns bulkExportCollection = version.addTableByColumns("20190921.8", "HFJ_BLK_EXPORT_COLLECTION", "PID");
-		bulkExportCollection.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		bulkExportCollection.addColumn("JOB_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		bulkExportCollection.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		bulkExportCollection.addColumn("JOB_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		bulkExportCollection.addForeignKey("20190921.9", "FK_BLKEXCOL_JOB").toColumn("JOB_PID").references("HFJ_BLK_EXPORT_JOB", "PID");
-		bulkExportCollection.addColumn("RES_TYPE").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
-		bulkExportCollection.addColumn("TYPE_FILTER").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 1000);
-		bulkExportCollection.addColumn("OPTLOCK").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+		bulkExportCollection.addColumn("RES_TYPE").nonNullable().type(ColumnTypeEnum.STRING, 40);
+		bulkExportCollection.addColumn("TYPE_FILTER").nullable().type(ColumnTypeEnum.STRING, 1000);
+		bulkExportCollection.addColumn("OPTLOCK").nonNullable().type(ColumnTypeEnum.INT);
 
 		// HFJ_BLK_EXPORT_COLFILE
 		version.addIdGenerator("20190921.10", "SEQ_BLKEXCOLFILE_PID");
 		Builder.BuilderAddTableByColumns bulkExportCollectionFile = version.addTableByColumns("20190921.11", "HFJ_BLK_EXPORT_COLFILE", "PID");
-		bulkExportCollectionFile.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		bulkExportCollectionFile.addColumn("COLLECTION_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		bulkExportCollectionFile.addColumn("RES_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
+		bulkExportCollectionFile.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		bulkExportCollectionFile.addColumn("COLLECTION_PID").nonNullable().type(ColumnTypeEnum.LONG);
+		bulkExportCollectionFile.addColumn("RES_ID").nonNullable().type(ColumnTypeEnum.STRING, 100);
 		bulkExportCollectionFile.addForeignKey("20190921.12", "FK_BLKEXCOLFILE_COLLECT").toColumn("COLLECTION_PID").references("HFJ_BLK_EXPORT_COLLECTION", "PID");
 
 		// HFJ_RES_VER_PROV
 		version.startSectionWithMessage("Processing bulkExportCollectionFile: HFJ_RES_VER_PROV");
 		Builder.BuilderAddTableByColumns resVerProv = version.addTableByColumns("20190921.13", "HFJ_RES_VER_PROV", "RES_VER_PID");
-		resVerProv.addColumn("RES_VER_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		resVerProv.addColumn("RES_VER_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		resVerProv
 			.addForeignKey("20190921.14", "FK_RESVERPROV_RESVER_PID")
 			.toColumn("RES_VER_PID")
 			.references("HFJ_RES_VER", "PID");
-		resVerProv.addColumn("RES_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		resVerProv.addColumn("RES_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		resVerProv
 			.addForeignKey("20190921.15", "FK_RESVERPROV_RES_PID")
 			.toColumn("RES_PID")
 			.references("HFJ_RESOURCE", "RES_ID");
-		resVerProv.addColumn("SOURCE_URI").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		resVerProv.addColumn("REQUEST_ID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 16);
+		resVerProv.addColumn("SOURCE_URI").nullable().type(ColumnTypeEnum.STRING, 100);
+		resVerProv.addColumn("REQUEST_ID").nullable().type(ColumnTypeEnum.STRING, 16);
 		resVerProv.addIndex("20190921.16", "IDX_RESVERPROV_SOURCEURI").unique(false).withColumns("SOURCE_URI");
 		resVerProv.addIndex("20190921.17", "IDX_RESVERPROV_REQUESTID").unique(false).withColumns("REQUEST_ID");
 
 		// TermValueSetConceptDesignation
 		version.startSectionWithMessage("Processing bulkExportCollectionFile: TRM_VALUESET_C_DESIGNATION");
 		Builder.BuilderWithTableName termValueSetConceptDesignationTable = version.onTable("TRM_VALUESET_C_DESIGNATION");
-		termValueSetConceptDesignationTable.addColumn("20190921.18", "VALUESET_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		termValueSetConceptDesignationTable.addColumn("20190921.18", "VALUESET_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		termValueSetConceptDesignationTable
 			.addForeignKey("20190921.19", "FK_TRM_VSCD_VS_PID")
 			.toColumn("VALUESET_PID")
@@ -395,8 +394,8 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		// TermValueSet
 		version.startSectionWithMessage("Processing bulkExportCollectionFile: TRM_VALUESET");
 		Builder.BuilderWithTableName termValueSetTable = version.onTable("TRM_VALUESET");
-		termValueSetTable.addColumn("20190921.22", "TOTAL_CONCEPTS").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		termValueSetTable.addColumn("20190921.23", "TOTAL_CONCEPT_DESIGNATIONS").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		termValueSetTable.addColumn("20190921.22", "TOTAL_CONCEPTS").nonNullable().type(ColumnTypeEnum.LONG);
+		termValueSetTable.addColumn("20190921.23", "TOTAL_CONCEPT_DESIGNATIONS").nonNullable().type(ColumnTypeEnum.LONG);
 		termValueSetTable
 			.dropIndex("20190921.24", "IDX_VALUESET_EXP_STATUS");
 
@@ -405,31 +404,31 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		// TermValueSetConcept
 		version.startSectionWithMessage("Processing bulkExportCollectionFile: TRM_VALUESET_CONCEPT");
 		Builder.BuilderWithTableName termValueSetConceptTable = version.onTable("TRM_VALUESET_CONCEPT");
-		termValueSetConceptTable.addColumn("20190921.26", "VALUESET_ORDER").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+		termValueSetConceptTable.addColumn("20190921.26", "VALUESET_ORDER").nonNullable().type(ColumnTypeEnum.INT);
 		termValueSetConceptTable
 			.addIndex("20190921.27", "IDX_VS_CONCEPT_ORDER")
 			.unique(true)
 			.withColumns("VALUESET_PID", "VALUESET_ORDER");
 
 		// Account for RESTYPE_LEN column increasing from 30 to 40
-		version.onTable("HFJ_RESOURCE").modifyColumn("20191002.1", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
-		version.onTable("HFJ_RES_VER").modifyColumn("20191002.2", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
-		version.onTable("HFJ_HISTORY_TAG").modifyColumn("20191002.3", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
-		version.onTable("HFJ_RES_LINK").modifyColumn("20191002.4", "SOURCE_RESOURCE_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
-		version.onTable("HFJ_RES_LINK").modifyColumn("20191002.5", "TARGET_RESOURCE_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
-		version.onTable("HFJ_RES_TAG").modifyColumn("20191002.6", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 40);
+		version.onTable("HFJ_RESOURCE").modifyColumn("20191002.1", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 40);
+		version.onTable("HFJ_RES_VER").modifyColumn("20191002.2", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 40);
+		version.onTable("HFJ_HISTORY_TAG").modifyColumn("20191002.3", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 40);
+		version.onTable("HFJ_RES_LINK").modifyColumn("20191002.4", "SOURCE_RESOURCE_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 40);
+		version.onTable("HFJ_RES_LINK").modifyColumn("20191002.5", "TARGET_RESOURCE_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 40);
+		version.onTable("HFJ_RES_TAG").modifyColumn("20191002.6", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 40);
 
 		// TermConceptDesignation
 		version.startSectionWithMessage("Processing table: TRM_CONCEPT_DESIG");
-		version.onTable("TRM_CONCEPT_DESIG").modifyColumn("20191002.7", "VAL").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 2000);
+		version.onTable("TRM_CONCEPT_DESIG").modifyColumn("20191002.7", "VAL").nonNullable().withType(ColumnTypeEnum.STRING, 2000);
 
 		// TermValueSetConceptDesignation
 		version.startSectionWithMessage("Processing table: TRM_VALUESET_C_DESIGNATION");
-		version.onTable("TRM_VALUESET_C_DESIGNATION").modifyColumn("20191002.8", "VAL").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 2000);
+		version.onTable("TRM_VALUESET_C_DESIGNATION").modifyColumn("20191002.8", "VAL").nonNullable().withType(ColumnTypeEnum.STRING, 2000);
 
 		// TermConceptProperty
 		version.startSectionWithMessage("Processing table: TRM_CONCEPT_PROPERTY");
-		version.onTable("TRM_CONCEPT_PROPERTY").addColumn("20191002.9", "PROP_VAL_LOB").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BLOB);
+		version.onTable("TRM_CONCEPT_PROPERTY").addColumn("20191002.9", "PROP_VAL_LOB").nullable().type(ColumnTypeEnum.BLOB);
 	}
 
 	protected void init400() { // 20190401 - 20190814
@@ -437,13 +436,13 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 
 		// BinaryStorageEntity
 		Builder.BuilderAddTableByColumns binaryBlob = version.addTableByColumns("20190722.1", "HFJ_BINARY_STORAGE_BLOB", "BLOB_ID");
-		binaryBlob.addColumn("BLOB_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		binaryBlob.addColumn("RESOURCE_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		binaryBlob.addColumn("BLOB_SIZE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
-		binaryBlob.addColumn("CONTENT_TYPE").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		binaryBlob.addColumn("BLOB_DATA").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BLOB);
-		binaryBlob.addColumn("PUBLISHED_DATE").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		binaryBlob.addColumn("BLOB_HASH").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 128);
+		binaryBlob.addColumn("BLOB_ID").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		binaryBlob.addColumn("RESOURCE_ID").nonNullable().type(ColumnTypeEnum.STRING, 100);
+		binaryBlob.addColumn("BLOB_SIZE").nullable().type(ColumnTypeEnum.INT);
+		binaryBlob.addColumn("CONTENT_TYPE").nonNullable().type(ColumnTypeEnum.STRING, 100);
+		binaryBlob.addColumn("BLOB_DATA").nonNullable().type(ColumnTypeEnum.BLOB);
+		binaryBlob.addColumn("PUBLISHED_DATE").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		binaryBlob.addColumn("BLOB_HASH").nullable().type(ColumnTypeEnum.STRING, 128);
 
 		// Interim builds used this name
 		version.onTable("TRM_VALUESET_CODE").dropThisTable("20190722.2");
@@ -453,15 +452,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.renameColumn("20190722.4", "mySourceValueSet", "SOURCE_VS", false, true)
 			.renameColumn("20190722.5", "myTargetValueSet", "TARGET_VS", false, true);
 		version.onTable("TRM_CONCEPT_MAP_GROUP")
-			.modifyColumn("20190722.6", "CONCEPT_MAP_URL").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.6", "CONCEPT_MAP_URL").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GROUP")
-			.modifyColumn("20190722.7", "SOURCE_VERSION").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.7", "SOURCE_VERSION").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GROUP")
-			.modifyColumn("20190722.8", "SOURCE_VS").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.8", "SOURCE_VS").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GROUP")
-			.modifyColumn("20190722.9", "TARGET_VERSION").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.9", "TARGET_VERSION").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GROUP")
-			.modifyColumn("20190722.10", "TARGET_VS").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.10", "TARGET_VS").nullable().withType(ColumnTypeEnum.STRING, 200);
 
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELEMENT")
 			.renameColumn("20190722.11", "myConceptMapUrl", "CONCEPT_MAP_URL", false, true)
@@ -469,15 +468,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.renameColumn("20190722.13", "mySystemVersion", "SYSTEM_VERSION", false, true)
 			.renameColumn("20190722.14", "myValueSet", "VALUESET_URL", false, true);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELEMENT")
-			.modifyColumn("20190722.15", "CONCEPT_MAP_URL").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.15", "CONCEPT_MAP_URL").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELEMENT")
-			.modifyColumn("20190722.16", "SOURCE_CODE").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+			.modifyColumn("20190722.16", "SOURCE_CODE").nonNullable().withType(ColumnTypeEnum.STRING, 500);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELEMENT")
-			.modifyColumn("20190722.17", "SYSTEM_URL").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.17", "SYSTEM_URL").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELEMENT")
-			.modifyColumn("20190722.18", "SYSTEM_VERSION").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.18", "SYSTEM_VERSION").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELEMENT")
-			.modifyColumn("20190722.19", "VALUESET_URL").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.19", "VALUESET_URL").nullable().withType(ColumnTypeEnum.STRING, 200);
 
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELM_TGT")
 			.renameColumn("20190722.20", "myConceptMapUrl", "CONCEPT_MAP_URL", false, true)
@@ -485,15 +484,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.renameColumn("20190722.22", "mySystemVersion", "SYSTEM_VERSION", false, true)
 			.renameColumn("20190722.23", "myValueSet", "VALUESET_URL", false, true);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELM_TGT")
-			.modifyColumn("20190722.24", "CONCEPT_MAP_URL").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.24", "CONCEPT_MAP_URL").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELM_TGT")
-			.modifyColumn("20190722.25", "SYSTEM_URL").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.25", "SYSTEM_URL").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELM_TGT")
-			.modifyColumn("20190722.26", "SYSTEM_VERSION").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.26", "SYSTEM_VERSION").nullable().withType(ColumnTypeEnum.STRING, 200);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELM_TGT")
-			.modifyColumn("20190722.27", "TARGET_CODE").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+			.modifyColumn("20190722.27", "TARGET_CODE").nonNullable().withType(ColumnTypeEnum.STRING, 500);
 		version.onTable("TRM_CONCEPT_MAP_GRP_ELM_TGT")
-			.modifyColumn("20190722.28", "VALUESET_URL").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.modifyColumn("20190722.28", "VALUESET_URL").nullable().withType(ColumnTypeEnum.STRING, 200);
 
 		version.onTable("TRM_CONCEPT")
 			.renameColumn("20190722.29", "CODE", "CODEVAL", false, true);
@@ -503,26 +502,26 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.startSectionWithMessage("Processing table: TRM_VALUESET");
 		version.addIdGenerator("20190722.30", "SEQ_VALUESET_PID");
 		Builder.BuilderAddTableByColumns termValueSetTable = version.addTableByColumns("20190722.31", "TRM_VALUESET", "PID");
-		termValueSetTable.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		termValueSetTable.addColumn("URL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		termValueSetTable.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		termValueSetTable.addColumn("URL").nonNullable().type(ColumnTypeEnum.STRING, 200);
 		termValueSetTable
 			.addIndex("20190722.32", "IDX_VALUESET_URL")
 			.unique(true)
 			.withColumns("URL");
-		termValueSetTable.addColumn("RES_ID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		termValueSetTable.addColumn("RES_ID").nonNullable().type(ColumnTypeEnum.LONG);
 		termValueSetTable
 			.addForeignKey("20190722.33", "FK_TRMVALUESET_RES")
 			.toColumn("RES_ID")
 			.references("HFJ_RESOURCE", "RES_ID");
-		termValueSetTable.addColumn("NAME").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		termValueSetTable.addColumn("NAME").nullable().type(ColumnTypeEnum.STRING, 200);
 
 		version.onTable("TRM_VALUESET")
 			.renameColumn("20190722.34", "NAME", "VSNAME", true, true);
 		version.onTable("TRM_VALUESET")
-			.modifyColumn("20190722.35", "RES_ID").nullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+			.modifyColumn("20190722.35", "RES_ID").nullable().withType(ColumnTypeEnum.LONG);
 
 		Builder.BuilderWithTableName termValueSetTableChange = version.onTable("TRM_VALUESET");
-		termValueSetTableChange.addColumn("20190722.36", "EXPANSION_STATUS").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 50);
+		termValueSetTableChange.addColumn("20190722.36", "EXPANSION_STATUS").nonNullable().type(ColumnTypeEnum.STRING, 50);
 		termValueSetTableChange
 			.addIndex("20190722.37", "IDX_VALUESET_EXP_STATUS")
 			.unique(false)
@@ -532,15 +531,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.startSectionWithMessage("Processing table: TRM_VALUESET_CONCEPT");
 		version.addIdGenerator("20190722.38", "SEQ_VALUESET_CONCEPT_PID");
 		Builder.BuilderAddTableByColumns termValueSetConceptTable = version.addTableByColumns("20190722.39", "TRM_VALUESET_CONCEPT", "PID");
-		termValueSetConceptTable.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		termValueSetConceptTable.addColumn("VALUESET_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		termValueSetConceptTable.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		termValueSetConceptTable.addColumn("VALUESET_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		termValueSetConceptTable
 			.addForeignKey("20190722.40", "FK_TRM_VALUESET_PID")
 			.toColumn("VALUESET_PID")
 			.references("TRM_VALUESET", "PID");
-		termValueSetConceptTable.addColumn("SYSTEM_URL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		termValueSetConceptTable.addColumn("CODEVAL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
-		termValueSetConceptTable.addColumn("DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 400);
+		termValueSetConceptTable.addColumn("SYSTEM_URL").nonNullable().type(ColumnTypeEnum.STRING, 200);
+		termValueSetConceptTable.addColumn("CODEVAL").nonNullable().type(ColumnTypeEnum.STRING, 500);
+		termValueSetConceptTable.addColumn("DISPLAY").nullable().type(ColumnTypeEnum.STRING, 400);
 		version.onTable("TRM_VALUESET_CONCEPT")
 			.renameColumn("20190722.41", "CODE", "CODEVAL", true, true)
 			.renameColumn("20190722.42", "SYSTEM", "SYSTEM_URL", true, true);
@@ -556,17 +555,17 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		version.startSectionWithMessage("Processing table: TRM_VALUESET_C_DESIGNATION");
 		version.addIdGenerator("20190801.3", "SEQ_VALUESET_C_DSGNTN_PID");
 		Builder.BuilderAddTableByColumns termValueSetConceptDesignationTable = version.addTableByColumns("20190801.4", "TRM_VALUESET_C_DESIGNATION", "PID");
-		termValueSetConceptDesignationTable.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		termValueSetConceptDesignationTable.addColumn("VALUESET_CONCEPT_PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		termValueSetConceptDesignationTable.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		termValueSetConceptDesignationTable.addColumn("VALUESET_CONCEPT_PID").nonNullable().type(ColumnTypeEnum.LONG);
 		termValueSetConceptDesignationTable
 			.addForeignKey("20190801.5", "FK_TRM_VALUESET_CONCEPT_PID")
 			.toColumn("VALUESET_CONCEPT_PID")
 			.references("TRM_VALUESET_CONCEPT", "PID");
-		termValueSetConceptDesignationTable.addColumn("LANG").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
-		termValueSetConceptDesignationTable.addColumn("USE_SYSTEM").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
-		termValueSetConceptDesignationTable.addColumn("USE_CODE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
-		termValueSetConceptDesignationTable.addColumn("USE_DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
-		termValueSetConceptDesignationTable.addColumn("VAL").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("LANG").nullable().type(ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("USE_SYSTEM").nullable().type(ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("USE_CODE").nullable().type(ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("USE_DISPLAY").nullable().type(ColumnTypeEnum.STRING, 500);
+		termValueSetConceptDesignationTable.addColumn("VAL").nonNullable().type(ColumnTypeEnum.STRING, 500);
 
 		// This index turned out not to be needed so it is disabled
 		termValueSetConceptDesignationTable
@@ -578,49 +577,49 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		// TermCodeSystemVersion
 		version.startSectionWithMessage("Processing table: TRM_CODESYSTEM_VER");
 		Builder.BuilderWithTableName termCodeSystemVersionTable = version.onTable("TRM_CODESYSTEM_VER");
-		termCodeSystemVersionTable.addColumn("20190814.1", "CS_DISPLAY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		termCodeSystemVersionTable.addColumn("20190814.1", "CS_DISPLAY").nullable().type(ColumnTypeEnum.STRING, 200);
 
 		// ResourceReindexJobEntry
 		version.addIdGenerator("20190814.2", "SEQ_RES_REINDEX_JOB");
 		Builder.BuilderAddTableByColumns reindex = version.addTableByColumns("20190814.3", "HFJ_RES_REINDEX_JOB", "PID");
-		reindex.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-		reindex.addColumn("RES_TYPE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		reindex.addColumn("UPDATE_THRESHOLD_HIGH").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		reindex.addColumn("JOB_DELETED").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
-		reindex.addColumn("UPDATE_THRESHOLD_LOW").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		reindex.addColumn("SUSPENDED_UNTIL").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
-		reindex.addColumn("REINDEX_COUNT").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+		reindex.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+		reindex.addColumn("RES_TYPE").nullable().type(ColumnTypeEnum.STRING, 100);
+		reindex.addColumn("UPDATE_THRESHOLD_HIGH").nonNullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		reindex.addColumn("JOB_DELETED").nonNullable().type(ColumnTypeEnum.BOOLEAN);
+		reindex.addColumn("UPDATE_THRESHOLD_LOW").nullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		reindex.addColumn("SUSPENDED_UNTIL").nullable().type(ColumnTypeEnum.DATE_TIMESTAMP);
+		reindex.addColumn("REINDEX_COUNT").nullable().type(ColumnTypeEnum.INT);
 
 		// Search
 		version.onTable("HFJ_SEARCH")
-			.addColumn("20190814.4", "SEARCH_DELETED").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BOOLEAN);
+			.addColumn("20190814.4", "SEARCH_DELETED").nullable().type(ColumnTypeEnum.BOOLEAN);
 		version.onTable("HFJ_SEARCH")
-			.modifyColumn("20190814.5", "SEARCH_LAST_RETURNED").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
+			.modifyColumn("20190814.5", "SEARCH_LAST_RETURNED").nonNullable().withType(ColumnTypeEnum.DATE_TIMESTAMP);
 		version.onTable("HFJ_SEARCH")
-			.addColumn("20190814.6", "SEARCH_PARAM_MAP").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.BLOB);
+			.addColumn("20190814.6", "SEARCH_PARAM_MAP").nullable().type(ColumnTypeEnum.BLOB);
 		version.onTable("HFJ_SEARCH")
-			.modifyColumn("20190814.7", "SEARCH_UUID").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 36);
+			.modifyColumn("20190814.7", "SEARCH_UUID").nonNullable().withType(ColumnTypeEnum.STRING, 36);
 
 		version.onTable("HFJ_SEARCH_PARM").dropThisTable("20190814.8");
 
 		// Make some columns non-nullable that were previously nullable - These are marked as failure allowed, since
 		// SQL Server won't let us change nullability on columns with indexes pointing to them
-		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20190814.9", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		version.onTable("HFJ_SPIDX_DATE").modifyColumn("20190814.10", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		version.onTable("HFJ_SPIDX_STRING").modifyColumn("20190814.11", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		version.onTable("HFJ_SPIDX_STRING").addColumn("20190814.12", "HASH_IDENTITY").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20190814.9", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_DATE").modifyColumn("20190814.10", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_STRING").modifyColumn("20190814.11", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_STRING").addColumn("20190814.12", "HASH_IDENTITY").nullable().type(ColumnTypeEnum.LONG);
 		version.onTable("HFJ_SPIDX_STRING").addIndex("20190814.13", "IDX_SP_STRING_HASH_IDENT").unique(false).withColumns("HASH_IDENTITY");
-		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20190814.14", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		version.onTable("HFJ_SPIDX_QUANTITY").modifyColumn("20190814.15", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_COORDS").modifyColumn("20190814.14", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_QUANTITY").modifyColumn("20190814.15", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
 		version.onTable("HFJ_SPIDX_QUANTITY").dropColumn("20190814.16", "HASH_UNITS_AND_VALPREFIX");
 		version.onTable("HFJ_SPIDX_QUANTITY").dropColumn("20190814.17", "HASH_VALPREFIX");
-		version.onTable("HFJ_SPIDX_NUMBER").modifyColumn("20190814.18", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		version.onTable("HFJ_SPIDX_TOKEN").modifyColumn("20190814.19", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		version.onTable("HFJ_SPIDX_URI").modifyColumn("20190814.20", "RES_TYPE").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 100);
-		version.onTable("HFJ_SPIDX_URI").modifyColumn("20190814.21", "SP_URI").nullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 254);
-		version.onTable("TRM_CODESYSTEM").modifyColumn("20190814.22", "CODE_SYSTEM_URI").nonNullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		version.onTable("TRM_CODESYSTEM").modifyColumn("20190814.23", "CS_NAME").nullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-		version.onTable("TRM_CODESYSTEM_VER").modifyColumn("20190814.24", "CS_VERSION_ID").nullable().failureAllowed().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		version.onTable("HFJ_SPIDX_NUMBER").modifyColumn("20190814.18", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_TOKEN").modifyColumn("20190814.19", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_URI").modifyColumn("20190814.20", "RES_TYPE").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 100);
+		version.onTable("HFJ_SPIDX_URI").modifyColumn("20190814.21", "SP_URI").nullable().failureAllowed().withType(ColumnTypeEnum.STRING, 254);
+		version.onTable("TRM_CODESYSTEM").modifyColumn("20190814.22", "CODE_SYSTEM_URI").nonNullable().failureAllowed().withType(ColumnTypeEnum.STRING, 200);
+		version.onTable("TRM_CODESYSTEM").modifyColumn("20190814.23", "CS_NAME").nullable().failureAllowed().withType(ColumnTypeEnum.STRING, 200);
+		version.onTable("TRM_CODESYSTEM_VER").modifyColumn("20190814.24", "CS_VERSION_ID").nullable().failureAllowed().withType(ColumnTypeEnum.STRING, 200);
 	}
 
 
@@ -633,7 +632,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		resourceLink
 			.modifyColumn("20180929.1", "SRC_PATH")
 			.nonNullable()
-			.withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+			.withType(ColumnTypeEnum.STRING, 200);
 
 		// Search
 		Builder.BuilderWithTableName search = version.onTable("HFJ_SEARCH");
@@ -641,7 +640,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		search
 			.addColumn("20181001.1", "OPTLOCK_VERSION")
 			.nullable()
-			.type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+			.type(ColumnTypeEnum.INT);
 
 		version.addTableRawSql("20181104.1", "HFJ_RES_REINDEX_JOB")
 			.addSql(DriverTypeEnum.MSSQL_2012, "create table HFJ_RES_REINDEX_JOB (PID bigint not null, JOB_DELETED bit not null, RES_TYPE varchar(255), SUSPENDED_UNTIL datetime2, UPDATE_THRESHOLD_HIGH datetime2 not null, UPDATE_THRESHOLD_LOW datetime2, primary key (PID))")
@@ -651,13 +650,13 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.addSql(DriverTypeEnum.MYSQL_5_7, " create table HFJ_RES_REINDEX_JOB (PID bigint not null, JOB_DELETED bit not null, RES_TYPE varchar(255), SUSPENDED_UNTIL datetime(6), UPDATE_THRESHOLD_HIGH datetime(6) not null, UPDATE_THRESHOLD_LOW datetime(6), primary key (PID))")
 			.addSql(DriverTypeEnum.ORACLE_12C, "create table HFJ_RES_REINDEX_JOB (PID number(19,0) not null, JOB_DELETED number(1,0) not null, RES_TYPE varchar2(255 char), SUSPENDED_UNTIL timestamp, UPDATE_THRESHOLD_HIGH timestamp not null, UPDATE_THRESHOLD_LOW timestamp, primary key (PID))");
 
-		version.onTable("TRM_CONCEPT_DESIG").addColumn("20181104.2", "CS_VER_PID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		version.onTable("TRM_CONCEPT_DESIG").addColumn("20181104.2", "CS_VER_PID").nullable().type(ColumnTypeEnum.LONG);
 		version.onTable("TRM_CONCEPT_DESIG").addForeignKey("20181104.3", "FK_CONCEPTDESIG_CSV").toColumn("CS_VER_PID").references("TRM_CODESYSTEM_VER", "PID");
 
-		version.onTable("TRM_CONCEPT_PROPERTY").addColumn("20181104.4", "CS_VER_PID").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		version.onTable("TRM_CONCEPT_PROPERTY").addColumn("20181104.4", "CS_VER_PID").nullable().type(ColumnTypeEnum.LONG);
 		version.onTable("TRM_CONCEPT_PROPERTY").addForeignKey("20181104.5", "FK_CONCEPTPROP_CSV").toColumn("CS_VER_PID").references("TRM_CODESYSTEM_VER", "PID");
 
-		version.onTable("TRM_CONCEPT").addColumn("20181104.6", "PARENT_PIDS").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.CLOB);
+		version.onTable("TRM_CONCEPT").addColumn("20181104.6", "PARENT_PIDS").nullable().type(ColumnTypeEnum.CLOB);
 
 	}
 
@@ -684,7 +683,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spidxCoords
 			.addColumn("20180903.1", "HASH_IDENTITY")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		if (!myFlags.contains(FlagEnum.NO_MIGRATE_HASHES)) {
 			spidxCoords
 				.dropIndex("20180903.2", "IDX_SP_COORDS");
@@ -705,7 +704,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spidxDate
 			.addColumn("20180903.6", "HASH_IDENTITY")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		if (!myFlags.contains(FlagEnum.NO_MIGRATE_HASHES)) {
 			spidxDate
 				.dropIndex("20180903.7", "IDX_SP_TOKEN");
@@ -728,7 +727,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spidxNumber
 			.addColumn("20180903.11", "HASH_IDENTITY")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		if (!myFlags.contains(FlagEnum.NO_MIGRATE_HASHES)) {
 			spidxNumber
 				.dropIndex("20180903.12", "IDX_SP_NUMBER");
@@ -749,15 +748,15 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spidxQuantity
 			.addColumn("20180903.15", "HASH_IDENTITY")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		spidxQuantity
 			.addColumn("20180903.16", "HASH_IDENTITY_SYS_UNITS")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		spidxQuantity
 			.addColumn("20180903.17", "HASH_IDENTITY_AND_UNITS")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		if (!myFlags.contains(FlagEnum.NO_MIGRATE_HASHES)) {
 			spidxQuantity
 				.dropIndex("20180903.18", "IDX_SP_QUANTITY");
@@ -788,7 +787,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spidxString
 			.addColumn("20180903.23", "HASH_NORM_PREFIX")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		if (!myFlags.contains(FlagEnum.NO_MIGRATE_HASHES)) {
 			spidxString
 				.dropIndex("20180903.24", "IDX_SP_STRING");
@@ -799,7 +798,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			spidxString
 				.addColumn("20180903.26", "HASH_EXACT")
 				.nullable()
-				.type(AddColumnTask.ColumnTypeEnum.LONG);
+				.type(ColumnTypeEnum.LONG);
 			spidxString
 				.addIndex("20180903.27", "IDX_SP_STRING_HASH_EXCT")
 				.unique(false)
@@ -818,19 +817,19 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spidxToken
 			.addColumn("20180903.29", "HASH_IDENTITY")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		spidxToken
 			.addColumn("20180903.30", "HASH_SYS")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		spidxToken
 			.addColumn("20180903.31", "HASH_SYS_AND_VALUE")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		spidxToken
 			.addColumn("20180903.32", "HASH_VALUE")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		if (!myFlags.contains(FlagEnum.NO_MIGRATE_HASHES)) {
 			spidxToken
 				.dropIndex("20180903.33", "IDX_SP_TOKEN");
@@ -868,7 +867,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spidxUri
 			.addColumn("20180903.40", "HASH_IDENTITY")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		if (!myFlags.contains(FlagEnum.NO_MIGRATE_HASHES)) {
 			spidxUri
 				.addIndex("20180903.41", "IDX_SP_URI_HASH_IDENTITY")
@@ -877,7 +876,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			spidxUri
 				.addColumn("20180903.42", "HASH_URI")
 				.nullable()
-				.type(AddColumnTask.ColumnTypeEnum.LONG);
+				.type(ColumnTypeEnum.LONG);
 			spidxUri
 				.addIndex("20180903.43", "IDX_SP_URI_HASH_URI")
 				.unique(false)
@@ -897,7 +896,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		spp
 			.addColumn("20180903.46", "HASH_PRESENCE")
 			.nullable()
-			.type(AddColumnTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		spp
 			.addIndex("20180903.47", "IDX_RESPARMPRESENT_HASHPRES")
 			.unique(false)
@@ -933,7 +932,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		trmConcept
 			.addColumn("20180903.50", "CONCEPT_UPDATED")
 			.nullable()
-			.type(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP);
+			.type(ColumnTypeEnum.DATE_TIMESTAMP);
 		trmConcept
 			.addIndex("20180903.51", "IDX_CONCEPT_UPDATED")
 			.unique(false)
@@ -941,7 +940,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		trmConcept
 			.modifyColumn("20180903.52", "CODE")
 			.nonNullable()
-			.withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 500);
+			.withType(ColumnTypeEnum.STRING, 500);
 
 		// Concept Designation
 		version.startSectionWithMessage("Starting work on table: TRM_CONCEPT_DESIG");
@@ -1078,7 +1077,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 			.addSql(DriverTypeEnum.MSSQL_2012, "create index IDX_CNCPT_MP_GRP_ELM_TGT_CD on TRM_CONCEPT_MAP_GRP_ELM_TGT (TARGET_CODE)")
 			.addSql(DriverTypeEnum.MSSQL_2012, "alter table TRM_CONCEPT_MAP_GRP_ELM_TGT add constraint FK_TCMGETARGET_ELEMENT foreign key (CONCEPT_MAP_GRP_ELM_PID) references TRM_CONCEPT_MAP_GRP_ELEMENT");
 
-		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").modifyColumn("20180907.7", "IDX_STRING").nonNullable().withType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
+		version.onTable("HFJ_IDX_CMP_STRING_UNIQ").modifyColumn("20180907.7", "IDX_STRING").nonNullable().withType(ColumnTypeEnum.STRING, 200);
 
 
 	}
@@ -1108,11 +1107,11 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		resourceLink
 			.addColumn("20180401.3", "CS_VERSION_ID")
 			.nullable()
-			.type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 255);
+			.type(ColumnTypeEnum.STRING, 255);
 		resourceLink
 			.addColumn("20180401.4", "CODESYSTEM_PID")
 			.nullable()
-			.type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+			.type(ColumnTypeEnum.LONG);
 		resourceLink
 			.addForeignKey("20180401.5", "FK_CODESYSVER_CS_ID")
 			.toColumn("CODESYSTEM_PID")
@@ -1124,7 +1123,7 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		concept
 			.addColumn("20180401.6", "CODE_SEQUENCE")
 			.nullable()
-			.type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+			.type(ColumnTypeEnum.INT);
 
 
 	}

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/api/Builder.java
@@ -343,12 +343,12 @@ public class Builder {
 					myNullable = theNullable;
 				}
 
-				public void withType(BaseTableColumnTypeTask.ColumnTypeEnum theColumnType) {
+				public void withType(ColumnTypeEnum theColumnType) {
 					withType(theColumnType, null);
 				}
 
-				public void withType(BaseTableColumnTypeTask.ColumnTypeEnum theColumnType, Integer theLength) {
-					if (theColumnType == BaseTableColumnTypeTask.ColumnTypeEnum.STRING) {
+				public void withType(ColumnTypeEnum theColumnType, Integer theLength) {
+					if (theColumnType == ColumnTypeEnum.STRING) {
 						if (theLength == null || theLength == 0) {
 							throw new IllegalArgumentException("Can not specify length 0 for column of type " + theColumnType);
 						}
@@ -439,11 +439,11 @@ public class Builder {
 					myNullable = theNullable;
 				}
 
-				public BuilderCompleteTask type(AddColumnTask.ColumnTypeEnum theColumnType) {
+				public BuilderCompleteTask type(ColumnTypeEnum theColumnType) {
 					return type(theColumnType, null);
 				}
 
-				public BuilderCompleteTask type(AddColumnTask.ColumnTypeEnum theColumnType, Integer theLength) {
+				public BuilderCompleteTask type(ColumnTypeEnum theColumnType, Integer theLength) {
 					AddColumnTask task = new AddColumnTask(myRelease, myVersion);
 					task.setColumnName(myColumnName);
 					task.setNullable(myNullable);

--- a/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTest.java
+++ b/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/AddColumnTest.java
@@ -2,15 +2,12 @@ package ca.uhn.fhir.jpa.migrate.taskdef;
 
 import ca.uhn.fhir.jpa.migrate.JdbcUtils;
 import ca.uhn.fhir.jpa.migrate.tasks.api.BaseMigrationTasks;
-import ca.uhn.fhir.jpa.migrate.tasks.api.Builder;
 import ca.uhn.fhir.util.VersionEnum;
 import org.flywaydb.core.internal.command.DbMigrate;
 import org.junit.Test;
 
 import java.sql.SQLException;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
@@ -30,7 +27,7 @@ public class AddColumnTest extends BaseTest {
 		AddColumnTask task = new AddColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("newcol");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		task.setNullable(true);
 		getMigrator().addTask(task);
 
@@ -46,14 +43,14 @@ public class AddColumnTest extends BaseTest {
 		AddColumnTask task = new AddColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("newcolint");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.INT);
+		task.setColumnType(ColumnTypeEnum.INT);
 		task.setNullable(true);
 		getMigrator().addTask(task);
 
 		getMigrator().migrate();
 
 		JdbcUtils.ColumnType type = JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "newcolint");
-		assertEquals(BaseTableColumnTypeTask.ColumnTypeEnum.INT, type.getColumnTypeEnum());
+		assertEquals(ColumnTypeEnum.INT, type.getColumnTypeEnum());
 	}
 
 	@Test
@@ -63,7 +60,7 @@ public class AddColumnTest extends BaseTest {
 		AddColumnTask task = new AddColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("newcol");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		getMigrator().addTask(task);
 
 		getMigrator().migrate();
@@ -79,7 +76,7 @@ public class AddColumnTest extends BaseTest {
 			.onTable("FOO_TABLE")
 			.addColumn("2001.01", "FOO_COLUMN")
 			.nullable()
-			.type(BaseTableColumnTypeTask.ColumnTypeEnum.INT);
+			.type(ColumnTypeEnum.INT);
 
 		getMigrator().addTasks(tasks.getTasks(VersionEnum.V0_1, VersionEnum.V4_0_0));
 		try {
@@ -99,7 +96,7 @@ public class AddColumnTest extends BaseTest {
 			.onTable("FOO_TABLE")
 			.addColumn("2001.01", "FOO_COLUMN")
 			.nullable()
-			.type(BaseTableColumnTypeTask.ColumnTypeEnum.INT)
+			.type(ColumnTypeEnum.INT)
 			.failureAllowed();
 
 		getMigrator().addTasks(tasks.getTasks(VersionEnum.V0_1, VersionEnum.V4_0_0));

--- a/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTaskTest.java
+++ b/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/AddTableByColumnTaskTest.java
@@ -47,13 +47,13 @@ public class AddTableByColumnTaskTest extends BaseTest {
 			Builder v = forVersion(VersionEnum.V3_5_0);
 
 			Builder.BuilderWithTableName targetTable = v.addTableByColumns("1", "TGT_TABLE", "PID");
-			targetTable.addColumn("2", "PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+			targetTable.addColumn("2", "PID").nonNullable().type(ColumnTypeEnum.LONG);
 
 			Builder.BuilderAddTableByColumns fooTable = v.addTableByColumns("3", "FOO_TABLE", "PID");
-			fooTable.addColumn("PID").nonNullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
-			fooTable.addColumn("HELLO").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-			fooTable.addColumn("GOODBYE").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 200);
-			fooTable.addColumn("COL_REF").nullable().type(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+			fooTable.addColumn("PID").nonNullable().type(ColumnTypeEnum.LONG);
+			fooTable.addColumn("HELLO").nullable().type(ColumnTypeEnum.STRING, 200);
+			fooTable.addColumn("GOODBYE").nullable().type(ColumnTypeEnum.STRING, 200);
+			fooTable.addColumn("COL_REF").nullable().type(ColumnTypeEnum.LONG);
 			fooTable.addIndex("4", "IDX_HELLO").unique(true).withColumns("HELLO");
 			fooTable.addIndex("5", "IDX_GOODBYE").unique(true).withColumnsStub("GOODBYE");
 			fooTable.dropIndexStub("6", "IDX_HELLO");

--- a/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/HashTest.java
+++ b/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/HashTest.java
@@ -26,7 +26,7 @@ public class HashTest {
 		task.setTableName("TRM_CODESYSTEM_VER");
 		task.setColumnName("CS_VERSION_ID");
 		task.setNullable(true);
-		task.setColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING);
+		task.setColumnType(ColumnTypeEnum.STRING);
 		task.setColumnLength(255);
 		return task;
 	}

--- a/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ModifyColumnTest.java
+++ b/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/ModifyColumnTest.java
@@ -27,14 +27,14 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.STRING);
+		task.setColumnType(ColumnTypeEnum.STRING);
 		task.setNullable(true);
 		task.setColumnLength(250);
 		getMigrator().addTask(task);
 
 		getMigrator().migrate();
 
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 250), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 250), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 		assertEquals(1, task.getExecutedStatements().size());
 
 		// Make sure additional migrations don't crash
@@ -50,14 +50,14 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.STRING);
+		task.setColumnType(ColumnTypeEnum.STRING);
 		task.setNullable(true);
 		task.setColumnLength(300);
 		getMigrator().addTask(task);
 
 		getMigrator().migrate();
 
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 300), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 300), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 		assertEquals(1, task.getExecutedStatements().size());
 
 		// Make sure additional migrations don't crash
@@ -73,7 +73,7 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "123456.7");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.STRING);
+		task.setColumnType(ColumnTypeEnum.STRING);
 		task.setNullable(true);
 		task.setColumnLength(200);
 
@@ -82,7 +82,7 @@ public class ModifyColumnTest extends BaseTest {
 		getMigrator().migrate();
 
 		assertEquals(0, task.getExecutedStatements().size());
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 
 		// Make sure additional migrations don't crash
 		getMigrator().migrate();
@@ -95,14 +95,14 @@ public class ModifyColumnTest extends BaseTest {
 		executeSql("create table SOMETABLE (PID bigint not null, TEXTCOL varchar(255) not null)");
 		assertFalse(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "PID"));
 		assertFalse(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 
 		// PID
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("PID");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		task.setNullable(true);
 		getMigrator().addTask(task);
 
@@ -110,7 +110,7 @@ public class ModifyColumnTest extends BaseTest {
 		task = new ModifyColumnTask("1", "2");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.STRING);
+		task.setColumnType(ColumnTypeEnum.STRING);
 		task.setNullable(true);
 		task.setColumnLength(255);
 		getMigrator().addTask(task);
@@ -120,8 +120,8 @@ public class ModifyColumnTest extends BaseTest {
 
 		assertTrue(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "PID"));
 		assertTrue(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 
 		// Make sure additional migrations don't crash
 		getMigrator().migrate();
@@ -135,8 +135,8 @@ public class ModifyColumnTest extends BaseTest {
 		executeSql("create table SOMETABLE (PID bigint not null, DATECOL timestamp not null)");
 		assertFalse(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "PID"));
 		assertFalse(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "DATECOL"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
-		assertEquals(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP, JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "DATECOL").getColumnTypeEnum());
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
+		assertEquals(ColumnTypeEnum.DATE_TIMESTAMP, JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "DATECOL").getColumnTypeEnum());
 
 		getMigrator().setNoColumnShrink(true);
 
@@ -144,7 +144,7 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("PID");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		task.setNullable(true);
 		getMigrator().addTask(task);
 
@@ -152,7 +152,7 @@ public class ModifyColumnTest extends BaseTest {
 		task = new ModifyColumnTask("1", "2");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("DATECOL");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.DATE_TIMESTAMP);
+		task.setColumnType(ColumnTypeEnum.DATE_TIMESTAMP);
 		task.setNullable(true);
 		getMigrator().addTask(task);
 
@@ -161,8 +161,8 @@ public class ModifyColumnTest extends BaseTest {
 
 		assertTrue(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "PID"));
 		assertTrue(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "DATECOL"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
-		assertEquals(BaseTableColumnTypeTask.ColumnTypeEnum.DATE_TIMESTAMP, JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "DATECOL").getColumnTypeEnum());
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
+		assertEquals(ColumnTypeEnum.DATE_TIMESTAMP, JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "DATECOL").getColumnTypeEnum());
 
 		// Make sure additional migrations don't crash
 		getMigrator().migrate();
@@ -174,14 +174,14 @@ public class ModifyColumnTest extends BaseTest {
 		executeSql("create table SOMETABLE (PID bigint, TEXTCOL varchar(255))");
 		assertTrue(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "PID"));
 		assertTrue(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 
 		// PID
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("PID");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		task.setNullable(false);
 		getMigrator().addTask(task);
 
@@ -189,7 +189,7 @@ public class ModifyColumnTest extends BaseTest {
 		task = new ModifyColumnTask("1", "2");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.STRING);
+		task.setColumnType(ColumnTypeEnum.STRING);
 		task.setNullable(false);
 		task.setColumnLength(255);
 		getMigrator().addTask(task);
@@ -199,8 +199,8 @@ public class ModifyColumnTest extends BaseTest {
 
 		assertFalse(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "PID"));
 		assertFalse(JdbcUtils.isColumnNullable(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.LONG, 19), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 255), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 
 		// Make sure additional migrations don't crash
 		getMigrator().migrate();
@@ -232,13 +232,13 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		task.setNullable(true);
 		task.setFailureAllowed(true);
 		getMigrator().addTask(task);
 
 		getMigrator().migrate();
-		assertEquals(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL").getColumnTypeEnum());
+		assertEquals(ColumnTypeEnum.STRING, JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL").getColumnTypeEnum());
 
 	}
 
@@ -250,7 +250,7 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		task.setNullable(true);
 		getMigrator().addTask(task);
 
@@ -270,11 +270,11 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "1");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("PID");
-		task.setColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.LONG);
+		task.setColumnType(ColumnTypeEnum.LONG);
 		task.setNullable(true);
 
 		JdbcUtils.ColumnType existingColumnType = JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "PID");
-		assertEquals(BaseTableColumnTypeTask.ColumnTypeEnum.LONG, existingColumnType.getColumnTypeEnum());
+		assertEquals(ColumnTypeEnum.LONG, existingColumnType.getColumnTypeEnum());
 		assertEquals(19L, existingColumnType.getLength().longValue());
 		assertTrue(existingColumnType.equals(task.getColumnType(), task.getColumnLength()));
 	}
@@ -288,7 +288,7 @@ public class ModifyColumnTest extends BaseTest {
 		ModifyColumnTask task = new ModifyColumnTask("1", "123456.7");
 		task.setTableName("SOMETABLE");
 		task.setColumnName("TEXTCOL");
-		task.setColumnType(AddColumnTask.ColumnTypeEnum.STRING);
+		task.setColumnType(ColumnTypeEnum.STRING);
 		task.setNullable(true);
 		task.setColumnLength(5);
 
@@ -296,7 +296,7 @@ public class ModifyColumnTest extends BaseTest {
 		getMigrator().migrate();
 
 		assertEquals(1, task.getExecutedStatements().size());
-		assertEquals(new JdbcUtils.ColumnType(BaseTableColumnTypeTask.ColumnTypeEnum.STRING, 10), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
+		assertEquals(new JdbcUtils.ColumnType(ColumnTypeEnum.STRING, 10), JdbcUtils.getColumnType(getConnectionProperties(), "SOMETABLE", "TEXTCOL"));
 
 		// Make sure additional migrations don't crash
 		getMigrator().migrate();

--- a/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/RenameColumnTaskDbSpecificTest.java
+++ b/hapi-fhir-jpaserver-migrate/src/test/java/ca/uhn/fhir/jpa/migrate/taskdef/RenameColumnTaskDbSpecificTest.java
@@ -1,0 +1,53 @@
+package ca.uhn.fhir.jpa.migrate.taskdef;
+
+import ca.uhn.fhir.jpa.migrate.DriverTypeEnum;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class RenameColumnTaskDbSpecificTest {
+
+	@Test
+	public void testBuildSqlStatementForMySql() {
+		assertEquals("ALTER TABLE SOMETABLE CHANGE COLUMN myTextCol TEXTCOL integer null", createRenameColumnSql(DriverTypeEnum.MYSQL_5_7));
+	}
+
+	private String createRenameColumnSql(DriverTypeEnum theDriverTypeEnum) {
+		RenameColumnTask task = new RenameColumnTask("1", "1");
+		task.setDriverType(theDriverTypeEnum);
+		task.setTableName("SOMETABLE");
+		task.setOldName("myTextCol");
+		task.setNewName("TEXTCOL");
+		return task.buildRenameColumnSqlStatement("integer", "null");
+	}
+
+	@Test
+	public void testBuildSqlStatementForDerby() {
+		assertEquals("RENAME COLUMN SOMETABLE.myTextCol TO TEXTCOL", createRenameColumnSql(DriverTypeEnum.DERBY_EMBEDDED));
+	}
+
+	@Test
+	public void testBuildSqlStatementForMariaDB() {
+		assertEquals("ALTER TABLE SOMETABLE CHANGE COLUMN myTextCol TO TEXTCOL", createRenameColumnSql(DriverTypeEnum.MARIADB_10_1));
+	}
+
+	@Test
+	public void testBuildSqlStatementForPostgres() {
+		assertEquals("ALTER TABLE SOMETABLE RENAME COLUMN myTextCol TO TEXTCOL", createRenameColumnSql(DriverTypeEnum.POSTGRES_9_4));
+	}
+
+	@Test
+	public void testBuildSqlStatementForMsSql() {
+		assertEquals("sp_rename 'SOMETABLE.myTextCol', 'TEXTCOL', 'COLUMN'", createRenameColumnSql(DriverTypeEnum.MSSQL_2012));
+	}
+
+	@Test
+	public void testBuildSqlStatementForOracle() {
+		assertEquals("ALTER TABLE SOMETABLE RENAME COLUMN myTextCol TO TEXTCOL", createRenameColumnSql(DriverTypeEnum.ORACLE_12C));
+	}
+
+	@Test
+	public void testBuildSqlStatementForH2() {
+		assertEquals("ALTER TABLE SOMETABLE ALTER COLUMN myTextCol RENAME TO TEXTCOL", createRenameColumnSql(DriverTypeEnum.H2_EMBEDDED));
+	}
+
+}


### PR DESCRIPTION
Note that this involves some potentially breaking changes due to refactoring of migration task classes.