### PR TITLE
fix coarseness bug. Fix tests. reinitialize silly bean

### DIFF
--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/BaseProviderR4Test.java
@@ -37,7 +37,7 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 		Resource resource = resourceLoader.getResource(theString);
 		String json = IOUtils.toString(resource.getInputStream(), Charsets.UTF_8);
 		myMdmSettings.setScriptText(json);
-
+		myMdmResourceMatcherSvc.init();
 	}
 
 	@BeforeEach
@@ -49,5 +49,6 @@ public abstract class BaseProviderR4Test extends BaseMdmR4Test {
 	public void after() throws IOException {
 		super.after();
 		myMdmSettings.setScriptText(defaultScript);
+		myMdmResourceMatcherSvc.init();// This bugger creates new objects from the beans and then ignores them.
 	}
 }

--- a/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderMatchR4Test.java
+++ b/hapi-fhir-jpaserver-mdm/src/test/java/ca/uhn/fhir/jpa/mdm/provider/MdmProviderMatchR4Test.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.mdm.provider;
 
 import ca.uhn.fhir.mdm.api.MdmConstants;
 import com.google.common.collect.Ordering;
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Medication;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -153,5 +155,74 @@ public class MdmProviderMatchR4Test extends BaseProviderR4Test {
 		Bundle result = myMdmProviderR4.match(newJane);
 		assertEquals(1, result.getEntry().size());
 		assertEquals(createdJane.getId(), result.getEntryFirstRep().getResource().getId());
+	}
+
+	@Test
+	public void testMatchWithCoarseDateGranularity() throws Exception {
+		setMdmRuleJson("mdm/coarse-birthdate-mdm-rules.json");
+
+		String granularPatient = "{\n" +
+			"    \"resourceType\": \"Patient\",\n" +
+			"    \"active\": true,\n" +
+			"    \"name\": [\n" +
+			"        {\n" +
+			"            \"family\": \"PETERSON\",\n" +
+			"            \"given\": [\n" +
+			"                \"GARY\",\n" +
+			"                \"D\"\n" +
+			"            ]\n" +
+			"        }\n" +
+			"    ],\n" +
+			"    \"telecom\": [\n" +
+			"        {\n" +
+			"            \"system\": \"phone\",\n" +
+			"            \"value\": \"100100100\",\n" +
+			"            \"use\": \"home\"\n" +
+			"        }\n" +
+			"    ],\n" +
+			"    \"gender\": \"male\",\n" +
+			"    \"birthDate\": \"1991-10-10\",\n" +
+			"    \"address\": [\n" +
+			"        {\n" +
+			"            \"state\": \"NY\",\n" +
+			"            \"postalCode\": \"12313\"\n" +
+			"        }\n" +
+			"    ]\n" +
+			"}";
+		IBaseResource iBaseResource = myFhirContext.newJsonParser().parseResource(granularPatient);
+		createPatient((Patient) iBaseResource);
+
+		String coarsePatient = "{\n" +
+			"    \"resourceType\": \"Patient\",\n" +
+			"    \"active\": true,\n" +
+			"    \"name\": [\n" +
+			"        {\n" +
+			"            \"family\": \"PETERSON\",\n" +
+			"            \"given\": [\n" +
+			"                \"GARY\",\n" +
+			"                \"D\"\n" +
+			"            ]\n" +
+			"        }\n" +
+			"    ],\n" +
+			"    \"telecom\": [\n" +
+			"        {\n" +
+			"            \"system\": \"phone\",\n" +
+			"            \"value\": \"100100100\",\n" +
+			"            \"use\": \"home\"\n" +
+			"        }\n" +
+			"    ],\n" +
+			"    \"gender\": \"male\",\n" +
+			"    \"birthDate\": \"1991-10\",\n" +
+			"    \"address\": [\n" +
+			"        {\n" +
+			"            \"state\": \"NY\",\n" +
+			"            \"postalCode\": \"12313\"\n" +
+			"        }\n" +
+			"    ]\n" +
+			"}";
+
+		IBaseResource coarseResource = myFhirContext.newJsonParser().parseResource(coarsePatient);
+		Bundle result = myMdmProviderR4.match((Patient) coarseResource);
+		assertEquals(1, result.getEntry().size());
 	}
 }

--- a/hapi-fhir-jpaserver-mdm/src/test/resources/mdm/coarse-birthdate-mdm-rules.json
+++ b/hapi-fhir-jpaserver-mdm/src/test/resources/mdm/coarse-birthdate-mdm-rules.json
@@ -1,0 +1,70 @@
+{
+	"version":"1",
+	"mdmTypes": ["Patient", "Practitioner"],
+	"candidateSearchParams":[],
+	"candidateFilterSearchParams":[],
+	"matchFields":[
+		{
+			"name":"gender",
+			"resourceType":"Patient",
+			"resourcePath":"gender",
+			"matcher":{
+				"algorithm":"STRING"
+			}
+		},
+		{
+			"name":"date-of-birth-precise",
+			"resourceType":"Patient",
+			"resourcePath":"birthDate",
+			"matcher":{
+				"algorithm":"STRING"
+			}
+		},
+		{
+			"name":"date-of-birth-imprecise",
+			"resourceType":"Patient",
+			"resourcePath":"birthDate",
+			"matcher":{
+				"algorithm":"DATE"
+			}
+		},
+		{
+			"name":"state",
+			"resourceType":"Patient",
+			"resourcePath":"address.state",
+			"matcher":{
+				"algorithm":"STRING"
+			}
+		},
+		{
+			"name":"postal-code",
+			"resourceType":"Patient",
+			"resourcePath":"address.postalCode",
+			"matcher":{
+				"algorithm":"STRING"
+			}
+		},
+		{
+			"name":"firstname-meta",
+			"resourceType":"Patient",
+			"resourcePath":"name.given",
+			"matcher":{
+				"algorithm":"DOUBLE_METAPHONE"
+			}
+		},
+		{
+			"name":"lastname-meta",
+			"resourceType":"Patient",
+			"resourcePath":"name.family",
+			"matcher":{
+				"algorithm":"DOUBLE_METAPHONE"
+			}
+		}
+	],
+	"matchResultMap":{
+		"date-of-birth-precise": "MATCH",
+		"lastname-meta,firstname-meta,date-of-birth-precise,gender": "MATCH",
+		"lastname-meta,firstname-meta,date-of-birth-imprecise,postal-code": "MATCH"
+	},
+	"eidSystem":"http://example.com/system"
+}

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/matcher/HapiDateMatcherR4.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/matcher/HapiDateMatcherR4.java
@@ -37,13 +37,15 @@ public class HapiDateMatcherR4 {
 			}
 			BaseDateTimeType leftPDate;
 			BaseDateTimeType rightPDate;
