### PR TITLE
Exposing hasIncludes on PersistedJpaBundleProvider

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/search/PersistedJpaBundleProvider.java
@@ -355,6 +355,11 @@ public class PersistedJpaBundleProvider implements IBundleProvider {
 
 	}
 
+	protected boolean hasIncludes() {
+		ensureSearchEntityLoaded();
+		return !mySearchEntity.getIncludes().isEmpty();
+	}
+
 	// Note: Leave as protected, HSPC depends on this
 	@SuppressWarnings("WeakerAccess")
 	protected List<IBaseResource> toResourceList(ISearchBuilder theSearchBuilder, List<ResourcePersistentId> thePids) {


### PR DESCRIPTION
I have an extended implementation of PersistedJpaBundleProvider and I need to know whether the search contains includes or not.