### PR TITLE
BaseClient: make invokeClient available for derived classes

### DIFF
--- a/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
+++ b/hapi-fhir-client/src/main/java/ca/uhn/fhir/rest/client/impl/BaseClient.java
@@ -211,15 +211,15 @@ public abstract class BaseClient implements IRestfulClient {
 		myRequestFormatParamStyle = theRequestFormatParamStyle;
 	}
 
-	<T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation) {
+	protected <T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation) {
 		return invokeClient(theContext, binding, clientInvocation, false);
 	}
 
-	<T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation, boolean theLogRequestAndResponse) {
+	protected <T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation, boolean theLogRequestAndResponse) {
 		return invokeClient(theContext, binding, clientInvocation, null, null, theLogRequestAndResponse, null, null, null, null, null);
 	}
 
-	<T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation, EncodingEnum theEncoding, Boolean thePrettyPrint,
+	protected <T> T invokeClient(FhirContext theContext, IClientResponseHandler<T> binding, BaseHttpClientInvocation clientInvocation, EncodingEnum theEncoding, Boolean thePrettyPrint,
 							 boolean theLogRequestAndResponse, SummaryEnum theSummaryMode, Set<String> theSubsetElements, CacheControlDirective theCacheControlDirective, String theCustomAcceptHeader,
 							 Map<String, List<String>> theCustomHeaders) {
 


### PR DESCRIPTION
I'm working on a Validation Client which can execute the $validate operation with a direct POST (see http://hl7.org/fhir/resource-operation-validate.html#examples).This is not directly possible with the existing GenericClient and I would like to base the Validation Client on the Generic Client because all functionality is already implemented. The only piece missing is, that I cannot access the invoke function from the derived class, I need to do:

```java
    MethodOutcome resp = invokeClient(getFhirContext(), binding, clientInvoke, null, null, false, null, null, null, null, theExtraParams);
```
This PR changes the visibility of the invokeClient function to protected so that I can access it from a derived class which is not in the same package.

 