-			if (comparison > 0) {
+			//Left date is coarser
+			if (comparison < 0) {
 				leftPDate = leftDate;
 				if (rightDate instanceof DateType) {
 					rightPDate = new DateType(rightDate.getValue(), leftDate.getPrecision());
 				} else {
 					rightPDate = new DateTimeType(rightDate.getValue(), leftDate.getPrecision());
 				}
+			//Right date is coarser
 			} else {
 				rightPDate = rightDate;
 				if (leftDate instanceof DateType) {

--- a/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
+++ b/hapi-fhir-server-mdm/src/main/java/ca/uhn/fhir/mdm/rules/svc/MdmResourceMatcherSvc.java
@@ -66,6 +66,7 @@ public class MdmResourceMatcherSvc {
 		if (myMdmRulesJson == null) {
 			throw new ConfigurationException("Failed to load MDM Rules.  If MDM is enabled, then MDM rules must be available in context.");
 		}
+		myFieldMatchers.clear();
 		for (MdmFieldMatchJson matchFieldJson : myMdmRulesJson.getMatchFields()) {
 			myFieldMatchers.add(new MdmResourceFieldMatcher( myFhirContext, matchFieldJson, myMdmRulesJson));
 		}

--- a/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/matcher/DateMatcherR4Test.java
+++ b/hapi-fhir-server-mdm/src/test/java/ca/uhn/fhir/mdm/rules/matcher/DateMatcherR4Test.java
@@ -49,14 +49,16 @@ public class DateMatcherR4Test extends BaseMatcherR4Test {
 	@Test
 	public void testExactDateTimePrecision() {
 		Calendar cal = new GregorianCalendar(2020, 6, 15, 11, 12, 13);
+		Date date = cal.getTime();
+
 		Calendar sameSecondCal = new GregorianCalendar(2020, 6, 15, 11, 12, 13);
 		sameSecondCal.add(Calendar.MILLISECOND, 123);
+		Date sameSecond = sameSecondCal.getTime();
+
 
 		Calendar sameDayCal = new GregorianCalendar(2020, 6, 15, 12, 34, 56);
-
-		Date date = cal.getTime();
-		Date sameSecond = sameSecondCal.getTime();
 		Date sameDay = sameDayCal.getTime();
+
 
 		// Same precision
 
@@ -75,14 +77,22 @@ public class DateMatcherR4Test extends BaseMatcherR4Test {
 		// Different precision matches by coarser precision
 		assertTrue(dateTimeMatch(date, date, TemporalPrecisionEnum.SECOND, TemporalPrecisionEnum.DAY));
 		assertTrue(dateTimeMatch(date, sameSecond, TemporalPrecisionEnum.SECOND, TemporalPrecisionEnum.DAY));
-		assertFalse(dateTimeMatch(date, sameDay, TemporalPrecisionEnum.SECOND, TemporalPrecisionEnum.DAY));
+		assertTrue(dateTimeMatch(date, sameDay, TemporalPrecisionEnum.SECOND, TemporalPrecisionEnum.DAY));
 
 		assertTrue(dateTimeMatch(date, date, TemporalPrecisionEnum.DAY, TemporalPrecisionEnum.SECOND));
 		assertTrue(dateTimeMatch(date, sameSecond, TemporalPrecisionEnum.DAY, TemporalPrecisionEnum.SECOND));
-		assertFalse(dateTimeMatch(date, sameDay, TemporalPrecisionEnum.DAY, TemporalPrecisionEnum.SECOND));
+		assertTrue(dateTimeMatch(date, sameDay, TemporalPrecisionEnum.DAY, TemporalPrecisionEnum.SECOND));
+
+
 	}
 
-	private boolean dateTimeMatch(Date theDate, Date theSameSecond, TemporalPrecisionEnum theTheDay, TemporalPrecisionEnum theTheDay2) {
-		return MdmMatcherEnum.DATE.match(ourFhirContext, new DateTimeType(theDate, theTheDay), new DateTimeType(theSameSecond, theTheDay2), true, null);
+	private boolean dateTimeMatch(Date theDate, Date theSecondDate, TemporalPrecisionEnum thePrecision, TemporalPrecisionEnum theSecondPrecision) {
+		return MdmMatcherEnum.DATE.match(
+			ourFhirContext,
+			new DateTimeType(theDate, thePrecision),
+			new DateTimeType(theSecondDate, theSecondPrecision),
+			true,
+			null
+		);
 	}
 }


### PR DESCRIPTION
Closes #2238 
* Swap comparison operator in date matcher
* Write test for matching patients
* Fix asserts in Date Match tests
* Some beans (Looking at you MdmResourceMatcherSvc) have an init method which populates a field. Subsequent test updates to MDM rules do not fix this, unless you manually call init() again, which I've done here. 

