### PR TITLE
fix np for empty npm package descr

### DIFF
--- a/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
+++ b/hapi-fhir-jpaserver-base/src/main/java/ca/uhn/fhir/jpa/packages/JpaPackageCache.java
@@ -218,7 +218,7 @@ public class JpaPackageCache extends BasePackageCacheManager implements IHapiPac
 
 			boolean currentVersion = updateCurrentVersionFlagForAllPackagesBasedOnNewIncomingVersion(thePackageId, packageVersionId);
 			String packageDesc;
-			if (npmPackage.description().length() > NpmPackageVersionEntity.PACKAGE_DESC_LENGTH) {
+			if (npmPackage.description()!=null && npmPackage.description().length() > NpmPackageVersionEntity.PACKAGE_DESC_LENGTH) {
 				packageDesc = npmPackage.description().substring(0, NpmPackageVersionEntity.PACKAGE_DESC_LENGTH - 4) + "...";
 			} else {
 				packageDesc = npmPackage.description();


### PR DESCRIPTION
We have encountered fhir npm packages which do not have descriptions. According to the spec they must [have](https://github.com/jamesagnew/hapi-fhir/compare/master...ahdis:oe_jpa_np_packagecache?expand=1) a description however. 

This PR fixes the NP Exception happening if no description is set and makes hapi more liberal. 