### PR TITLE
xml:lang attribute prefix gets removed during serialization

### DIFF
--- a/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java
+++ b/hapi-fhir-base/src/main/java/ca/uhn/fhir/parser/XmlParser.java
@@ -705,12 +705,6 @@ public class XmlParser extends BaseParser {
 							theEventWriter.writeStartElement(prefix, se.getName().getLocalPart(), namespaceURI);
 							theEventWriter.writeNamespace(prefix, namespaceURI);
 						}
-//						for (Iterator<Attribute> iter= se.getAttributes(); iter.hasNext(); ) {
-//							Attribute next = iter.next();
-//							if ("lang".equals(next.getName().getLocalPart())) {
-//								theEventWriter.writeAttribute("", "", next.getName().getLocalPart(), next.getValue());
-//							}
-//						}
 						firstElement = false;
 					} else {
 						if (isBlank(se.getName().getPrefix())) {
@@ -730,7 +724,11 @@ public class XmlParser extends BaseParser {
 					}
 					for (Iterator<?> attrIter = se.getAttributes(); attrIter.hasNext(); ) {
 						Attribute next = (Attribute) attrIter.next();
-						theEventWriter.writeAttribute(next.getName().getLocalPart(), next.getValue());
+						if (isBlank(next.getName().getNamespaceURI())) {
+							theEventWriter.writeAttribute(next.getName().getLocalPart(), next.getValue());
+						} else {
+							theEventWriter.writeAttribute(next.getName().getPrefix(), next.getName().getNamespaceURI(), next.getName().getLocalPart(), next.getValue());
+						}
 					}
 					break;
 				case XMLStreamConstants.DTD:

--- a/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/XmlParserR4Test.java
+++ b/hapi-fhir-structures-r4/src/test/java/ca/uhn/fhir/parser/XmlParserR4Test.java
@@ -1,14 +1,14 @@
 package ca.uhn.fhir.parser;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
 
-import ca.uhn.fhir.test.BaseTest;
+import java.io.IOException;
+import java.net.URL;
 
-import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.AuditEvent;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Composition;
@@ -16,17 +16,17 @@ import org.hl7.fhir.r4.model.DocumentReference;
 import org.hl7.fhir.r4.model.MessageHeader;
 import org.hl7.fhir.r4.model.Narrative;
 import org.hl7.fhir.r4.model.Observation;
+import org.hl7.fhir.r4.model.Parameters;
 import org.hl7.fhir.r4.model.Patient;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import ca.uhn.fhir.context.FhirContext;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 
-import java.io.IOException;
-import java.net.URL;
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.test.BaseTest;
 
 public class XmlParserR4Test extends BaseTest {
 	private static final Logger ourLog = LoggerFactory.getLogger(XmlParserR4Test.class);
@@ -151,6 +151,31 @@ public class XmlParserR4Test extends BaseTest {
 		AuditEvent ae = ourCtx.newXmlParser().parseResource(AuditEvent.class, auditEvent);
 		String auditEventAsString = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(ae);
 		assertEquals(auditEvent, auditEventAsString);
+	}
+	
+	/**
+	 * Ensure that a xml:lang attribute is de- and reserialized correctly
+	 */
+	@Test
+	public void testDivXhtmlLangAttribute() {
+		String parameters = "<Parameters xmlns=\"http://hl7.org/fhir\">\n" + 
+				"   <parameter>\n" + 
+				"      <name value=\"resource\"/>\n" + 
+				"      <resource>\n" + 
+				"         <Patient xmlns=\"http://hl7.org/fhir\">\n" + 
+				"            <id value=\"example\"/>\n" + 
+				"            <language value=\"de\"/>\n" + 
+				"            <text>\n" + 
+				"               <status value=\"generated\"/>\n" + 
+				"               <div xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"de\" lang=\"de\">42 </div>\n" + 
+				"            </text>\n" + 
+				"         </Patient>\n" + 
+				"      </resource>\n" + 
+				"   </parameter>\n" + 
+				"</Parameters>";
+		Parameters pa = ourCtx.newXmlParser().parseResource(Parameters.class, parameters);
+		String parameteresAsString = ourCtx.newXmlParser().setPrettyPrint(true).encodeResourceToString(pa);
+		assertEquals(parameters, parameteresAsString);
 	}
 
 


### PR DESCRIPTION
See also issue https://github.com/jamesagnew/hapi-fhir/issues/2111

When defining the language for the div element the lang attribute to be specified with lang and xml:lang for xhtml [reference](https://www.w3.org/International/questions/qa-html-language-declarations#basics) e.g.:

```xml
<div lang="fr" xml:lang="fr" xmlns="http://www.w3.org/1999/xhtml">
```
During serialization to xml or json the xml prefix is removed from the xml:lang attribute and we have two lang="fr" attributes which is invalid.

This PR changes the xml serialization in Xml (since its xhtml it is also used during the json serialization). A testcase is provided to check that serialization and deserialization are consistent.

