### PR TITLE
Bulk intermittent bug

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobCloser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobCloser.java
@@ -49,10 +49,8 @@ public class BulkExportJobCloser implements Tasklet {
 	@Override
 	public RepeatStatus execute(StepContribution theStepContribution, ChunkContext theChunkContext) throws Exception {
 		if (theChunkContext.getStepContext().getStepExecution().getJobExecution().getStatus() == BatchStatus.STARTED) {
-			ourLog.warn("Job Closer is setting job to COMPLETE!");
 			myBulkExportDaoSvc.setJobToStatus(myJobUUID, BulkJobStatusEnum.COMPLETE);
 		} else {
-			ourLog.error("Job Closer is setting job to ERROR!");
 			myBulkExportDaoSvc.setJobToStatus(myJobUUID, BulkJobStatusEnum.ERROR);
 		}
 		return RepeatStatus.FINISHED;

--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobCloser.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/bulk/job/BulkExportJobCloser.java
@@ -22,7 +22,6 @@ package ca.uhn.fhir.jpa.bulk.job;
 
 import ca.uhn.fhir.jpa.bulk.model.BulkJobStatusEnum;
 import ca.uhn.fhir.jpa.bulk.svc.BulkExportDaoSvc;
-import org.slf4j.Logger;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.StepContribution;
 import org.springframework.batch.core.scope.context.ChunkContext;
@@ -31,14 +30,10 @@ import org.springframework.batch.repeat.RepeatStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
 /**
  * Will run before and after a job to set the status to whatever is appropriate.
  */
 public class BulkExportJobCloser implements Tasklet {
-	private static final Logger ourLog = getLogger(BulkExportJobCloser.class);
-
 
 	@Value("#{jobExecutionContext['jobUUID']}")
 	private String myJobUUID;

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.awaitility.Awaitility.await;
@@ -339,7 +340,7 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 	//Note that if the job is generated, and doesnt rely on an existed persisted BulkExportJobEntity, it will need to
 	//create one itself, which means that its jobUUID isnt known until it starts. to get around this, we move
 	public void awaitJobCompletion(JobExecution theJobExecution) throws InterruptedException {
-		await().until(() -> {
+		await().atMost(100, TimeUnit.SECONDS).until(() -> {
 			ourLog.warn("Checking to see if jobExecution {} is finished", theJobExecution.getId());
 			JobExecution jobExecution = myJobExplorer.getJobExecution(theJobExecution.getId());
 			ourLog.warn("That jobExecution currently has status: {}", jobExecution.getStatus());

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -340,10 +340,9 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 	//Note that if the job is generated, and doesnt rely on an existed persisted BulkExportJobEntity, it will need to
 	//create one itself, which means that its jobUUID isnt known until it starts. to get around this, we move
 	public void awaitJobCompletion(JobExecution theJobExecution) throws InterruptedException {
-		await().atMost(100, TimeUnit.SECONDS).until(() -> {
-			ourLog.warn("Checking to see if jobExecution {} is finished", theJobExecution.getId());
+		await().atMost(120, TimeUnit.SECONDS).until(() -> {
 			JobExecution jobExecution = myJobExplorer.getJobExecution(theJobExecution.getId());
-			ourLog.warn("That jobExecution currently has status: {}", jobExecution.getStatus());
+			ourLog.info("JobExecution {} currently has status: {}", theJobExecution.getId(), jobExecution.getStatus());
 			return jobExecution.getStatus() == BatchStatus.COMPLETED;
 		});
 	}

--- a/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
+++ b/hapi-fhir-jpaserver-base/src/test/java/ca/uhn/fhir/jpa/bulk/BulkDataExportSvcImplR4Test.java
@@ -340,7 +340,9 @@ public class BulkDataExportSvcImplR4Test extends BaseJpaR4Test {
 	//create one itself, which means that its jobUUID isnt known until it starts. to get around this, we move
 	public void awaitJobCompletion(JobExecution theJobExecution) throws InterruptedException {
 		await().until(() -> {
+			ourLog.warn("Checking to see if jobExecution {} is finished", theJobExecution.getId());
 			JobExecution jobExecution = myJobExplorer.getJobExecution(theJobExecution.getId());
+			ourLog.warn("That jobExecution currently has status: {}", jobExecution.getStatus());
 			return jobExecution.getStatus() == BatchStatus.COMPLETED;
 		});
 	}


### PR DESCRIPTION
`BulkDataExportSvcImplR4Test.testWithoutSpecificResources` is intermittently failing. This is because in spring batch we end up creating 145 partitions in this job, (as that is the count of resource types in the system). On particularly slow systems, processing all of these, including spring batch overhead, causes it to exceed the 10s default awaitility timeout. This patch increases the timeout so slow machines don't have these intermittents. 