### PR TITLE
Add migration for package change

### DIFF
--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/JobNameChangedTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/JobNameChangedTask.java
@@ -1,0 +1,46 @@
+package ca.uhn.fhir.jpa.migrate.taskdef;
+
+/*-
+ * #%L
+ * HAPI FHIR JPA Server - Migration
+ * %%
+ * Copyright (C) 2014 - 2020 University Health Network
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import ca.uhn.fhir.util.VersionEnum;
+
+public class JobNameChangedTask extends BaseColumnCalculatorTask{
+
+	/**
+	 * Constructor
+	 */
+	public JobNameChangedTask(VersionEnum theRelease, String theVersion) {
+		super(theRelease, theVersion);
+		setDescription("Renames a Job in Quartz Table");
+	}
+
+	@Override
+	protected boolean shouldSkipTask() {
+		return false;
+	}
+
+	public JobNameChangedTask addNameChange(String theOldQualifiedClassName, String theNewQualifiedClassName) {
+		this.setWhereClause(getColumnName() + " = '" + theOldQualifiedClassName + "'");
+		this.addCalculator(this.getColumnName(), t -> theNewQualifiedClassName);
+		return this;
+	}
+
+}

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/tasks/HapiFhirJpaMigrationTasks.java
@@ -25,6 +25,7 @@ import ca.uhn.fhir.jpa.migrate.taskdef.ArbitrarySqlTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateHashesTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.CalculateOrdinalDatesTask;
 import ca.uhn.fhir.jpa.migrate.taskdef.ColumnTypeEnum;
+import ca.uhn.fhir.jpa.migrate.taskdef.JobNameChangedTask;
 import ca.uhn.fhir.jpa.migrate.tasks.api.BaseMigrationTasks;
 import ca.uhn.fhir.jpa.migrate.tasks.api.Builder;
 import ca.uhn.fhir.jpa.model.config.PartitionSettings;
@@ -126,6 +127,40 @@ public class HapiFhirJpaMigrationTasks extends BaseMigrationTasks<VersionEnum> {
 		Builder.BuilderWithTableName pkgVerMod = version.onTable("NPM_PACKAGE_VER");
 		pkgVerMod.modifyColumn("20200629.1", "PKG_DESC").nullable().withType(ColumnTypeEnum.STRING, 200);
 		pkgVerMod.modifyColumn("20200629.2", "DESC_UPPER").nullable().withType(ColumnTypeEnum.STRING, 200);
+
+
+		//Moving of BulkExport Job package.
+		String oldBulkJobFqcn ="ca.uhn.fhir.jpa.bulk.BulkDataExportSvcImpl";
+		String oldBulkJobFqcnInnerClass = oldBulkJobFqcn + "$Job";
+		String newBulkJobFqcn = "ca.uhn.fhir.jpa.bulk.svc.BulkDataExportSvcImpl$Job";
+		String newBulkJobFqcnInnerClass= newBulkJobFqcn + "$Job";
+
+		Builder.BuilderWithTableName qrtzJobDetail = version.onTable("QRTZ_JOB_DETAILS");
+		qrtzJobDetail.addTask(new JobNameChangedTask(VersionEnum.V5_1_0, "20200713.1")
+			.addNameChange(oldBulkJobFqcn, newBulkJobFqcn)
+			.setColumnName("JOB_NAME")
+		);
+		qrtzJobDetail.addTask(new JobNameChangedTask(VersionEnum.V5_1_0, "20200713.2")
+			.addNameChange(oldBulkJobFqcnInnerClass, newBulkJobFqcnInnerClass)
+			.setColumnName("JOB_CLASS_NAME")
+		);
+
+		Builder.BuilderWithTableName qrtzSimpleTriggers = version.onTable("QRTZ_SIMPLE_TRIGGERS");
+		qrtzSimpleTriggers.addTask(new JobNameChangedTask(VersionEnum.V5_1_0, "20200713.3")
+			.addNameChange(oldBulkJobFqcn, newBulkJobFqcn)
+			.setColumnName("TRIGGER_NAME")
+		);
+
+		Builder.BuilderWithTableName qrtzTriggers= version.onTable("QRTZ_TRIGGERS");
+		qrtzTriggers.addTask(new JobNameChangedTask(VersionEnum.V5_1_0, "20200713.4")
+			.addNameChange(oldBulkJobFqcn, newBulkJobFqcn)
+			.setColumnName("TRIGGER_NAME")
+		);
+
+		qrtzTriggers.addTask(new JobNameChangedTask(VersionEnum.V5_1_0, "20200713.5")
+			.addNameChange(oldBulkJobFqcn, newBulkJobFqcn)
+			.setColumnName("JOB_NAME")
+		);
 	}
 
 	protected void init510_20200610() {


### PR DESCRIPTION
Bulk Export package change caused an error in migration in Quartz. Quartz maintains class names of its jobs in persisted form, so when a job changes packages, it is necessary to migrate any data to reflect this new package. This results in 3 tables being modified: 
* `QRTZ_JOB_DETAILS`
* `QRTZ_SIMPLE_TRIGGERS`
* `QRTZ_TRIGGERS`

Which each reference that fully qualified class name in some way. 