### PR TITLE
add CorsInterceptorTest

### DIFF
--- a/hapi-fhir-server/pom.xml
+++ b/hapi-fhir-server/pom.xml
@@ -78,6 +78,12 @@
 			<artifactId>spring-messaging</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/CorsInterceptorTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/CorsInterceptorTest.java
@@ -17,6 +17,14 @@ public class CorsInterceptorTest {
 		CorsConfiguration corsConfiguration = new CorsConfiguration();
 		corsConfiguration.applyPermitDefaultValues();
 		corsConfiguration.setAllowedMethods(Arrays.asList(new String[] { "*" }));
+		corsConfiguration.setExposedHeaders(Arrays.asList(new String[] {
+			"Content-Location",
+			"Date",
+			"ETag",
+			"Location",
+			"X-Request-Id",
+			"X-Correlation-Id"
+		}));
 		CorsInterceptor corsInterceptor = new CorsInterceptor(corsConfiguration);
 
 System.err.println("Custom CorsConfiguration");
@@ -24,7 +32,7 @@ System.err.println("allowCredentials = " + corsConfiguration.getAllowCredentials
 System.err.println("allowedHeaders = " + Arrays.toString(corsConfiguration.getAllowedHeaders().toArray()));
 System.err.println("allowedMethods = " + Arrays.toString(corsConfiguration.getAllowedMethods().toArray()));
 System.err.println("allowedOrigins = " + Arrays.toString(corsConfiguration.getAllowedOrigins().toArray()));
-System.err.println("exposedHeaders = " + corsConfiguration.getExposedHeaders());
+System.err.println("exposedHeaders = " + Arrays.toString(corsConfiguration.getExposedHeaders().toArray()));
 System.err.println("maxAge = " + corsConfiguration.getMaxAge());
 
 		assertSame(corsConfiguration, corsInterceptor.getConfig());
@@ -32,7 +40,7 @@ System.err.println("maxAge = " + corsConfiguration.getMaxAge());
 		assertNotNull(corsConfiguration.getAllowedHeaders());
 		assertNotNull(corsConfiguration.getAllowedMethods());
 		assertNotNull(corsConfiguration.getAllowedOrigins());
-		assertNull(corsConfiguration.getExposedHeaders());
+		assertNotNull(corsConfiguration.getExposedHeaders());
 		assertEquals(Long.valueOf(1800l),corsConfiguration.getMaxAge());
 		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Content-Type"})));
 		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Authorization"})));

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/CorsInterceptorTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/CorsInterceptorTest.java
@@ -7,10 +7,14 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 
 public class CorsInterceptorTest {
+
+	private static final Logger ourLog = LoggerFactory.getLogger(CorsInterceptorTest.class);
 
 	@Test
 	public void testCustomCorsConfig() {
@@ -27,14 +31,6 @@ public class CorsInterceptorTest {
 		}));
 		CorsInterceptor corsInterceptor = new CorsInterceptor(corsConfiguration);
 
-System.err.println("Custom CorsConfiguration");
-System.err.println("allowCredentials = " + corsConfiguration.getAllowCredentials());
-System.err.println("allowedHeaders = " + Arrays.toString(corsConfiguration.getAllowedHeaders().toArray()));
-System.err.println("allowedMethods = " + Arrays.toString(corsConfiguration.getAllowedMethods().toArray()));
-System.err.println("allowedOrigins = " + Arrays.toString(corsConfiguration.getAllowedOrigins().toArray()));
-System.err.println("exposedHeaders = " + Arrays.toString(corsConfiguration.getExposedHeaders().toArray()));
-System.err.println("maxAge = " + corsConfiguration.getMaxAge());
-
 		assertSame(corsConfiguration, corsInterceptor.getConfig());
 		assertNull(corsConfiguration.getAllowCredentials());
 		assertNotNull(corsConfiguration.getAllowedHeaders());
@@ -47,20 +43,21 @@ System.err.println("maxAge = " + corsConfiguration.getMaxAge());
 		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Authorization", "Content-Type"})));
 		assertNotNull(corsConfiguration.checkHttpMethod(HttpMethod.GET));
 		assertNotNull(corsConfiguration.checkOrigin("http://clinfhir.com"));
+
+		ourLog.info("Custom CorsConfiguration:  allowCredentials = {};  allowedHeaders = {};  " +
+			"allowedMethods = {};  allowedOrigins = {};  exposedHeaders = {};  maxAge = {}",
+			corsConfiguration.getAllowCredentials(),
+			Arrays.toString(corsConfiguration.getAllowedHeaders().toArray()),
+			Arrays.toString(corsConfiguration.getAllowedMethods().toArray()),
+			Arrays.toString(corsConfiguration.getAllowedOrigins().toArray()),
+			Arrays.toString(corsConfiguration.getExposedHeaders().toArray()),
+			corsConfiguration.getMaxAge());
 	}
 
 	@Test
 	public void testDefaultCorsConfig() {
 		CorsInterceptor corsInterceptor = new CorsInterceptor();
 		CorsConfiguration corsConfiguration = corsInterceptor.getConfig();
-
-System.err.println("Default CorsConfiguration");
-System.err.println("allowCredentials = " + corsConfiguration.getAllowCredentials());
-System.err.println("allowedHeaders = " + Arrays.toString(corsConfiguration.getAllowedHeaders().toArray()));
-System.err.println("allowedMethods = " + Arrays.toString(corsConfiguration.getAllowedMethods().toArray()));
-System.err.println("allowedOrigins = " + Arrays.toString(corsConfiguration.getAllowedOrigins().toArray()));
-System.err.println("exposedHeaders = " + Arrays.toString(corsConfiguration.getExposedHeaders().toArray()));
-System.err.println("maxAge = " + corsConfiguration.getMaxAge());
 
 		assertNull(corsConfiguration.getAllowCredentials());
 		assertNotNull(corsConfiguration.getAllowedHeaders());
@@ -73,5 +70,14 @@ System.err.println("maxAge = " + corsConfiguration.getMaxAge());
 		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Authorization", "Content-Type"})));
 		assertNotNull(corsConfiguration.checkHttpMethod(HttpMethod.GET));
 		assertNotNull(corsConfiguration.checkOrigin("http://clinfhir.com"));
+
+		ourLog.info("Default CorsConfiguration:  allowCredentials = {};  allowedHeaders = {};  " +
+			"allowedMethods = {};  allowedOrigins = {};  exposedHeaders = {};  maxAge = {}",
+			corsConfiguration.getAllowCredentials(),
+			Arrays.toString(corsConfiguration.getAllowedHeaders().toArray()),
+			Arrays.toString(corsConfiguration.getAllowedMethods().toArray()),
+			Arrays.toString(corsConfiguration.getAllowedOrigins().toArray()),
+			Arrays.toString(corsConfiguration.getExposedHeaders().toArray()),
+			corsConfiguration.getMaxAge());
 	}
 }

