### PR TITLE
Validate theSearchParamRegistry is not null

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/JpaConformanceProviderR4.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/JpaConformanceProviderR4.java
@@ -81,6 +81,7 @@ public class JpaConformanceProviderR4 extends org.hl7.fhir.r4.hapi.rest.server.S
 		Validate.notNull(theRestfulServer);
 		Validate.notNull(theSystemDao);
 		Validate.notNull(theDaoConfig);
+		Validate.notNull(theSearchParamRegistry);
 
 		myRestfulServer = theRestfulServer;
 		mySystemDao = theSystemDao;


### PR DESCRIPTION
in the R4 ConformanceProvider there are validations on `theRestfulServer`, `theSystemDao`, and `theDaoConfig` to be not null but no such validation for `theSearchParamRegistry`. 

However, if you look at [line 128](https://github.com/jamesagnew/hapi-fhir/blob/fd46d0965fafaf2b6cabb169e53ab8b7c464f099/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/provider/r4/JpaConformanceProviderR4.java#L128) it assumes `mySearchParamRegistry` is not null. Passing in a null value will cause a null pointer exception. Since these validations already exist it is easy enough to just add a check for the search param registry too. 

The DSTU2/3 Conformance Providers do not include this argument and the R5 version doesn't validate any of the arguments so I only added the check here.