### PR TITLE
Remove all references to Person from EMPI revisited

### DIFF
--- a/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/broker/MdmQueueConsumerLoader.java
+++ b/hapi-fhir-jpaserver-mdm/src/main/java/ca/uhn/fhir/jpa/mdm/broker/MdmQueueConsumerLoader.java
@@ -52,9 +52,9 @@ public class MdmQueueConsumerLoader {
 		if (myMdmChannel == null) {
 			ChannelConsumerSettings config = new ChannelConsumerSettings();
 			config.setConcurrentConsumers(myMdmSettings.getConcurrentConsumers());
-			myMdmChannel = myChannelFactory.getOrCreateReceiver(IMdmSettings.MDM_CHANNEL_NAME, ResourceModifiedJsonMessage.class, config);
+			myMdmChannel = myChannelFactory.getOrCreateReceiver(IMdmSettings.EMPI_CHANNEL_NAME, ResourceModifiedJsonMessage.class, config);
 			if (myMdmChannel == null) {
-				ourLog.error("Unable to create receiver for {}", IMdmSettings.MDM_CHANNEL_NAME);
+				ourLog.error("Unable to create receiver for {}", IMdmSettings.EMPI_CHANNEL_NAME);
 			} else {
 				myMdmChannel.subscribe(myMdmMessageHandler);
 				ourLog.info("MDM Matching Consumer subscribed to Matching Channel {} with name {}", myMdmChannel.getClass().getName(), myMdmChannel.getName());

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmSettings.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/api/IMdmSettings.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 public interface IMdmSettings {
 
 	String MDM_CHANNEL_NAME = "mdm";
+	String EMPI_CHANNEL_NAME = "empi";
 
 	// Parallel processing of MDM can result in missed matches.  Best to single-thread.
 	int MDM_DEFAULT_CONCURRENT_CONSUMERS = 1;


### PR DESCRIPTION
Second attempt at merging EMPI to MDM functionality.  Closes #2161.

Many large scale changes. The primary purpose of this PR is to change the EMPI solution to an MDM solution. In broad strokes, this means that the Person resource is no longer special.

The new solution (MDM) involves creating another resource where Person used to be used. For example, if MDM is occurring on a patient, we will create a new Patient for them, and tag that patient as a Golden Record. This means that several things ahve changed:

Provider methods that used to point to type of Person are now server-level operations in which you specify a resource type.
Link updating and querying no longer rely on Person IDs, but instead on arbitrary resource ids, depending on the resource type you are referring to in MDM.

Change to the EMPI config to require a list of mdmTypes