--- a/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/CorsInterceptorTest.java
+++ b/hapi-fhir-server/src/test/java/ca/uhn/fhir/rest/server/interceptor/CorsInterceptorTest.java
@@ -1,0 +1,69 @@
+package ca.uhn.fhir.rest.server.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.cors.CorsConfiguration;
+
+public class CorsInterceptorTest {
+
+	@Test
+	public void testCustomCorsConfig() {
+		CorsConfiguration corsConfiguration = new CorsConfiguration();
+		corsConfiguration.applyPermitDefaultValues();
+		corsConfiguration.setAllowedMethods(Arrays.asList(new String[] { "*" }));
+		CorsInterceptor corsInterceptor = new CorsInterceptor(corsConfiguration);
+
+System.err.println("Custom CorsConfiguration");
+System.err.println("allowCredentials = " + corsConfiguration.getAllowCredentials());
+System.err.println("allowedHeaders = " + Arrays.toString(corsConfiguration.getAllowedHeaders().toArray()));
+System.err.println("allowedMethods = " + Arrays.toString(corsConfiguration.getAllowedMethods().toArray()));
+System.err.println("allowedOrigins = " + Arrays.toString(corsConfiguration.getAllowedOrigins().toArray()));
+System.err.println("exposedHeaders = " + corsConfiguration.getExposedHeaders());
+System.err.println("maxAge = " + corsConfiguration.getMaxAge());
+
+		assertSame(corsConfiguration, corsInterceptor.getConfig());
+		assertNull(corsConfiguration.getAllowCredentials());
+		assertNotNull(corsConfiguration.getAllowedHeaders());
+		assertNotNull(corsConfiguration.getAllowedMethods());
+		assertNotNull(corsConfiguration.getAllowedOrigins());
+		assertNull(corsConfiguration.getExposedHeaders());
+		assertEquals(Long.valueOf(1800l),corsConfiguration.getMaxAge());
+		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Content-Type"})));
+		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Authorization"})));
+		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Authorization", "Content-Type"})));
+		assertNotNull(corsConfiguration.checkHttpMethod(HttpMethod.GET));
+		assertNotNull(corsConfiguration.checkOrigin("http://clinfhir.com"));
+	}
+
+	@Test
+	public void testDefaultCorsConfig() {
+		CorsInterceptor corsInterceptor = new CorsInterceptor();
+		CorsConfiguration corsConfiguration = corsInterceptor.getConfig();
+
+System.err.println("Default CorsConfiguration");
+System.err.println("allowCredentials = " + corsConfiguration.getAllowCredentials());
+System.err.println("allowedHeaders = " + Arrays.toString(corsConfiguration.getAllowedHeaders().toArray()));
+System.err.println("allowedMethods = " + Arrays.toString(corsConfiguration.getAllowedMethods().toArray()));
+System.err.println("allowedOrigins = " + Arrays.toString(corsConfiguration.getAllowedOrigins().toArray()));
+System.err.println("exposedHeaders = " + Arrays.toString(corsConfiguration.getExposedHeaders().toArray()));
+System.err.println("maxAge = " + corsConfiguration.getMaxAge());
+
+		assertNull(corsConfiguration.getAllowCredentials());
+		assertNotNull(corsConfiguration.getAllowedHeaders());
+		assertNotNull(corsConfiguration.getAllowedMethods());
+		assertNotNull(corsConfiguration.getAllowedOrigins());
+		assertNotNull(corsConfiguration.getExposedHeaders());
+		assertNull(corsConfiguration.getMaxAge());
+		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Content-Type"})));
+//		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Authorization"})));
+		assertNotNull(corsConfiguration.checkHeaders(Arrays.asList(new String[] {"Authorization", "Content-Type"})));
+		assertNotNull(corsConfiguration.checkHttpMethod(HttpMethod.GET));
+		assertNotNull(corsConfiguration.checkOrigin("http://clinfhir.com"));
+	}
+}


