### PR TITLE
Rename accessors, fix whitespace

### DIFF
--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/HapiMessageHeaders.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/HapiMessageHeaders.java
@@ -87,7 +87,7 @@ public class HapiMessageHeaders implements IModelJson {
 	}
 
 	public MessageHeaders toMessageHeaders() {
-		 Map<String, Object> returnedHeaders = new HashMap<>(this.headers);
+		Map<String, Object> returnedHeaders = new HashMap<>(this.headers);
 		returnedHeaders.put(RETRY_COUNT_KEY, myRetryCount);
 		returnedHeaders.put(FIRST_FAILURE_KEY, myFirstFailureTimestamp);
 		returnedHeaders.put(LAST_FAILURE_KEY, myLastFailureTimestamp);

--- a/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/HapiMessageHeaders.java
+++ b/hapi-fhir-server/src/main/java/ca/uhn/fhir/rest/server/messaging/json/HapiMessageHeaders.java
@@ -10,7 +10,7 @@ package ca.uhn.fhir.rest.server.messaging.json;
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *	  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -34,62 +34,64 @@ import java.util.Map;
  * they can also be accessed in standard map fashion with a `get` on the map.
  */
 public class HapiMessageHeaders implements IModelJson {
-    public static final String RETRY_COUNT_KEY = "retryCount";
-    public static final String FIRST_FAILURE_KEY = "firstFailureTimestamp";
-    public static final String LAST_FAILURE_KEY = "lastFailureTimestamp";
+	public static final String RETRY_COUNT_KEY = "retryCount";
+	public static final String FIRST_FAILURE_KEY = "firstFailureTimestamp";
+	public static final String LAST_FAILURE_KEY = "lastFailureTimestamp";
 
-    @JsonProperty(RETRY_COUNT_KEY)
-    private Integer myRetryCount = 0;
-    @JsonProperty(FIRST_FAILURE_KEY)
-    private Long myFirstFailureTimestamp;
-    @JsonProperty(LAST_FAILURE_KEY)
-    private Long myLastFailureTimestamp;
+	@JsonProperty(RETRY_COUNT_KEY)
+	private Integer myRetryCount = 0;
+	@JsonProperty(FIRST_FAILURE_KEY)
+	private Long myFirstFailureTimestamp;
+	@JsonProperty(LAST_FAILURE_KEY)
+	private Long myLastFailureTimestamp;
 
-    @JsonProperty("customHeaders")
-    private final Map<String, Object> headers;
+	@JsonProperty("customHeaders")
+	private final Map<String, Object> headers;
 
-    public HapiMessageHeaders(Map<String, Object> theHeaders) {
-        headers = theHeaders;
-    }
+	public HapiMessageHeaders(Map<String, Object> theHeaders) {
+		headers = theHeaders;
+	}
 
-    public HapiMessageHeaders() {
-        headers = new HashMap<>();
-    }
+	public HapiMessageHeaders() {
+		headers = new HashMap<>();
+	}
 
-    public Integer getRetryCount() {
-    	return this.myRetryCount;
-    }
+	public Integer getRetryCount() {
+		return this.myRetryCount;
+	}
 
-    public Long getFirstFailureDate() {
-    	return this.myFirstFailureTimestamp;
-    }
+	public Long getFirstFailureTimestamp() {
+		return this.myFirstFailureTimestamp;
+	}
 
-    public Long getLastFailureDate() {
-    	return this.myLastFailureTimestamp;
-    }
+	public Long getLastFailureTimestamp() {
+		return this.myLastFailureTimestamp;
+	}
 
-    public void setRetryCount(Integer theRetryCount) {
-    	this.myRetryCount = theRetryCount;
-	 }
+	public void setRetryCount(Integer theRetryCount) {
+		this.myRetryCount = theRetryCount;
+	}
 
-    public void setLastFailureDate(Long theLastFailureDate) {
-    	this.myLastFailureTimestamp = theLastFailureDate;
-	 }
+	public void setLastFailureTimestamp(Long theLastFailureTimestamp) {
+		this.myLastFailureTimestamp = theLastFailureTimestamp;
+	}
 
-	 public void setFirstFailureDate(Long theFirstFailureDate) {
-    	this.myFirstFailureTimestamp = theFirstFailureDate;
-	 }
 
-    public Map<String, Object> getCustomHeaders() {
-        return this.headers;
-    }
+	public void setFirstFailureTimestamp(Long theFirstFailureTimestamp) {
+		this.myFirstFailureTimestamp = theFirstFailureTimestamp;
+	}
 
-    public MessageHeaders toMessageHeaders() {
+
+	public Map<String, Object> getCustomHeaders() {
+		return this.headers;
+	}
+
+	public MessageHeaders toMessageHeaders() {
 		 Map<String, Object> returnedHeaders = new HashMap<>(this.headers);
-    	returnedHeaders.put(RETRY_COUNT_KEY, myRetryCount);
-	 	returnedHeaders.put(FIRST_FAILURE_KEY, myFirstFailureTimestamp);
-	 	returnedHeaders.put(LAST_FAILURE_KEY, myLastFailureTimestamp);
-	 	return new MessageHeaders(returnedHeaders);
-	 }
+		returnedHeaders.put(RETRY_COUNT_KEY, myRetryCount);
+		returnedHeaders.put(FIRST_FAILURE_KEY, myFirstFailureTimestamp);
+		returnedHeaders.put(LAST_FAILURE_KEY, myLastFailureTimestamp);
+		return new MessageHeaders(returnedHeaders);
+	}
 
 }

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/messaging/BaseResourceModifiedMessageTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/messaging/BaseResourceModifiedMessageTest.java
@@ -23,8 +23,8 @@ class ResourceOperationMessageTest {
 		jsonMessage = mapper.readValue(serialized, ResourceOperationJsonMessage.class);
 
 		assertThat(jsonMessage.getHapiHeaders().getRetryCount(), is(equalTo(0)));
-		assertThat(jsonMessage.getHapiHeaders().getFirstFailureDate(), is(equalTo(null)));
-		assertThat(jsonMessage.getHapiHeaders().getLastFailureDate(), is(equalTo(null)));
+		assertThat(jsonMessage.getHapiHeaders().getFirstFailureTimestamp(), is(equalTo(null)));
+		assertThat(jsonMessage.getHapiHeaders().getLastFailureTimestamp(), is(equalTo(null)));
 
 		assertThat(jsonMessage.getHeaders().get(RETRY_COUNT_KEY), is(equalTo(0)));
 		assertThat(jsonMessage.getHeaders().get(FIRST_FAILURE_KEY), is(equalTo(null)));


### PR DESCRIPTION
Minor changes to accessor name to reflect data type. 