### PR TITLE
Add test, fix code to handle empty candidate search param test

### DIFF
--- a/hapi-fhir-jpaserver-empi/src/main/java/ca/uhn/fhir/jpa/empi/svc/EmpiResourceFilteringSvc.java
+++ b/hapi-fhir-jpaserver-empi/src/main/java/ca/uhn/fhir/jpa/empi/svc/EmpiResourceFilteringSvc.java
@@ -58,13 +58,18 @@ public class EmpiResourceFilteringSvc {
 		String resourceType = myFhirContext.getResourceType(theResource);
 		List<EmpiResourceSearchParamJson> candidateSearchParams = empiSettings.getEmpiRules().getCandidateSearchParams();
 
-		boolean containsValueForSomeSearchParam = candidateSearchParams.stream()
-			.filter(csp -> myEmpiSearchParamSvc.searchParamTypeIsValidForResourceType(csp.getResourceType(), resourceType))
-			.flatMap(csp -> csp.getSearchParams().stream())
-			.map(searchParam -> myEmpiSearchParamSvc.getValueFromResourceForSearchParam(theResource, searchParam))
-			.anyMatch(valueList -> !valueList.isEmpty());
 
-		ourLog.debug("Is {} suitable for EMPI processing? : {}", theResource.getId(), containsValueForSomeSearchParam);
-		return containsValueForSomeSearchParam;
+		if (candidateSearchParams.isEmpty()) {
+			ourLog.debug("As there are no Candidate Search parameters, {} is suitable for processing.", theResource.getId());;
+			return true;
+		} else {
+			boolean containsValueForSomeSearchParam = candidateSearchParams.stream()
+				.filter(csp -> myEmpiSearchParamSvc.searchParamTypeIsValidForResourceType(csp.getResourceType(), resourceType))
+				.flatMap(csp -> csp.getSearchParams().stream())
+				.map(searchParam -> myEmpiSearchParamSvc.getValueFromResourceForSearchParam(theResource, searchParam))
+				.anyMatch(valueList -> !valueList.isEmpty());
+			ourLog.debug("Is {} suitable for EMPI processing? : {}", theResource.getId(), containsValueForSomeSearchParam);
+			return containsValueForSomeSearchParam;
+		}
 	}
 }

--- a/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/svc/EmpiResourceFilteringSvcTest.java
+++ b/hapi-fhir-jpaserver-empi/src/test/java/ca/uhn/fhir/jpa/empi/svc/EmpiResourceFilteringSvcTest.java
@@ -1,16 +1,20 @@
 package ca.uhn.fhir.jpa.empi.svc;
 
+import ca.uhn.fhir.empi.rules.config.EmpiSettings;
 import ca.uhn.fhir.jpa.empi.BaseEmpiR4Test;
 import org.hl7.fhir.r4.model.BooleanType;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.io.IOException;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 class EmpiResourceFilteringSvcTest extends BaseEmpiR4Test {
+
 
 	@Autowired
 	private EmpiResourceFilteringSvc myEmpiResourceFilteringSvc;
@@ -35,5 +39,31 @@ class EmpiResourceFilteringSvcTest extends BaseEmpiR4Test {
 		boolean shouldBeProcessed = myEmpiResourceFilteringSvc.shouldBeProcessed(patient);
 
 		assertThat(shouldBeProcessed, is(equalTo(true)));
+	}
+
+	@Test
+	public void testEmptyCandidateSearchParamsIsValid() throws IOException {
+		String emptyCandidateRules = "{\n" +
+			"\t\"version\": \"1\",\n" +
+			"\t\"candidateSearchParams\" : [],\n" +
+			"\t\"candidateFilterSearchParams\" : [{\n" +
+			"\t\t\"resourceType\" : \"Patient\",\n" +
+			"\t\t\"searchParam\" : \"name\"\n" +
+			"\t}],\n" +
+			"\t\"matchFields\" : [],\n" +
+			"\t\"matchResultMap\" : {}\n" +
+			"}\n";
+		//Here we hack in an empty candidate search param attribute
+		String originalText = ((EmpiSettings) myEmpiConfig).getScriptText();
+		((EmpiSettings) myEmpiConfig).setScriptText(emptyCandidateRules);
+
+
+		Patient patient = new Patient();
+		boolean shouldBeProcessed = myEmpiResourceFilteringSvc.shouldBeProcessed(patient);
+
+		assertThat(shouldBeProcessed, is(equalTo(true)));
+		
+		((EmpiSettings) myEmpiConfig).setScriptText(originalText);
+
 	}
 }


### PR DESCRIPTION
A use case was omitted from the original implementation of the filtering service, specifically when candidateSearchParams was empty. 