### PR DESCRIPTION
This pull request is related to a recent clinFHIR enhancement to enable use of an OAuth access token with clinFHIR, as discussed on chat.fhir.org here:

https://chat.fhir.org/#narrow/stream/179176-clinFHIR/topic/OAuth.20access.20token

When using an OAuth access token, clinFHIR adds an "Authorization: Bearer <access_token>" header to its FHIR API requests.  Additionally, it sends a CORS preflight HTTP OPTIONS request.

When testing this using a FHIR server based on hapi-fhir v5.1.0, David Hay and I discovered the server was returning HTTP status 403 (Forbidden) in its response to the CORS preflight OPTIONS request.

To prevent the server from rejecting the CORS preflight OPTIONS request, instead of using the default CorsInterceptor configuration, it was necessary to customize the CorsConfiguration.

In short, this CorsInterceptor doesn't work:
```
       CorsInterceptor corsInterceptor = new CorsInterceptor();
```

But this does:
```
        CorsConfiguration corsConfiguration = new CorsConfiguration();
        corsConfiguration.applyPermitDefaultValues();
        corsConfiguration.setAllowedMethods(Arrays.asList(new String[] { "*" }));
        CorsInterceptor corsInterceptor = new CorsInterceptor(corsConfiguration);
```

This pull request adds a CorsInterceptorTest which may be useful for exploring the CorsConfiguration topic.  (I wasn't sure what modification to the default CorsConfiguration might be most appropriate, but it appears the "Authorization" header is not among the allowedHeaders in the default CorsConfiguration.)