### PR TITLE
EMPI Storage interceptor bug fix

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/dao/expunge/ExpungeEverythingService.java
@@ -196,7 +196,6 @@ public class ExpungeEverythingService {
 
 			ourLog.info("Have deleted {} entities of type {} in {}", outcome, theEntityType.getSimpleName(), sw.toString());
 		}
-
 		return outcome;
 	}
 
@@ -206,5 +205,4 @@ public class ExpungeEverythingService {
 		ourLog.debug("SqlQuery affected {} rows in {}: {}", outcome, sw.toString(), theQuery);
 		return outcome;
 	}
-
 }

--- a/hapi-fhir-jpaserver-empi/src/main/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptor.java
+++ b/hapi-fhir-jpaserver-empi/src/main/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptor.java
@@ -78,6 +78,7 @@ public class EmpiStorageInterceptor implements IEmpiStorageInterceptor {
 
 	@Hook(Pointcut.STORAGE_PRESTORAGE_RESOURCE_UPDATED)
 	public void blockManualPersonManipulationOnUpdate(IBaseResource theOldResource, IBaseResource theNewResource, RequestDetails theRequestDetails, ServletRequestDetails theServletRequestDetails) {
+
 		//If running in single EID mode, forbid multiple eids.
 		if (myEmpiSettings.isPreventMultipleEids()) {
 			forbidIfHasMultipleEids(theNewResource);
@@ -94,6 +95,7 @@ public class EmpiStorageInterceptor implements IEmpiStorageInterceptor {
 		}
 		forbidIfEmpiManagedTagIsPresent(theOldResource);
 		forbidModifyingEmpiTag(theNewResource, theOldResource);
+
 		if (myEmpiSettings.isPreventEidUpdates()) {
 			forbidIfModifyingExternalEidOnTarget(theNewResource, theOldResource);
 		}
@@ -110,6 +112,10 @@ public class EmpiStorageInterceptor implements IEmpiStorageInterceptor {
 	private void forbidIfModifyingExternalEidOnTarget(IBaseResource theNewResource, IBaseResource theOldResource) {
 		List<CanonicalEID> newExternalEids = myEIDHelper.getExternalEid(theNewResource);
 		List<CanonicalEID> oldExternalEids = myEIDHelper.getExternalEid(theOldResource);
+		if (oldExternalEids.isEmpty()) {
+			return;
+		}
+
 		if (!myEIDHelper.eidMatchExists(newExternalEids, oldExternalEids)) {
 			throwBlockEidChange();
 		}
@@ -143,7 +149,6 @@ public class EmpiStorageInterceptor implements IEmpiStorageInterceptor {
 	private boolean isInternalRequest(RequestDetails theRequestDetails) {
 		return theRequestDetails == null;
 	}
-
 
 	private void forbidIfEmpiManagedTagIsPresent(IBaseResource theResource) {
 		if (EmpiUtil.isEmpiManaged(theResource)) {

--- a/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptorIT.java
+++ b/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptorIT.java
@@ -20,6 +20,7 @@ import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Person;
 import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.SearchParameter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -28,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.Date;
 import java.util.List;
 
 import static ca.uhn.fhir.empi.api.EmpiConstants.CODE_HAPI_EMPI_MANAGED;
@@ -237,7 +239,48 @@ public class EmpiStorageInterceptorIT extends BaseEmpiR4Test {
 		}
 
 		setPreventMultipleEids(false);
+	}
 
+	@Test
+	public void testChecksOnlyApplyToRelevantResourceTypes() {
+		setPreventEidUpdates(true);
+		SearchParameter fooSp = new SearchParameter();
+		fooSp.setCode("foo");
+		fooSp.addBase("Bundle");
+		fooSp.setType(Enumerations.SearchParamType.REFERENCE);
+		fooSp.setTitle("FOO SP");
+		fooSp.setExpression("Bundle.entry[0].resource.as(Composition).encounter");
+		fooSp.setXpathUsage(org.hl7.fhir.r4.model.SearchParameter.XPathUsageType.NORMAL);
+		fooSp.setStatus(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
+
+		myEmpiHelper.doCreateResource(fooSp, true);
+
+		fooSp.setXpathUsage(SearchParameter.XPathUsageType.PHONETIC);
+
+		myEmpiHelper.doUpdateResource(fooSp, true);
+	}
+
+	@Test
+	public void testPatientsWithNoEIDCanBeUpdated() throws InterruptedException {
+		setPreventEidUpdates(true);
+		Patient p = new Patient();
+		EmpiHelperR4.OutcomeAndLogMessageWrapper wrapper = myEmpiHelper.createWithLatch(p);
+
+		p.setId(wrapper.getDaoMethodOutcome().getId());
+		p.setBirthDate(new Date());
+		myEmpiHelper.updateWithLatch(p);
+		setPreventEidUpdates(false);
+	}
+
+	@Test
+	public void testPatientsCanHaveEIDAddedInStrictMode() throws InterruptedException {
+		setPreventEidUpdates(true);
+		Patient p = new Patient();
+		EmpiHelperR4.OutcomeAndLogMessageWrapper messageWrapper = myEmpiHelper.createWithLatch(p);
+		p.setId(messageWrapper.getDaoMethodOutcome().getId());
+		addExternalEID(p, "zoop");
+		myEmpiHelper.updateWithLatch(p);
+		setPreventEidUpdates(false);
 	}
 
 	private void setPreventEidUpdates(boolean thePrevent) {

--- a/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptorIT.java
+++ b/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptorIT.java
@@ -278,7 +278,7 @@ public class EmpiStorageInterceptorIT extends BaseEmpiR4Test {
 		Patient p = new Patient();
 		EmpiHelperR4.OutcomeAndLogMessageWrapper messageWrapper = myEmpiHelper.createWithLatch(p);
 		p.setId(messageWrapper.getDaoMethodOutcome().getId());
-		addExternalEID(p, "zoop");
+		addExternalEID(p, "external eid");
 		myEmpiHelper.updateWithLatch(p);
 		setPreventEidUpdates(false);
 	}

--- a/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptorIT.java
+++ b/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/interceptor/EmpiStorageInterceptorIT.java
@@ -242,8 +242,10 @@ public class EmpiStorageInterceptorIT extends BaseEmpiR4Test {
 	}
 
 	@Test
-	public void testChecksOnlyApplyToRelevantResourceTypes() {
+	public void testInterceptorHandlesNonEmpiResources() {
 		setPreventEidUpdates(true);
+
+		//Create some arbitrary resource.
 		SearchParameter fooSp = new SearchParameter();
 		fooSp.setCode("foo");
 		fooSp.addBase("Bundle");
@@ -254,9 +256,7 @@ public class EmpiStorageInterceptorIT extends BaseEmpiR4Test {
 		fooSp.setStatus(org.hl7.fhir.r4.model.Enumerations.PublicationStatus.ACTIVE);
 
 		myEmpiHelper.doCreateResource(fooSp, true);
-
 		fooSp.setXpathUsage(SearchParameter.XPathUsageType.PHONETIC);
-
 		myEmpiHelper.doUpdateResource(fooSp, true);
 	}
 


### PR DESCRIPTION
Currently, two sets of empty EIDs count as though they don't match, where we actually do want them to match. This fixes two bugs: 
1. In Strict EID mode, an EID could not be added to an existing patient. 
2. For any resource being PUT to the server, this PUT fails as the interceptor considers two empty EID sets as being disjoint. 

The fix is to allow addition of an EID if the old resource has none, in strict mode. If the old resource has no EID, simply allow the update. 