### PR TITLE
Fix mssql drop index and table migrations

### DIFF
--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
@@ -60,6 +60,14 @@ public abstract class BaseTask {
 		mySchemaVersion = theSchemaVersion;
 	}
 
+	public String getMyProductVersion() {
+		return myProductVersion;
+	}
+
+	public String getMySchemaVersion() {
+		return mySchemaVersion;
+	}
+
 	public boolean isNoColumnShrink() {
 		return myNoColumnShrink;
 	}
@@ -137,16 +145,18 @@ public abstract class BaseTask {
 		return myConnectionProperties;
 	}
 
-	public void setConnectionProperties(DriverTypeEnum.ConnectionProperties theConnectionProperties) {
+	public BaseTask setConnectionProperties(DriverTypeEnum.ConnectionProperties theConnectionProperties) {
 		myConnectionProperties = theConnectionProperties;
+		return this;
 	}
 
 	public DriverTypeEnum getDriverType() {
 		return myDriverType;
 	}
 
-	public void setDriverType(DriverTypeEnum theDriverType) {
+	public BaseTask setDriverType(DriverTypeEnum theDriverType) {
 		myDriverType = theDriverType;
+		return this;
 	}
 
 	public abstract void validate();

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/BaseTask.java
@@ -60,11 +60,11 @@ public abstract class BaseTask {
 		mySchemaVersion = theSchemaVersion;
 	}
 
-	public String getMyProductVersion() {
+	public String getProductVersion() {
 		return myProductVersion;
 	}
 
-	public String getMySchemaVersion() {
+	public String getSchemaVersion() {
 		return mySchemaVersion;
 	}
 

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropIndexTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropIndexTask.java
@@ -86,8 +86,12 @@ public class DropIndexTask extends BaseTableTask {
 			@Language("SQL") String findConstraintSql = "SELECT DISTINCT constraint_name FROM user_cons_columns WHERE constraint_name = ? AND table_name = ?";
 			@Language("SQL") String dropConstraintSql = "ALTER TABLE " + getTableName() + " DROP CONSTRAINT ?";
 			findAndDropConstraint(findConstraintSql, dropConstraintSql);
-
 			findConstraintSql = "SELECT DISTINCT constraint_name FROM all_constraints WHERE index_name = ? AND table_name = ?";
+			findAndDropConstraint(findConstraintSql, dropConstraintSql);
+		} else if (getDriverType() == DriverTypeEnum.MSSQL_2012) {
+			// Legacy deletion for SQL Server unique indexes
+			@Language("SQL") String findConstraintSql = "SELECT tc.CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS tc WHERE tc.CONSTRAINT_NAME = ? AND tc.TABLE_NAME = ?";
+			@Language("SQL") String dropConstraintSql = "ALTER TABLE " + getTableName() + " DROP CONSTRAINT ?";
 			findAndDropConstraint(findConstraintSql, dropConstraintSql);
 		}
 

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropTableTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropTableTask.java
@@ -63,14 +63,15 @@ public class DropTableTask extends BaseTableTask {
 			}
 		}
 
+		DropIndexTask theIndexTask = new DropIndexTask(getMyProductVersion(), getMySchemaVersion());
+		theIndexTask
+			.setTableName(getTableName())
+			.setConnectionProperties(getConnectionProperties())
+			.setDriverType(getDriverType());
 		for (String nextIndex : indexNames) {
-			List<String> sqls = DropIndexTask.createDropIndexSql(getConnectionProperties(), getTableName(), nextIndex, getDriverType());
-			if (!sqls.isEmpty()) {
-				logInfo(ourLog, "Dropping index {} on table {} in preparation for table delete", nextIndex, getTableName());
-			}
-			for (@Language("SQL") String sql : sqls) {
-				executeSql(getTableName(), sql);
-			}
+			theIndexTask
+				.setIndexName(nextIndex)
+				.execute();
 		}
 
 		logInfo(ourLog, "Dropping table: {}", getTableName());

--- a/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropTableTask.java
+++ b/hapi-fhir-jpaserver-migrate/src/main/java/ca/uhn/fhir/jpa/migrate/taskdef/DropTableTask.java
@@ -63,7 +63,7 @@ public class DropTableTask extends BaseTableTask {
 			}
 		}
 
-		DropIndexTask theIndexTask = new DropIndexTask(getMyProductVersion(), getMySchemaVersion());
+		DropIndexTask theIndexTask = new DropIndexTask(getProductVersion(), getSchemaVersion());
 		theIndexTask
 			.setTableName(getTableName())
 			.setConnectionProperties(getConnectionProperties())


### PR DESCRIPTION
My idea with the `DropTableTask` change is to `execute` the `DropIndexTask` rather than just generating the sql and running it from `DropTableTask`. This change works, but I'm rather new to best practices so I might be doing something silly :-)