### PR TITLE
Replace deprecated gradle dependency example in docs

### DIFF
--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/android/client.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/android/client.md
@@ -16,8 +16,8 @@ To add the HAPI library via Gradle, you should add the [hapi-fhir-android](https
 
 ```groovy
 dependencies {
-    compile "ca.uhn.hapi.fhir:hapi-fhir-android:3.1.0-SNAPSHOT"
-    compile "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:3.1.0-SNAPSHOT"
+    implementation "ca.uhn.hapi.fhir:hapi-fhir-android:3.1.0-SNAPSHOT"
+    implementation "ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:3.1.0-SNAPSHOT"
 }
 ```
 

--- a/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/introduction/downloading_and_importing.md
+++ b/hapi-fhir-docs/src/main/resources/ca/uhn/hapi/fhir/docs/introduction/downloading_and_importing.md
@@ -48,9 +48,9 @@ Note that if you wish to perform validation, you may also want to include the "v
 If you are using Gradle, you may use the following dependencies. Note that if you are doing Android development, you may want to use our [Android build](/docs/android/client.html) instead.
 
 ```groovy
-compile 'ca.uhn.hapi.fhir:hapi-fhir-base:${project.version}'
-compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:${project.version}'
-compile 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:${project.version}'
+implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:${project.version}'
+implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-dstu2:${project.version}'
+implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:${project.version}'
 ```
 
 <a name="snapshot"/>


### PR DESCRIPTION
Minimal change to the documentation, replacing the gradle examples usage of compile with implementation.

> The usage of the compile and runtime configurations in the Java ecosystem plugins has been discouraged since Gradle 3.4.
https://docs.gradle.org/current/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations